### PR TITLE
Feature/access sessions automatic logout

### DIFF
--- a/app/api/auth/session/refresh/route.ts
+++ b/app/api/auth/session/refresh/route.ts
@@ -1,17 +1,55 @@
 import { NextResponse } from "next/server";
 import { issueSessionCookieResponse } from "@/lib/auth/issueSessionCookieResponse";
+import { cookies } from "next/headers";
+import { getAdmin } from "@/lib/firebase/admin";
+import {
+  applyProjectSessionStartCookie,
+  evaluateProjectSessionWindow,
+  getProjectSessionCookieName,
+  hardExpiredProjectSessionResponse,
+  isHardExpiredFromAuthTime,
+} from "@/lib/auth/projectSessionWindow";
 
 export const runtime = "nodejs";
 
 export async function POST(req: Request) {
   try {
-    const { idToken } = (await req.json()) as { idToken?: string };
+    const { idToken, projectKey } = (await req.json()) as {
+      idToken?: string;
+      projectKey?: string;
+    };
 
     if (!idToken) {
       return NextResponse.json({ ok: false, reason: "missing_idToken" }, { status: 400 });
     }
 
-    return await issueSessionCookieResponse(idToken);
+    if (projectKey) {
+      const { auth } = getAdmin();
+      const decoded = await auth.verifyIdToken(idToken, false);
+      if (isHardExpiredFromAuthTime(decoded.auth_time)) {
+        return hardExpiredProjectSessionResponse(projectKey);
+      }
+    }
+
+    const res = await issueSessionCookieResponse(idToken);
+
+    if (projectKey) {
+      const cookieStore = await cookies();
+      const sessionState = evaluateProjectSessionWindow(
+        projectKey,
+        cookieStore.get(getProjectSessionCookieName(projectKey))?.value,
+      );
+
+      if (sessionState.hardExpired) {
+        return hardExpiredProjectSessionResponse(projectKey);
+      }
+
+      if (sessionState.shouldSetStartCookie) {
+        applyProjectSessionStartCookie(res, projectKey, sessionState.nowSeconds);
+      }
+    }
+
+    return res;
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : String(err);
     return NextResponse.json(

--- a/app/api/auth/session/refresh/route.ts
+++ b/app/api/auth/session/refresh/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { issueSessionCookieResponse } from "@/lib/auth/issueSessionCookieResponse";
+
+export const runtime = "nodejs";
+
+export async function POST(req: Request) {
+  try {
+    const { idToken } = (await req.json()) as { idToken?: string };
+
+    if (!idToken) {
+      return NextResponse.json({ ok: false, reason: "missing_idToken" }, { status: 400 });
+    }
+
+    return await issueSessionCookieResponse(idToken);
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    return NextResponse.json(
+      { ok: false, reason: "session_refresh_failed", message: errorMessage },
+      { status: 401 },
+    );
+  }
+}

--- a/app/api/auth/session/route.ts
+++ b/app/api/auth/session/route.ts
@@ -1,46 +1,18 @@
 import { NextResponse } from "next/server";
-import { getAdmin } from "@/lib/firebase/admin";
+import { issueSessionCookieResponse } from "@/lib/auth/issueSessionCookieResponse";
 
 export const runtime = "nodejs";
 
 export async function POST(req: Request) {
-  console.log("SESSION ROUTE HIT"); // 👈 ADD HERE
-  console.log("admin projectId =", process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID, process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID);
-
   try {
     const { idToken } = (await req.json()) as { idToken?: string };
 
     if (!idToken) {
-      console.log("No idToken received");
-      // return NextResponse.json({ ok: false }, { status: 400 });
       return NextResponse.json({ ok: false, reason: "missing_idToken" }, { status: 400 });
     }
 
-    const { auth } = getAdmin();
-
-    await auth.verifyIdToken(idToken, false);
-
-    const expiresIn = 5 * 24 * 60 * 60 * 1000;
-    const sessionCookie = await auth.createSessionCookie(idToken, { expiresIn });
-
-    const res = NextResponse.json({ ok: true });
-
-    res.cookies.set({
-      name: "session",
-      value: sessionCookie,
-      httpOnly: true,
-      secure: process.env.NODE_ENV === "production",
-      sameSite: "lax",
-      path: "/",
-      maxAge: Math.floor(expiresIn / 1000),
-    });
-
-    console.log("Session cookie set"); // 👈 Optional second log
-
-    return res;
+    return await issueSessionCookieResponse(idToken);
   } catch (err) {
-    console.error("Session creation error:", err);
-    // return NextResponse.json({ ok: false }, { status: 401 });
     const errorMessage = err instanceof Error ? err.message : String(err);
     return NextResponse.json(
       { ok: false, reason: "session_create_failed", message: errorMessage },

--- a/app/api/media/proxy/route.ts
+++ b/app/api/media/proxy/route.ts
@@ -1,6 +1,12 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { getAdmin } from "@/lib/firebase/admin";
+import {
+  evaluateProjectSessionWindow,
+  getProjectSessionCookieName,
+  hardExpiredProjectSessionResponse,
+  isHardExpiredFromAuthTime,
+} from "@/lib/auth/projectSessionWindow";
 
 export const runtime = "nodejs";
 
@@ -11,6 +17,7 @@ function normalizeEmail(email?: string | null) {
 export async function GET(req: Request) {
   try {
     const { auth, db, bucket } = getAdmin();
+    const cookieStore = await cookies();
     const { searchParams } = new URL(req.url);
     const projectKey = searchParams.get("projectKey") ?? "";
     const objectPath = searchParams.get("objectPath") ?? "";
@@ -23,7 +30,7 @@ export async function GET(req: Request) {
       return NextResponse.json({ ok: false, reason: "invalid_path" }, { status: 400 });
     }
 
-    const session = (await cookies()).get("session")?.value;
+    const session = cookieStore.get("session")?.value;
     if (!session) {
       return NextResponse.json({ ok: false, reason: "no_session" }, { status: 401 });
     }
@@ -57,6 +64,18 @@ export async function GET(req: Request) {
 
       if (!enabled || (!uidOk && !emailOk)) {
         return NextResponse.json({ ok: false, reason: "not_allowed" }, { status: 403 });
+      }
+
+      if (isHardExpiredFromAuthTime((decoded as { auth_time?: number }).auth_time)) {
+        return hardExpiredProjectSessionResponse(projectKey);
+      }
+
+      const projectSessionState = evaluateProjectSessionWindow(
+        projectKey,
+        cookieStore.get(getProjectSessionCookieName(projectKey))?.value,
+      );
+      if (projectSessionState.hardExpired) {
+        return hardExpiredProjectSessionResponse(projectKey);
       }
     }
 

--- a/app/api/media/signed-url/route.ts
+++ b/app/api/media/signed-url/route.ts
@@ -1,6 +1,13 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { getAdmin } from "@/lib/firebase/admin";
+import {
+  applyProjectSessionStartCookie,
+  evaluateProjectSessionWindow,
+  getProjectSessionCookieName,
+  hardExpiredProjectSessionResponse,
+  isHardExpiredFromAuthTime,
+} from "@/lib/auth/projectSessionWindow";
 
 export const runtime = "nodejs";
 
@@ -23,6 +30,7 @@ function buildProxyUrl(req: Request, projectKey: string, objectPath: string) {
 export async function POST(req: Request) {
   try {
     const { auth, db, bucket } = getAdmin();
+    const cookieStore = await cookies();
 
     const { projectKey, objectPath } = (await req.json()) as Body;
 
@@ -36,7 +44,7 @@ export async function POST(req: Request) {
     }
 
     // verify session cookie; fallback to Bearer ID token when cookie is unavailable
-    const session = (await cookies()).get("session")?.value;
+    const session = cookieStore.get("session")?.value;
     let decoded: { uid: string; email?: string | null } | null = null;
 
     if (session) {
@@ -97,10 +105,47 @@ export async function POST(req: Request) {
       if (!enabled || (!uidOk && !emailOk)) {
         return NextResponse.json({ ok: false, reason: "not_allowed" }, { status: 403 });
       }
-    }
 
-    // sign URL
-    const expiresMs = 10 * 60 * 1000; // 10 minutes
+      // Strong absolute timeout check based on Firebase auth_time.
+      if (isHardExpiredFromAuthTime((decoded as { auth_time?: number }).auth_time)) {
+        return hardExpiredProjectSessionResponse(projectKey);
+      }
+
+      const projectSessionCookieName = getProjectSessionCookieName(projectKey);
+      const projectSessionState = evaluateProjectSessionWindow(
+        projectKey,
+        cookieStore.get(projectSessionCookieName)?.value,
+      );
+      if (projectSessionState.hardExpired) {
+        return hardExpiredProjectSessionResponse(projectKey);
+      }
+
+      // sign URL
+      const expiresMs = 10 * 60 * 1000; // 10 minutes
+      let url: string;
+      try {
+        [url] = await bucket.file(objectPath).getSignedUrl({
+          version: "v4",
+          action: "read",
+          expires: Date.now() + expiresMs,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (message.includes("PERMISSION_DENIED")) {
+          url = buildProxyUrl(req, projectKey, objectPath);
+        } else {
+          throw error;
+        }
+      }
+
+      const res = NextResponse.json({ ok: true, url, expiresAt: Date.now() + expiresMs });
+      if (projectSessionState.shouldSetStartCookie) {
+        applyProjectSessionStartCookie(res, projectKey, projectSessionState.nowSeconds);
+      }
+      return res;
+    }
+    // Public project path (no allowlist/session window enforcement needed)
+    const expiresMs = 10 * 60 * 1000;
     let url: string;
     try {
       [url] = await bucket.file(objectPath).getSignedUrl({
@@ -116,7 +161,6 @@ export async function POST(req: Request) {
         throw error;
       }
     }
-
     return NextResponse.json({ ok: true, url, expiresAt: Date.now() + expiresMs });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -10,12 +10,12 @@ import { usePathname } from 'next/navigation';
 import styles from './footer.module.scss';
 
 type FooterProps = {
-  isDark: boolean;
-  logoFontColor: string;
-  fontColor: string;
-}
+  isDark?: boolean;
+  logoFontColor?: string;
+  fontColor?: string;
+};
 
-export function Footer(props: FooterProps) {
+export function Footer(props: FooterProps = {}) {
     const screenDevice = useResponsive();
     const pathname = usePathname();
 
@@ -70,7 +70,7 @@ export function Footer(props: FooterProps) {
                         { MenuLinks }
                     </div>
                     <div className={styles['logo-section']}>
-                        <FooterLogo color={logoFontColor} height='20px' />
+                        <FooterLogo color={logoFontColor} width="55px" height="20px" />
                     </div>
                     <div className={styles['copyright-section']}>
                         <span style={{
@@ -85,7 +85,7 @@ export function Footer(props: FooterProps) {
             <div className="container" >
                 <div className={styles['footer-container']} >
                     <div className={styles['logo-section']}>
-                        <FooterLogo color={logoFontColor} height='20px' />
+                        <FooterLogo color={logoFontColor} width="55px" height="20px" />
 
                         <div className="contact-area">
                             <IconButton color="primary" component="label" onClick={handleLinkedIn}>

--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -3,7 +3,7 @@
 import IconButton from '@mui/material/IconButton';
 import LinkedInIcon from '@mui/icons-material/LinkedIn';
 
-import { useResponsive } from '@/app/lib/responsive/ResponsiveQueryProvider';
+import { useResponsive } from '@/lib/responsive/ResponsiveQueryProvider';
 import { FooterLogo } from './FooterLogo';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';

--- a/lib/access/ProjectAccessGate.tsx
+++ b/lib/access/ProjectAccessGate.tsx
@@ -70,6 +70,15 @@ function requestId(projectKey: string, uid: string) {
   return `${projectKey}_${uid}`;
 }
 
+/** Default: 6 hours. Override with `SESSION_SILENT_REFRESH_INTERVAL_MS` (see next.config.ts env). */
+function getSilentRefreshIntervalMs(): number {
+  const DEFAULT_MS = 6 * 60 * 60 * 1000;
+  const raw = process.env.SESSION_SILENT_REFRESH_INTERVAL_MS;
+  if (raw === undefined || raw === "") return DEFAULT_MS;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_MS;
+}
+
 export default function ProjectAccessGate({
   projectId,
   projectKey,
@@ -206,6 +215,48 @@ export default function ProjectAccessGate({
 
     return () => unsub();
   }, [user, allowed, projectKey, visibility, visibilityLoading]);
+
+  React.useEffect(() => {
+    if (visibilityLoading) return;
+    if (visibility !== "restricted" || !user) return;
+
+    const signedInUser = user;
+    const refreshEveryMs = getSilentRefreshIntervalMs();
+    let cancelled = false;
+
+    async function refreshServerSession() {
+      try {
+        const idToken = await signedInUser.getIdToken(true);
+        await fetch("/api/auth/session/refresh", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ idToken }),
+          credentials: "include",
+        });
+      } catch {
+        // Transient network/auth errors — next interval or tab focus will retry.
+      }
+    }
+
+    void refreshServerSession();
+
+    const intervalId = window.setInterval(() => {
+      if (!cancelled) void refreshServerSession();
+    }, refreshEveryMs);
+
+    const onVisibility = () => {
+      if (cancelled || document.visibilityState !== "visible") return;
+      void refreshServerSession();
+    };
+
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, [user, visibility, visibilityLoading]);
 
   async function mintSessionCookie(user: User) {
     const idToken = await user.getIdToken(true);

--- a/lib/access/ProjectAccessGate.tsx
+++ b/lib/access/ProjectAccessGate.tsx
@@ -35,6 +35,8 @@ import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 
 import { auth, db } from "@/firebase";
+import SessionAccessDialog from "@/lib/access/SessionAccessDialog";
+import { signOutSessionAndReloadForSignIn } from "@/lib/auth/signInAgainNavigation";
 import { ProjectAccessContext } from "./ProjectAccessContext";
 
 type GateProps = {
@@ -70,9 +72,9 @@ function requestId(projectKey: string, uid: string) {
   return `${projectKey}_${uid}`;
 }
 
-/** Default: 6 hours. Override with `SESSION_SILENT_REFRESH_INTERVAL_MS` (see next.config.ts env). */
+/** Default: 24 hours. Override with `SESSION_SILENT_REFRESH_INTERVAL_MS` (see next.config.ts env). */
 function getSilentRefreshIntervalMs(): number {
-  const DEFAULT_MS = 6 * 60 * 60 * 1000;
+  const DEFAULT_MS = 24 * 60 * 60 * 1000;
   const raw = process.env.SESSION_SILENT_REFRESH_INTERVAL_MS;
   if (raw === undefined || raw === "") return DEFAULT_MS;
   const n = Number(raw);
@@ -106,6 +108,7 @@ export default function ProjectAccessGate({
   const [password, setPassword] = React.useState("");
   const [authBusy, setAuthBusy] = React.useState(false);
   const [msg, setMsg] = React.useState<string | null>(null);
+  const [sessionHardExpired, setSessionHardExpired] = React.useState(false);
 
   React.useEffect(() => {
     const unsub = onAuthStateChanged(auth, (u) => {
@@ -218,35 +221,44 @@ export default function ProjectAccessGate({
 
   React.useEffect(() => {
     if (visibilityLoading) return;
-    if (visibility !== "restricted" || !user) return;
+    if (visibility !== "restricted" || !user || sessionHardExpired) return;
 
     const signedInUser = user;
     const refreshEveryMs = getSilentRefreshIntervalMs();
     let cancelled = false;
 
-    async function refreshServerSession() {
+    async function refreshServerSessionWithReasonHandling() {
       try {
         const idToken = await signedInUser.getIdToken(true);
-        await fetch("/api/auth/session/refresh", {
+        const res = await fetch("/api/auth/session/refresh", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ idToken }),
+          body: JSON.stringify({ idToken, projectKey }),
           credentials: "include",
         });
+
+        if (!res.ok) {
+          const payload = (await res.json().catch(() => null)) as
+            | { reason?: string }
+            | null;
+          if (payload?.reason === "session_hard_expired") {
+            setSessionHardExpired(true);
+          }
+        }
       } catch {
         // Transient network/auth errors — next interval or tab focus will retry.
       }
     }
 
-    void refreshServerSession();
+    void refreshServerSessionWithReasonHandling();
 
     const intervalId = window.setInterval(() => {
-      if (!cancelled) void refreshServerSession();
+      if (!cancelled) void refreshServerSessionWithReasonHandling();
     }, refreshEveryMs);
 
     const onVisibility = () => {
       if (cancelled || document.visibilityState !== "visible") return;
-      void refreshServerSession();
+      void refreshServerSessionWithReasonHandling();
     };
 
     document.addEventListener("visibilitychange", onVisibility);
@@ -256,7 +268,11 @@ export default function ProjectAccessGate({
       window.clearInterval(intervalId);
       document.removeEventListener("visibilitychange", onVisibility);
     };
-  }, [user, visibility, visibilityLoading]);
+  }, [user, visibility, visibilityLoading, sessionHardExpired, projectKey]);
+
+  const handleSessionDialogSignInAgain = React.useCallback(() => {
+    void signOutSessionAndReloadForSignIn(auth);
+  }, []);
 
   async function mintSessionCookie(user: User) {
     const idToken = await user.getIdToken(true);
@@ -377,43 +393,62 @@ export default function ProjectAccessGate({
   const accessPending =
     visibility === "restricted" && !!user && !allowlistReady;
 
+  const sessionDialog = (
+    <SessionAccessDialog
+      open={sessionHardExpired}
+      reason="session_hard_expired"
+      onSignInAgain={handleSessionDialogSignInAgain}
+    />
+  );
+
   if (loading || visibilityLoading || accessPending) {
     const verifyingOnly = accessPending && !loading && !visibilityLoading;
 
     return (
-      <Box sx={{ minHeight: "60vh", display: "grid", placeItems: "center", px: 2 }}>
-        <Stack spacing={2} alignItems="center" sx={{ width: "100%", maxWidth: 360 }}>
-          <CircularProgress />
-          <Typography variant="body2" color="text.secondary" textAlign="center">
-            {verifyingOnly ? "Verifying access…" : "Checking access…"}
-          </Typography>
-          {verifyingOnly ? (
-            <LinearProgress sx={{ width: "100%", borderRadius: 1 }} />
-          ) : null}
-        </Stack>
-      </Box>
+      <>
+        {sessionDialog}
+        <Box sx={{ minHeight: "60vh", display: "grid", placeItems: "center", px: 2 }}>
+          <Stack spacing={2} alignItems="center" sx={{ width: "100%", maxWidth: 360 }}>
+            <CircularProgress />
+            <Typography variant="body2" color="text.secondary" textAlign="center">
+              {verifyingOnly ? "Verifying access…" : "Checking access…"}
+            </Typography>
+            {verifyingOnly ? (
+              <LinearProgress sx={{ width: "100%", borderRadius: 1 }} />
+            ) : null}
+          </Stack>
+        </Box>
+      </>
     );
   }
 
   if (visibility === "public") {
     return (
-      <ProjectAccessContext.Provider value={{ projectKey, visibility }}>
-        {children}
-      </ProjectAccessContext.Provider>
+      <>
+        {sessionDialog}
+        <ProjectAccessContext.Provider value={{ projectKey, visibility }}>
+          {children}
+        </ProjectAccessContext.Provider>
+      </>
     );
   }
 
   if (user && allowed) {
     return (
-      <ProjectAccessContext.Provider value={{ projectKey, visibility }}>
-        {children}
-      </ProjectAccessContext.Provider>
+      <>
+        {sessionDialog}
+        <ProjectAccessContext.Provider value={{ projectKey, visibility }}>
+          {children}
+        </ProjectAccessContext.Provider>
+      </>
     );
   }
 
   return (
-    <Box sx={{ maxWidth: 720, mx: "auto", py: { xs: 5, md: 8 }, px: 2 }}>
-      <Paper sx={{ p: { xs: 2, md: 3 }, borderRadius: 2 }}>
+    <>
+      {sessionDialog}
+      <Box sx={{ maxWidth: 720, mx: "auto", py: { xs: 5, md: 8 }, px: 2 }}>
+        <Paper sx={{ p: { xs: 2, md: 3 }, borderRadius: 2 }}>
         <Stack spacing={2}>
           <Typography variant="h4" sx={{ fontWeight: 800 }}>
             {title}
@@ -532,7 +567,8 @@ export default function ProjectAccessGate({
             </Stack>
           )}
         </Stack>
-      </Paper>
-    </Box>
+        </Paper>
+      </Box>
+    </>
   );
 }

--- a/lib/access/SessionAccessDialog.tsx
+++ b/lib/access/SessionAccessDialog.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import React from "react";
+import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import WarningAmberRoundedIcon from "@mui/icons-material/WarningAmberRounded";
+
+export type SessionAccessDialogReason =
+  | "session_hard_expired"
+  | "no_session"
+  | "bad_session"
+  | "not_allowed"
+  | "signed_url_failed"
+  | "unknown";
+
+type SessionAccessDialogProps = {
+  open: boolean;
+  reason: SessionAccessDialogReason;
+  onSignInAgain: () => void;
+};
+
+function getDialogCopy(reason: SessionAccessDialogReason) {
+  if (reason === "not_allowed") {
+    return {
+      title: "Access required",
+      description:
+        "Your account does not currently have access to this protected project content. Please sign in with an approved account.",
+      actionLabel: "Sign in with another account",
+    };
+  }
+
+  if (reason === "signed_url_failed") {
+    return {
+      title: "Protected content unavailable",
+      description:
+        "We could not verify access to protected media right now. Please sign in again to refresh your secure session.",
+      actionLabel: "Sign in again",
+    };
+  }
+
+  return {
+    title: "Session expired",
+    description:
+      "Your secure access session is no longer valid. Please sign in again to continue viewing protected project content.",
+    actionLabel: "Sign in again",
+  };
+}
+
+export default function SessionAccessDialog({
+  open,
+  reason,
+  onSignInAgain,
+}: SessionAccessDialogProps) {
+  const copy = getDialogCopy(reason);
+
+  return (
+    <Dialog
+      open={open}
+      maxWidth="xs"
+      fullWidth
+      aria-labelledby="session-access-dialog-title"
+    >
+      <DialogTitle id="session-access-dialog-title" sx={{ textAlign: "center" }}>
+        {copy.title}
+      </DialogTitle>
+      <DialogContent>
+        <Stack direction="row" spacing={1.25} alignItems="flex-start">
+          <WarningAmberRoundedIcon color="warning" sx={{ mt: 0.2 }} />
+          <Typography variant="body2" color="text.secondary">
+            {copy.description}
+          </Typography>
+        </Stack>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2, justifyContent: "center" }}>
+        <Button onClick={onSignInAgain} variant="contained">
+          {copy.actionLabel}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/lib/auth/issueSessionCookieResponse.ts
+++ b/lib/auth/issueSessionCookieResponse.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { getAdmin } from "@/lib/firebase/admin";
+
+const SESSION_COOKIE_NAME = "session";
+
+/** Default: 5 days */
+const DEFAULT_SESSION_MAX_AGE_SECONDS = 5 * 24 * 60 * 60;
+
+function getSessionMaxAgeSeconds(): number {
+  const raw = process.env.SESSION_COOKIE_MAX_AGE_SECONDS;
+  if (raw === undefined || raw === "") return DEFAULT_SESSION_MAX_AGE_SECONDS;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_SESSION_MAX_AGE_SECONDS;
+  return Math.floor(n);
+}
+
+/**
+ * Verifies a Firebase ID token and sets the httpOnly session cookie used by API routes.
+ * Cookie lifetime is controlled by `SESSION_COOKIE_MAX_AGE_SECONDS` (seconds).
+ */
+export async function issueSessionCookieResponse(idToken: string) {
+  const { auth } = getAdmin();
+
+  await auth.verifyIdToken(idToken, false);
+
+  const maxAgeSeconds = getSessionMaxAgeSeconds();
+  const expiresInMs = maxAgeSeconds * 1000;
+
+  const sessionCookie = await auth.createSessionCookie(idToken, {
+    expiresIn: expiresInMs,
+  });
+
+  const res = NextResponse.json({ ok: true });
+
+  res.cookies.set({
+    name: SESSION_COOKIE_NAME,
+    value: sessionCookie,
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: maxAgeSeconds,
+  });
+
+  return res;
+}

--- a/lib/auth/projectSessionWindow.ts
+++ b/lib/auth/projectSessionWindow.ts
@@ -1,0 +1,119 @@
+import { NextResponse } from "next/server";
+
+const SESSION_COOKIE_NAME = "session";
+const PROJECT_SESSION_COOKIE_PREFIX = "project_session_started_";
+const DEFAULT_ABSOLUTE_SESSION_TIMEOUT_SECONDS = 3 * 24 * 60 * 60;
+const DEFAULT_SESSION_COOKIE_MAX_AGE_SECONDS = 5 * 24 * 60 * 60;
+
+function getAbsoluteTimeoutSeconds(): number {
+  const raw = process.env.ABSOLUTE_PROJECT_SESSION_TIMEOUT_SECONDS;
+  if (raw === undefined || raw === "") return DEFAULT_ABSOLUTE_SESSION_TIMEOUT_SECONDS;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_ABSOLUTE_SESSION_TIMEOUT_SECONDS;
+  return Math.floor(n);
+}
+
+export function getAbsoluteProjectSessionTimeoutSeconds() {
+  return getAbsoluteTimeoutSeconds();
+}
+
+function getSessionCookieMaxAgeSeconds(): number {
+  const raw = process.env.SESSION_COOKIE_MAX_AGE_SECONDS;
+  if (raw === undefined || raw === "") return DEFAULT_SESSION_COOKIE_MAX_AGE_SECONDS;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_SESSION_COOKIE_MAX_AGE_SECONDS;
+  return Math.floor(n);
+}
+
+function cookieNameForProject(projectKey: string) {
+  return `${PROJECT_SESSION_COOKIE_PREFIX}${projectKey}`;
+}
+
+function parseEpochSeconds(value?: string): number | null {
+  if (!value) return null;
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return Math.floor(n);
+}
+
+export function evaluateProjectSessionWindow(projectKey: string, startedAtRaw?: string) {
+  const startedAtSeconds = parseEpochSeconds(startedAtRaw);
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const timeoutSeconds = getAbsoluteTimeoutSeconds();
+
+  if (!startedAtSeconds) {
+    return { hardExpired: false, shouldSetStartCookie: true, nowSeconds };
+  }
+
+  const elapsedSeconds = nowSeconds - startedAtSeconds;
+  const hardExpired = elapsedSeconds >= timeoutSeconds;
+
+  return {
+    hardExpired,
+    shouldSetStartCookie: false,
+    nowSeconds,
+  };
+}
+
+export function isHardExpiredFromAuthTime(authTimeSeconds?: number | null) {
+  if (!authTimeSeconds || !Number.isFinite(authTimeSeconds)) return false;
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const elapsedSeconds = nowSeconds - Math.floor(authTimeSeconds);
+  return elapsedSeconds >= getAbsoluteTimeoutSeconds();
+}
+
+export function applyProjectSessionStartCookie(
+  res: NextResponse,
+  projectKey: string,
+  startedAtSeconds: number,
+) {
+  // Keep the "started at" marker around at least as long as the main session cookie.
+  // If this marker expires too early, the absolute timeout window can accidentally reset.
+  const markerMaxAgeSeconds = Math.max(
+    getAbsoluteTimeoutSeconds(),
+    getSessionCookieMaxAgeSeconds(),
+  );
+
+  res.cookies.set({
+    name: cookieNameForProject(projectKey),
+    value: String(startedAtSeconds),
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: markerMaxAgeSeconds,
+  });
+}
+
+export function hardExpiredProjectSessionResponse(projectKey: string) {
+  const res = NextResponse.json(
+    { ok: false, reason: "session_hard_expired" },
+    { status: 401 },
+  );
+
+  res.cookies.set({
+    name: SESSION_COOKIE_NAME,
+    value: "",
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: 0,
+  });
+
+  res.cookies.set({
+    name: cookieNameForProject(projectKey),
+    value: "",
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: 0,
+  });
+
+  return res;
+}
+
+export function getProjectSessionCookieName(projectKey: string) {
+  return cookieNameForProject(projectKey);
+}

--- a/lib/auth/signInAgainNavigation.ts
+++ b/lib/auth/signInAgainNavigation.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { signOut, type Auth } from "firebase/auth";
+
+/**
+ * Clears the httpOnly session cookie, signs out of Firebase (fire-and-forget),
+ * then hard-navigates to the current URL so App Router client state resets and gated UIs remount.
+ */
+export async function signOutSessionAndReloadForSignIn(auth: Auth) {
+  try {
+    await fetch("/api/auth/logout", {
+      method: "POST",
+      credentials: "include",
+    });
+  } catch {
+    // Network / server errors — still attempt client navigation + Firebase sign-out.
+  }
+
+  void signOut(auth).catch(() => {});
+
+  const target =
+    `${window.location.pathname}${window.location.search}${window.location.hash}` || "/";
+  window.location.assign(target);
+}

--- a/lib/media/GatedImage.tsx
+++ b/lib/media/GatedImage.tsx
@@ -8,6 +8,10 @@ import LinearProgress from "@mui/material/LinearProgress";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { auth } from "@/firebase";
+import SessionAccessDialog, {
+  type SessionAccessDialogReason,
+} from "@/lib/access/SessionAccessDialog";
+import { signOutSessionAndReloadForSignIn } from "@/lib/auth/signInAgainNavigation";
 
 type GatedImageProps = {
   projectKey: string; // e.g. "project_4"
@@ -41,6 +45,18 @@ export default function GatedImage({
   const [url, setUrl] = React.useState<string | null>(null);
   const [err, setErr] = React.useState<string | null>(null);
   const [imageReady, setImageReady] = React.useState(false);
+  const [dialogReason, setDialogReason] =
+    React.useState<SessionAccessDialogReason | null>(null);
+
+  const isAccessIssueReason = React.useCallback((reason?: string) => {
+    return (
+      reason === "session_hard_expired" ||
+      reason === "no_session" ||
+      reason === "bad_session" ||
+      reason === "not_allowed" ||
+      reason === "signed_url_failed"
+    );
+  }, []);
 
   React.useEffect(() => {
     let alive = true;
@@ -66,7 +82,11 @@ export default function GatedImage({
       if (!alive) return;
 
       if (!res.ok || !data?.url) {
-        setErr(data?.message || data?.reason || `signed-url failed (${res.status})`);
+        const reason = typeof data?.reason === "string" ? data.reason : undefined;
+        if (isAccessIssueReason(reason)) {
+          setDialogReason(reason as SessionAccessDialogReason);
+        }
+        setErr(data?.message || reason || `signed-url failed (${res.status})`);
         return;
       }
 
@@ -81,7 +101,7 @@ export default function GatedImage({
     return () => {
       alive = false;
     };
-  }, [projectKey, objectPath]);
+  }, [projectKey, objectPath, isAccessIssueReason]);
 
   React.useEffect(() => {
     if (!fullViewportLoading) return;
@@ -126,6 +146,10 @@ export default function GatedImage({
       />
     );
 
+  const handleSignInAgain = React.useCallback(() => {
+    void signOutSessionAndReloadForSignIn(auth);
+  }, []);
+
   return (
     <Box
       sx={{
@@ -159,6 +183,11 @@ export default function GatedImage({
         </Box>
       ) : null}
       {inner}
+      <SessionAccessDialog
+        open={dialogReason !== null}
+        reason={dialogReason ?? "unknown"}
+        onSignInAgain={handleSignInAgain}
+      />
     </Box>
   );
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,11 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  /* Expose silent-refresh interval to the client bundle without requiring NEXT_PUBLIC_ */
+  env: {
+    SESSION_SILENT_REFRESH_INTERVAL_MS:
+      process.env.SESSION_SILENT_REFRESH_INTERVAL_MS ?? "",
+  },
   /* config options here */
   sassOptions: {
     additionalData: `


### PR DESCRIPTION

- Added shared session-cookie issuance helper in lib/auth/issueSessionCookieResponse.ts so session creation and refresh use identical verification/cookie behavior.
- Added dedicated POST /api/auth/session/refresh endpoint in app/api/auth/session/refresh/route.ts (same body contract as login: { idToken }).
- Refactored app/api/auth/session/route.ts to use the shared helper and keep error responses consistent.
- Added client-side silent renew loop in lib/access/ProjectAccessGate.tsx that runs when a user is signed in on a restricted page:

> - > refreshes immediately on mount,
> - > refreshes on a fixed interval,
> - > refreshes when tab becomes visible again.
> 

**Configuration**
Session TTL is now env-driven via SESSION_COOKIE_MAX_AGE_SECONDS (server).
Silent refresh interval is env-driven via SESSION_SILENT_REFRESH_INTERVAL_MS (exposed to client through next.config.ts).
