### PR TITLE
Improvement/my work page

### DIFF
--- a/app/aboutme/components/AboutMeIntro/aboutme_intro.module.scss
+++ b/app/aboutme/components/AboutMeIntro/aboutme_intro.module.scss
@@ -42,7 +42,7 @@
     &Desc {
       p {
         color: $font-color-bold;
-        font-size: 16px;
+        @include fluid-type(16px, 20px, 24px);
         font-weight: 500;
       }
     }

--- a/app/mywork/MyWorkPage.tsx
+++ b/app/mywork/MyWorkPage.tsx
@@ -10,6 +10,7 @@ import Project, { type ProjectProps } from "./Project";
 import { db } from "@/firebase";
 import PdfModal from "@/lib/pdf/PdfModal";
 import Typewriter from "typewriter-effect";
+import AOS from "aos";
 import { MyWorkPageData } from "./data/mywork-data";
 
 const FLOAT_COUNT = 14;
@@ -115,6 +116,13 @@ export default function MyWorkPageView() {
     return () => unsubscribe();
   }, []);
 
+  useEffect(() => {
+    const id = requestAnimationFrame(() => {
+      AOS.refresh();
+    });
+    return () => cancelAnimationFrame(id);
+  }, [projects, isLoading, hasError]);
+
   return (
     <section className={styles.myWorkSection} id="my-work">
       <div className={styles.myWorkPage}>
@@ -143,11 +151,20 @@ export default function MyWorkPageView() {
 
         <div className={styles.content}>
           
-          <h2 className={styles.heading}>
+          <h2
+            className={styles.heading}
+            data-aos="fade-up"
+            data-aos-duration="1000"
+          >
             <MyWorkTitleTypewriter />
           </h2>
 
-          <div className={styles.summarySection}>
+          <div
+            className={styles.summarySection}
+            data-aos="fade-up"
+            data-aos-delay="100"
+            data-aos-duration="1000"
+          >
             <span className={styles.summarySectionText}>
               I build and contribute to end-to-end applications using technologies such as
               Angular, React, Node.js, and iOS, bridging UX design and engineering to
@@ -161,19 +178,34 @@ export default function MyWorkPageView() {
 
           {/* simple error/loading handling */}
           {hasError && (
-            <p className={styles.errorText}>
+            <p
+              className={styles.errorText}
+              data-aos="fade-up"
+              data-aos-duration="700"
+            >
               Something went wrong loading projects. Please try again later.
             </p>
           )}
 
           {isLoading && !hasError && (
-            <p className={styles.loadingText}>Loading projects…</p>
+            <p
+              className={styles.loadingText}
+              data-aos="fade-up"
+              data-aos-duration="700"
+            >
+              Loading projects…
+            </p>
           )}
 
           {!isLoading && !hasError && (
             <div className={styles.portfolioProjectsContainer}>
-              {projects.map((project) => (
-                <div key={project.id}>
+              {projects.map((project, index) => (
+                <div
+                  key={project.id}
+                  data-aos="fade-up"
+                  data-aos-duration="700"
+                  data-aos-delay={String(Math.min(index * 80, 400))}
+                >
                   <Project
                     data={project.data}
                     onOpenPdf={(url, title) => openPdf(url, title)}

--- a/app/mywork/MyWorkPage.tsx
+++ b/app/mywork/MyWorkPage.tsx
@@ -102,7 +102,7 @@ export default function MyWorkPageView() {
 
   return (
     <section className={styles.myWorkSection} id="my-work">
-      <div className="global-container">
+      <div className={styles.myWorkPage}>
         {/* Decorative floating images */}
         <div className={styles.floatLayer}>
           {floaters.map((f, i) => (

--- a/app/mywork/MyWorkPage.tsx
+++ b/app/mywork/MyWorkPage.tsx
@@ -9,8 +9,23 @@ import { collection, onSnapshot, orderBy, query } from "firebase/firestore";
 import Project, { type ProjectProps } from "./Project";
 import { db } from "@/firebase";
 import PdfModal from "@/lib/pdf/PdfModal";
+import Typewriter from "typewriter-effect";
+import { MyWorkPageData } from "./data/mywork-data";
 
 const FLOAT_COUNT = 14;
+
+function MyWorkTitleTypewriter() {
+  return (
+    <Typewriter
+      options={{
+        strings: MyWorkPageData.pageTitle,
+        autoStart: true,
+        loop: false,
+        deleteSpeed: 50,
+      }}
+    />
+  );
+}
 
 type FloaterConfig = {
   img: any;
@@ -127,7 +142,10 @@ export default function MyWorkPageView() {
         </div>
 
         <div className={styles.content}>
-          <h2 className={styles.heading}>My Work</h2>
+          
+          <h2 className={styles.heading}>
+            <MyWorkTitleTypewriter />
+          </h2>
 
           <div className={styles.summarySection}>
             <span className={styles.summarySectionText}>

--- a/app/mywork/Project.tsx
+++ b/app/mywork/Project.tsx
@@ -34,8 +34,8 @@ type Props = {
 };
 
 const cardSize = {
-  width: { xs: 280, sm: 280, md: 276, lg: 276, xl: 345 },
-  height: { xs: 180, sm: 180, md: 177, lg: 177, xl: 221 },
+  width: { xs: 320, sm: 320, md: 276, lg: 276, xl: 276 },
+  height: { xs: 226, sm: 226, md: 195, lg: 195, xl: 195 },
 } as const;
 
 export default function Project({ data, onOpenPdf }: Props) {

--- a/app/mywork/Project.tsx
+++ b/app/mywork/Project.tsx
@@ -148,13 +148,34 @@ export default function Project({ data, onOpenPdf }: Props) {
             sx={{
               ...cardSize,
               p: 0,
+              display: "flex",
+              flexDirection: "column",
               backgroundColor: "rgba(0, 0, 0, 0.05)",
               borderRadius: 2,
               overflow: "hidden",
             }}
           >
-            <CardActionArea sx={{ width: "100%", height: "100%" }} onClick={handleAction}>
-              <CardContent sx={{ p: 2, height: "100%" }}>
+            <CardActionArea
+              sx={{
+                flex: 1,
+                minHeight: 0,
+                width: "100%",
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "stretch",
+                justifyContent: "center",
+              }}
+              onClick={handleAction}
+            >
+              <CardContent
+                sx={{
+                  p: 2,
+                  width: "100%",
+                  maxHeight: "100%",
+                  flex: "0 1 auto",
+                  overflowY: "auto",
+                }}
+              >
                 <Typography
                   sx={{
                     fontFamily: "'Poppins', sans-serif",

--- a/app/mywork/data/mywork-data.ts
+++ b/app/mywork/data/mywork-data.ts
@@ -1,0 +1,3 @@
+export const MyWorkPageData = {
+  pageTitle: "My Work",
+} as const;

--- a/app/mywork/mywork.module.scss
+++ b/app/mywork/mywork.module.scss
@@ -1,10 +1,25 @@
+.myWorkPage {
+  /* Narrower cap than global layout — `$mywork-content-max-width` (`main` already uses `global-container`). */
+  width: 100%;
+  max-width: $mywork-content-max-width;
+  margin-left: auto;
+  margin-right: auto;
+  box-sizing: border-box;
+  position: relative;
+
+  @media screen and #{$tablet} {
+    padding-left: clamp(2rem, 4vw, 2.5rem);
+    padding-right: clamp(2rem, 4vw, 2.5rem);
+  }
+}
+
 .myWorkSection {
   min-height: 100vh;
   width: 100%;
   //background-color: #f4f8fb;
 
   .content {
-    @include global-container;
+    width: 100%;
     z-index: 1;
   }
 

--- a/app/mywork/mywork.module.scss
+++ b/app/mywork/mywork.module.scss
@@ -45,7 +45,7 @@
         max-width: 420px;
       }
 
-      @include fluid-type(16px, 18px, 20px);
+      @include fluid-type(16px, 20px, 24px);
       font-family: var(--font-figtree);
       color: $font-color-bold;
       line-height: 1.6;

--- a/styles/variables.scss
+++ b/styles/variables.scss
@@ -12,6 +12,9 @@ $layout-content-max-width: 1563px;
 /** About page main column — narrower for comfortable reading. */
 $about-me-content-max-width: 1024px;
 
+/** My Work page main column — same cap as About for consistent layout. */
+$mywork-content-max-width: 1024px;
+
 
 // Mobile ranges
 $mobile-min: 360px;


### PR DESCRIPTION
Pull request summary: /mywork page

- Layout: Introduced $mywork-content-max-width (1024px) in variables.scss and a .myWorkPage wrapper that mirrors the About page: centered column, box-sizing, tablet-only horizontal padding, and position: relative for the float layer. Removed the extra inner global-container / global-container mixin on content so spacing isn’t doubled with (public) main.

- Project cards: Increased xs card size to 320×206 (keeps ~desktop aspect ratio); sm stays 280×180 so two cards still fit at 600px. Back of card: Flex layout on the MUI Card and CardActionArea (flexDirection: column, justifyContent: center, flex: 1, minHeight: 0) so back-face copy is vertically centered, with scroll on long text.

- Hero: Replaced static “My Work” with a typewriter title (typewriter-effect), copy driven by app/mywork/data/mywork-data.ts.

- Motion: Added AOS data-aos on the heading, summary, error/loading, and each project (staggered delays), plus AOS.refresh() after Firestore-driven updates so lazy-loaded projects still animate.