### PR TITLE
Ar storyteller/improvement/project into section

### DIFF
--- a/app/projects/ar-story-teller/ArStoryTeller.module.scss
+++ b/app/projects/ar-story-teller/ArStoryTeller.module.scss
@@ -111,14 +111,14 @@ $project-font-family: poppins;
 }
 
 @mixin stdesktop-section-subtitle1 {
-    font-family: poppins;
+    font-family: var(--font-satoshi), sans-serif;
     font-size: 1.8rem;
     font-weight: 600;
     color: $project-font-color;
 }
 
 @mixin stdesktop-section-subtitle2 {
-    font-family: poppins;
+    font-family: var(--font-satoshi), sans-serif;
     font-size: 1.5rem;
     font-weight: 600;
     color: $project-font-color;
@@ -173,7 +173,7 @@ $project-font-family: poppins;
 
 
 @mixin stlgmd-section-subtitle1 {
-    font-family: poppins;
+    font-family: var(--font-satoshi), sans-serif;
     font-size: 1.4rem;
     font-weight: 600;
     color: $project-font-color;
@@ -181,7 +181,7 @@ $project-font-family: poppins;
 
 
 @mixin stlgmd-section-subtitle2 {
-    font-family: poppins;
+    font-family: var(--font-satoshi), sans-serif;
     font-size: 1.2rem;
     font-weight: 600;
     color: $project-font-color;
@@ -234,7 +234,7 @@ $project-font-family: poppins;
 
 
 @mixin stsmsx-section-subtitle1 {
-    font-family: poppins;
+    font-family: var(--font-satoshi), sans-serif;
     font-size: 1.2rem;
     font-weight: 600;
     color: $project-font-color;
@@ -242,7 +242,7 @@ $project-font-family: poppins;
 
 
 @mixin stsmsx-section-subtitle2 {
-    font-family: poppins;
+    font-family: var(--font-satoshi), sans-serif;
     font-size: 1.2rem;
     font-weight: 600;
     color: $project-font-color;

--- a/app/projects/ar-story-teller/ArStoryTellerPage.tsx
+++ b/app/projects/ar-story-teller/ArStoryTellerPage.tsx
@@ -74,7 +74,7 @@ export function ArStoryTellerPage({
             }}
           />
           <TeamSection data={{ team: projectData.team }} />
-          <ProjectOverviewSection />
+          <ProjectOverviewSection data={{ projectOverview: projectData.projectOverview }} />
           <CaseStudyOverviewSection data={{ caseStudy: projectData.caseStudy }} />
           <DesignSystemSection data={{ caseStudy: projectData.caseStudy }} />
           <ConclusionsAndImpactSection data={{ caseStudy: projectData.caseStudy }} />

--- a/app/projects/ar-story-teller/components/OverviewParagraphBlock.scss
+++ b/app/projects/ar-story-teller/components/OverviewParagraphBlock.scss
@@ -1,5 +1,5 @@
 @mixin desktop-title-text {
-    font-family: var(--font-poppins);
+    font-family: var(--font-satoshi), sans-serif;
     font-size: 1.5rem;
     font-weight: 600;
     color: #03133C;
@@ -13,7 +13,7 @@
 }
 
 @mixin lgmd-title-text {
-    font-family: var(--font-poppins);
+    font-family: var(--font-satoshi), sans-serif;
     font-size: 1.5rem;
     font-weight: 600;
     color: #03133C;
@@ -133,7 +133,7 @@
         justify-content: center;
         align-items: center;
         .storyteller-mdlg-paragraph-title {
-            font-family: var(--font-poppins);
+            font-family: var(--font-satoshi), sans-serif;
             font-size: 1.8rem;
             font-weight: 600;
             color: #102764;
@@ -162,7 +162,7 @@
         justify-content: center;
         align-items: center;
         .storyteller-mobile-paragraph-title {
-            font-family: var(--font-poppins);
+            font-family: var(--font-satoshi), sans-serif;
             font-size: 1.5rem;
             font-weight: 600;
             color: #102764;

--- a/app/projects/ar-story-teller/components/OverviewParagraphBlock.scss
+++ b/app/projects/ar-story-teller/components/OverviewParagraphBlock.scss
@@ -1,13 +1,13 @@
 @mixin desktop-title-text {
     font-family: var(--font-satoshi), sans-serif;
-    font-size: 1.5rem;
+    font-size: 40px;
     font-weight: 600;
     color: #03133C;
 }
 
 @mixin desktop-section-text {
-    font-family: var(--font-poppins);
-    font-size: 1.2rem;
+    font-family: var(--font-source-sans-3), "Source Sans 3", system-ui, sans-serif;
+    font-size: 1.5rem;
     font-weight: 400;
     color: #03133C;
 }
@@ -20,7 +20,7 @@
 }
 
 @mixin lgmd-section-text {
-    font-family: var(--font-poppins);
+    font-family: var(--font-source-sans-3), "Source Sans 3", system-ui, sans-serif;
     font-size: 1.2rem;
     font-weight: 400;
     color: #03133C;
@@ -141,7 +141,7 @@
 
         .storyteller-mdlg-paragraph-text {
             padding-top: 2.5rem;
-            font-family: var(--font-poppins);
+            font-family: var(--font-source-sans-3), "Source Sans 3", system-ui, sans-serif;
             font-size: 1.2rem;
             font-weight: 400;
             color: #102764;
@@ -171,7 +171,7 @@
 
         .storyteller-mobile-paragraph-text {
             padding-top: 2rem;
-            font-family: var(--font-poppins);
+            font-family: var(--font-source-sans-3), "Source Sans 3", system-ui, sans-serif;
             font-size: 1rem;
             font-weight: 400;
             color: #102764;

--- a/app/projects/ar-story-teller/components/OverviewParagraphBlock.tsx
+++ b/app/projects/ar-story-teller/components/OverviewParagraphBlock.tsx
@@ -43,7 +43,7 @@ export function OverviewParagraphBlock({
                             <SectionTitle
                                 title={title1}
                                 paddingTop={0}
-                                paddingBottom="1rem"
+                                paddingBottom="0.1rem"
                             />
                         ) : null}
                         <p>{paragraph1}</p>

--- a/app/projects/ar-story-teller/components/OverviewParagraphBlock.tsx
+++ b/app/projects/ar-story-teller/components/OverviewParagraphBlock.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import './OverviewParagraphBlock.scss';
+import { SectionTitle } from './SectionTitle';
 import WaitingPeopleDesktop from '../Images/WaitingPeople-DesktopLg.png';
 import WaitingPeopleLgMd from '../Images/WaitingPeople-LgMd.png';
 import WaitingPeopleSMSX from '../Images/WaitingPeople-SMSX.png';
@@ -38,13 +39,25 @@ export function OverviewParagraphBlock({
             >
                 <div className="project-summary-container">
                     <div className="storyteller-laptoplg-content-left">
-                        <span>{title1}</span>
+                        {title1 ? (
+                            <SectionTitle
+                                title={title1}
+                                paddingTop={0}
+                                paddingBottom="1rem"
+                            />
+                        ) : null}
                         <p>{paragraph1}</p>
                     </div>
                 </div>
                 <div className="project-summary-container">
                     <div className="storyteller-laptoplg-content-right">
-                        <span>{title2}</span>
+                        {title2 ? (
+                            <SectionTitle
+                                title={title2}
+                                paddingTop={0}
+                                paddingBottom="1rem"
+                            />
+                        ) : null}
                         <p>{paragraph2}</p>
                     </div>
                 </div>
@@ -62,13 +75,25 @@ export function OverviewParagraphBlock({
             >
                 <div className="project-summary-container">
                     <div className="content">
-                        <span>{title1}</span>
+                        {title1 ? (
+                            <SectionTitle
+                                title={title1}
+                                paddingTop={0}
+                                paddingBottom="1rem"
+                            />
+                        ) : null}
                         <p>{paragraph1}</p>
                     </div>
                 </div>
                 <div className="project-summary-container">
                     <div className="content">
-                        <span>{title2}</span>
+                        {title2 ? (
+                            <SectionTitle
+                                title={title2}
+                                paddingTop={0}
+                                paddingBottom="1rem"
+                            />
+                        ) : null}
                         <p>{paragraph2}</p>
                     </div>
                 </div>
@@ -86,13 +111,25 @@ export function OverviewParagraphBlock({
             >
                 <div className="storyteller-mobile-paragraph-container">
                     <div className="storyteller-mobile-content">
-                        <div className="storyteller-mobile-paragraph-title">{title1}</div>
+                        {title1 ? (
+                            <SectionTitle
+                                title={title1}
+                                paddingTop={0}
+                                paddingBottom="0.625rem"
+                            />
+                        ) : null}
                         <p className="storyteller-mobile-paragraph-text">{paragraph1}</p>
                     </div>
                 </div>
                 <div className="storyteller-mobile-paragraph-container">
                     <div className="storyteller-mobile-content">
-                        <div className="storyteller-mobile-paragraph-title">{title2}</div>
+                        {title2 ? (
+                            <SectionTitle
+                                title={title2}
+                                paddingTop={0}
+                                paddingBottom="0.625rem"
+                            />
+                        ) : null}
                         <p className="storyteller-mobile-paragraph-text">{paragraph2}</p>
                     </div>
                 </div>

--- a/app/projects/ar-story-teller/components/ParagraphImg.scss
+++ b/app/projects/ar-story-teller/components/ParagraphImg.scss
@@ -17,7 +17,9 @@
             display: flex;
             flex-direction: column;
             align-items: center;
-            width: 100%;
+            width: var(--paragraph-img-width, 100%);
+            max-width: 100%;
+            box-sizing: border-box;
             //background-color: aqua;
         }
 
@@ -31,7 +33,7 @@
             display: flex;
             flex-direction: column;
             align-items: stretch;
-            width: 90%;
+            width: var(--paragraph-img-width, 90%);
             max-width: 100%;
             box-sizing: border-box;
         }
@@ -79,7 +81,9 @@
             display: flex;
             flex-direction: column;
             align-items: center;
-            width: 100%;
+            width: var(--paragraph-img-width, 100%);
+            max-width: 100%;
+            box-sizing: border-box;
         }
 
         &__image {
@@ -92,7 +96,9 @@
             display: flex;
             flex-direction: column;
             align-items: stretch;
-            width: 100%;
+            width: var(--paragraph-img-width, 100%);
+            max-width: 100%;
+            box-sizing: border-box;
         }
 
         &__title {
@@ -139,7 +145,9 @@
             display: flex;
             flex-direction: column;
             align-items: center;
-            width: 80%;
+            width: var(--paragraph-img-width, 80%);
+            max-width: 100%;
+            box-sizing: border-box;
         }
 
         &__image {
@@ -151,7 +159,9 @@
             display: flex;
             flex-direction: column;
             align-items: stretch;
-            width: 80%;
+            width: var(--paragraph-img-width, 80%);
+            max-width: 100%;
+            box-sizing: border-box;
         }
 
         &__title {

--- a/app/projects/ar-story-teller/components/ParagraphImg.tsx
+++ b/app/projects/ar-story-teller/components/ParagraphImg.tsx
@@ -1,4 +1,5 @@
 'use client';
+import type { ComponentPropsWithoutRef, CSSProperties } from 'react';
 import './ParagraphImg.scss';
 import { useResponsive } from '@/lib/responsive/ResponsiveQueryProvider';
 import { StaticImageData } from 'next/image';
@@ -6,17 +7,31 @@ import ProjectImage from '@/lib/media/ProjectImage';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-interface ParagraphImgProps {
+interface ParagraphImgProps extends ComponentPropsWithoutRef<'div'> {
     alt?: string;
     imagesSrc?: StaticImageData[] | string[];
     description?: string;
     title?: string;
-    [key: string]: unknown;
+    /** Image + caption width as % of parent (1–100). Omit to use SCSS defaults per breakpoint. */
+    widthPercent?: number;
+}
+
+function clampWidthPercent(value: number): number {
+    return Math.min(100, Math.max(1, value));
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
-export function ParagraphImg({ alt = '', imagesSrc = [], description, title, ...props }: ParagraphImgProps) {
+export function ParagraphImg({
+    alt = '',
+    imagesSrc = [],
+    description,
+    title,
+    widthPercent,
+    className,
+    style,
+    ...props
+}: ParagraphImgProps) {
     const screenDevice = useResponsive();
 
     const getImagePath = (index: number) => {
@@ -39,8 +54,21 @@ export function ParagraphImg({ alt = '', imagesSrc = [], description, title, ...
 
     const hasCaption = Boolean(title?.trim()) || Boolean(description?.trim());
 
+    const rootStyle: CSSProperties = {
+        ...(widthPercent !== undefined
+            ? {
+                  ['--paragraph-img-width' as string]: `${clampWidthPercent(widthPercent)}%`,
+              }
+            : {}),
+        ...style,
+    };
+
     return (
-        <div {...props} className="storyteller-paragraphimg">
+        <div
+            {...props}
+            className={['storyteller-paragraphimg', className].filter(Boolean).join(' ')}
+            style={rootStyle}
+        >
             <div className="storyteller-paragraphimg__media">
                 <ProjectImage objectPath={objectPath} alt={alt} className="storyteller-paragraphimg__image" />
             </div>

--- a/app/projects/ar-story-teller/components/ProjectHeader.scss
+++ b/app/projects/ar-story-teller/components/ProjectHeader.scss
@@ -127,13 +127,13 @@
             .banner-text-title {
                 margin-bottom: 1.5rem;
                 font-size: clamp(1.875rem, 1.2vw + 1.15rem, 2.1rem);
-                font-family: var(--font-poppins);
+                font-family: var(--font-satoshi), sans-serif;
                 color: #ffffff;
                 font-weight: 600;
             }
             p {
                 font-size: clamp(1.25rem, 1.05vw + 0.94rem, 1.4rem);
-                font-family: var(--font-poppins);
+                font-family: var(--font-satoshi), sans-serif;
                 color: #ffbb00;
                 font-weight: 600;
                 width: 55%;
@@ -175,14 +175,14 @@
             .banner-text-title {
                 margin-bottom: 1.5rem;
                 font-size: 2rem;
-                font-family: var(--font-poppins);
+                font-family: var(--font-satoshi), sans-serif;
                 color: #ffffff;
                 font-weight: 600;
                 width: 100%;
             }
             p {
                 font-size: 1.2rem;
-                font-family: var(--font-poppins);
+                font-family: var(--font-satoshi), sans-serif;
                 color: #ffbb00;
                 font-weight: 500;
                 width: 80%;
@@ -232,7 +232,7 @@
             .banner-text-title {
                 margin-bottom: 1.5rem;
                 font-size: 1.2rem;
-                font-family: var(--font-poppins);
+                font-family: var(--font-satoshi), sans-serif;
                 color: #ffffff;
                 font-weight: 600;
                 width: 100%;
@@ -240,7 +240,7 @@
             }
             p {
                 font-size: 1rem;
-                font-family: var(--font-poppins);
+                font-family: var(--font-satoshi), sans-serif;
                 color: #ffbb00;
                 font-weight: 500;
                 width: 100%;

--- a/app/projects/ar-story-teller/components/ProjectOverview.scss
+++ b/app/projects/ar-story-teller/components/ProjectOverview.scss
@@ -2,6 +2,26 @@
    Variables (`$desktop`, `$tablet`, `$mobile`, `$font-color-bold`, `$font-color-normal`)
    come from `styles/variables.scss` via Next's `sassOptions.additionalData`. */
 
+/* Column heading scale — same rhythm as `SectionTitle` (40 / 34 / 28 px): ~15% down per step. */
+@mixin overview-column-title-type($font-size) {
+    font-family: var(--font-satoshi), sans-serif;
+    font-size: $font-size;
+    font-style: normal;
+    font-weight: 600;
+    line-height: normal;
+    color: $font-color-bold;
+}
+
+/* List copy — Source Sans 3; steps match `ParagraphText` ratio (24 / 22 / 18 px) from 27 px desktop. */
+@mixin overview-items-type($font-size) {
+    font-family: var(--font-source-sans-3), "Source Sans 3", system-ui, sans-serif;
+    font-size: $font-size;
+    font-style: normal;
+    font-weight: 400;
+    line-height: normal;
+    color: $font-color-normal;
+}
+
 .overview-container {
     margin-left: auto;
     margin-right: auto;
@@ -63,10 +83,7 @@
         }
 
         .overview-column-title {
-            font-family: var(--font-poppins);
-            font-size: 1.2rem;
-            font-weight: 600;
-            color: $font-color-bold;
+            @include overview-column-title-type(27px);
             padding-bottom: 0.5rem;
         }
 
@@ -80,10 +97,7 @@
             width: 100%;
 
             li {
-                font-family: var(--font-poppins);
-                font-size: 1.1rem;
-                font-weight: 400;
-                color: $font-color-normal;
+                @include overview-items-type(22px);
             }
         }
     }
@@ -124,10 +138,7 @@
         }
 
         .overview-column-title {
-            font-family: var(--font-poppins);
-            font-size: 1.1rem;
-            font-weight: 600;
-            color: $font-color-bold;
+            @include overview-column-title-type(22px);
             padding-bottom: 0.5rem;
         }
 
@@ -141,10 +152,7 @@
             width: 100%;
 
             li {
-                font-family: var(--font-poppins);
-                font-size: 1rem;
-                font-weight: 400;
-                color: $font-color-normal;
+                @include overview-items-type(22px);
             }
         }
     }
@@ -156,9 +164,9 @@
     }
 
     .overview-title {
-        font-size: 1.375rem;
+        font-size: 22px;
         padding-top: 1.25rem;
-        padding-bottom: 1rem;
+        padding-bottom: 2rem;
     }
 
     .overview-rows {
@@ -184,10 +192,7 @@
 
         .overview-row-icon-label {
             margin-top: 0.5rem;
-            font-family: var(--font-poppins);
-            font-size: 1rem;
-            font-weight: 600;
-            color: $font-color-bold;
+            @include overview-column-title-type(18px);
         }
 
         .overview-row-items {
@@ -201,10 +206,7 @@
             gap: 0.25rem;
 
             li {
-                font-family: var(--font-poppins);
-                font-size: 1rem;
-                font-weight: 400;
-                color: $font-color-normal;
+                @include overview-items-type(20px);
             }
         }
     }

--- a/app/projects/ar-story-teller/components/ProjectOverview.tsx
+++ b/app/projects/ar-story-teller/components/ProjectOverview.tsx
@@ -1,54 +1,24 @@
 'use client';
+import type { ComponentPropsWithoutRef } from 'react';
 import './ProjectOverview.scss';
-import Image, { type StaticImageData } from 'next/image';
-import MyRolesIcon from '../Images/MyRolesIcon.png';
-import TimelineIcon from '../Images/TimelineIcon.png';
-import CategoryIcon from '../Images/CategoryIcon.png';
+import ProjectImage from '@/lib/media/ProjectImage';
 import { useResponsive } from '@/lib/responsive/ResponsiveQueryProvider';
+import type {
+    ProjectOverviewColumn,
+    ProjectOverviewData,
+} from '@/app/projects/ar-story-teller/types/arStoryTellerContent';
 
-interface ProjectOverviewProps {
-    title?: string;
-    [key: string]: unknown;
+interface ProjectOverviewProps extends ComponentPropsWithoutRef<'div'> {
+    data: ProjectOverviewData;
 }
 
-interface OverviewItem {
-    icon: StaticImageData;
-    title: string;
-    items: string[];
-}
+const ICON_SIZE = 60;
 
-/* Hardcoded copy — no data flows into this component yet (see `ArStoryTellerPage`). */
-const OVERVIEW_ITEMS: OverviewItem[] = [
-    {
-        icon: MyRolesIcon,
-        title: 'My Roles',
-        items: ['Project Lead', 'UX/UI Designer', 'Technology Research'],
-    },
-    {
-        icon: TimelineIcon,
-        title: 'Timeline',
-        items: ['9 Months'],
-    },
-    {
-        icon: CategoryIcon,
-        title: 'Category',
-        items: [
-            'Extended Reality (XR)',
-            'Entertainment',
-            'Computer Vision',
-            'iOS Mobile Development',
-        ],
-    },
-];
-
-const OVERVIEW_HEADING = 'Project Overview';
-const ICON_SIZE = 42;
-
-function OverviewIcon({ icon, alt }: { icon: StaticImageData; alt: string }) {
+function OverviewIcon({ objectPath, alt }: { objectPath: string; alt: string }) {
     return (
-        <Image
+        <ProjectImage
+            objectPath={objectPath}
             alt={alt}
-            src={icon}
             width={ICON_SIZE}
             height={ICON_SIZE}
             className="overview-icon-img"
@@ -56,11 +26,14 @@ function OverviewIcon({ icon, alt }: { icon: StaticImageData; alt: string }) {
     );
 }
 
-function OverviewColumn({ item }: { item: OverviewItem }) {
+function OverviewColumn({ item }: { item: ProjectOverviewColumn }) {
     return (
         <div className="overview-column">
             <div className="overview-column-icon">
-                <OverviewIcon icon={item.icon} alt={`${item.title} icon`} />
+                <OverviewIcon
+                    objectPath={item.icon}
+                    alt={`${item.title} icon`}
+                />
             </div>
             <div className="overview-column-title">{item.title}</div>
             <ul className="overview-column-items">
@@ -72,11 +45,14 @@ function OverviewColumn({ item }: { item: OverviewItem }) {
     );
 }
 
-function OverviewRow({ item }: { item: OverviewItem }) {
+function OverviewRow({ item }: { item: ProjectOverviewColumn }) {
     return (
         <div className="overview-row">
             <div className="overview-row-icon">
-                <OverviewIcon icon={item.icon} alt={`${item.title} icon`} />
+                <OverviewIcon
+                    objectPath={item.icon}
+                    alt={`${item.title} icon`}
+                />
                 <div className="overview-row-icon-label">{item.title}</div>
             </div>
             <ul className="overview-row-items">
@@ -88,15 +64,16 @@ function OverviewRow({ item }: { item: OverviewItem }) {
     );
 }
 
-export function ProjectOverview({ title, ...props }: ProjectOverviewProps) {
+export function ProjectOverview({ data, ...props }: ProjectOverviewProps) {
     const screenDevice = useResponsive();
+    const { title, columns } = data;
 
     if (screenDevice.isDesktopOrLaptop || screenDevice.isTablet) {
         return (
             <div {...props} className="overview-container">
-                <h2 className="overview-title">{title ?? OVERVIEW_HEADING}</h2>
+                <h2 className="overview-title">{title}</h2>
                 <div className="overview-columns">
-                    {OVERVIEW_ITEMS.map((item) => (
+                    {columns.map((item) => (
                         <OverviewColumn key={item.title} item={item} />
                     ))}
                 </div>
@@ -107,9 +84,9 @@ export function ProjectOverview({ title, ...props }: ProjectOverviewProps) {
     if (screenDevice.isMobile) {
         return (
             <div {...props} className="overview-container overview-container--mobile">
-                <h2 className="overview-title">{title ?? OVERVIEW_HEADING}</h2>
+                <h2 className="overview-title">{title}</h2>
                 <div className="overview-rows">
-                    {OVERVIEW_ITEMS.map((item) => (
+                    {columns.map((item) => (
                         <OverviewRow key={item.title} item={item} />
                     ))}
                 </div>

--- a/app/projects/ar-story-teller/components/SectionSubTitle.scss
+++ b/app/projects/ar-story-teller/components/SectionSubTitle.scss
@@ -9,7 +9,7 @@
 
         .section-sub-title__label {
             color: #03133c;
-            font-family: var(--font-satoshi), var(--font-poppins), sans-serif;
+            font-family: var(--font-satoshi), sans-serif;
             font-size: 40px;
             font-style: normal;
             font-weight: 700;
@@ -27,7 +27,7 @@
         .section-sub-title__label {
             text-align: center;
             color: #03133c;
-            font-family: var(--font-satoshi), var(--font-poppins), sans-serif;
+            font-family: var(--font-satoshi), sans-serif;
             font-size: 34px;
             font-style: normal;
             font-weight: 700;
@@ -46,7 +46,7 @@
         .section-sub-title__label {
             text-align: center;
             color: #03133c;
-            font-family: var(--font-satoshi), var(--font-poppins), sans-serif;
+            font-family: var(--font-satoshi), sans-serif;
             font-size: 28px;
             font-style: normal;
             font-weight: 700;

--- a/app/projects/ar-story-teller/components/SectionTitle.scss
+++ b/app/projects/ar-story-teller/components/SectionTitle.scss
@@ -13,7 +13,7 @@
             padding-top: 1rem;
             text-align: left;
             color: #03133c;
-            font-family: var(--font-satoshi), var(--font-poppins), sans-serif;
+            font-family: var(--font-satoshi), sans-serif;
             font-size: 40px;
             font-style: normal;
             font-weight: 700;
@@ -32,7 +32,7 @@
             padding-bottom: 3rem;
             text-align: center;
             color: #03133c;
-            font-family: var(--font-satoshi), var(--font-poppins), sans-serif;
+            font-family: var(--font-satoshi), sans-serif;
             /* ~15% under desktop (40px) — strong on tablet without matching desktop scale */
             font-size: 34px;
             font-style: normal;
@@ -52,7 +52,7 @@
             padding-bottom: 10px;
             text-align: center;
             color: #03133c;
-            font-family: var(--font-satoshi), var(--font-poppins), sans-serif;
+            font-family: var(--font-satoshi), sans-serif;
             /* ~30% under desktop — readable in narrow columns; try 30px if this feels tight */
             font-size: 28px;
             font-style: normal;

--- a/app/projects/ar-story-teller/components/SubTitle.scss
+++ b/app/projects/ar-story-teller/components/SubTitle.scss
@@ -3,7 +3,7 @@
     margin: auto;
 
     .subtitle-paragraph {
-        font-family: poppins;
+        font-family: var(--font-satoshi), sans-serif;
         font-size: 2.5rem;
         font-weight: 600;
         color: $font-color-normal;
@@ -19,7 +19,7 @@
     margin: auto;
 
     .subtitle-paragraph {
-        font-family: poppins;
+        font-family: var(--font-satoshi), sans-serif;
         font-size: 1.4rem;
         font-weight: 600;
         color: $font-color-normal;
@@ -35,7 +35,7 @@
 
 
     .subtitle-paragraph {
-        font-family: poppins;
+        font-family: var(--font-satoshi), sans-serif;
         font-size: 1.2rem;
         font-weight: 600;
         color: $font-color-normal;

--- a/app/projects/ar-story-teller/components/SubTitle1.scss
+++ b/app/projects/ar-story-teller/components/SubTitle1.scss
@@ -5,7 +5,7 @@
 
 
         .subtitle-paragraph {
-            font-family: poppins;
+            font-family: var(--font-satoshi), sans-serif;
             font-size: 1.4rem;
             font-weight: 600;
             color: $font-color-normal;
@@ -23,7 +23,7 @@
         padding-top: 3rem;
 
         .subtitle-paragraph {
-            font-family: poppins;
+            font-family: var(--font-satoshi), sans-serif;
             font-size: 1.4rem;
             font-weight: 600;
             color: $font-color-normal;
@@ -41,7 +41,7 @@
 
         padding-top: 1rem;
         .subtitle-paragraph {
-            font-family: poppins;
+            font-family: var(--font-satoshi), sans-serif;
             font-size: 1.2rem;
             font-weight: 600;
             color: $font-color-normal;

--- a/app/projects/ar-story-teller/components/SubTitle2.scss
+++ b/app/projects/ar-story-teller/components/SubTitle2.scss
@@ -3,7 +3,7 @@
         padding-top: 3rem;
         padding-bottom: 1.5rem;
         .subtitle-paragraph {
-            font-family: poppins;
+            font-family: var(--font-satoshi), sans-serif;
             font-size: 1.4rem;
             font-weight: 600;
             color: $font-color-normal;
@@ -19,7 +19,7 @@
     .st-subtitle2-container {
         padding-top: 3rem;
         .subtitle-paragraph {
-            font-family: poppins;
+            font-family: var(--font-satoshi), sans-serif;
             font-size: 2.5rem;
             font-weight: 600;
             color: $font-color-normal;
@@ -37,7 +37,7 @@
         padding-top: 2rem;
 
         .subtitle-paragraph {
-            font-family: poppins;
+            font-family: var(--font-satoshi), sans-serif;
             font-size: 1.2rem;
             font-weight: 600;
             color: $font-color-normal;

--- a/app/projects/ar-story-teller/components/Team.scss
+++ b/app/projects/ar-story-teller/components/Team.scss
@@ -1,44 +1,44 @@
 @mixin member-title-desktop {
-    font-family: poppins;
-    font-size: 1.2rem;
-    font-weight: 600;
+    font-family: var(--font-source-sans-3), "Source Sans 3", system-ui, sans-serif;
+    font-size: 24px;
+    font-weight: 400;
     color: $font-color-normal;
 }
 
 @mixin member-name-desktop {
-    font-family: poppins;
-    font-size: 1.2rem;
-    font-weight: 400;
+    font-family: var(--font-source-sans-3), "Source Sans 3", system-ui, sans-serif;
+    font-size: 24px;
+    font-weight: 600;
     color: $font-color-bold;
 }
 
 
 @mixin member-name-mdlg {
-    font-family: poppins;
-    font-size: 1rem;
-    font-weight: 600;
+    font-family: var(--font-source-sans-3), "Source Sans 3", system-ui, sans-serif;
+    font-size: 20px;
+    font-weight: 400;
     color: $font-color-bold;
 }
 
 
 @mixin member-title-mdlg {
-    font-family: poppins;
+    font-family: var(--font-source-sans-3), "Source Sans 3", system-ui, sans-serif;
     font-size: 1rem;
-    font-weight: 400;
+    font-weight: 600;
     color: $font-color-normal;
 }
 
 @mixin member-name-smsx {
-    font-family: poppins;
-    font-size: 1.2rem;
-    font-weight: 400;
+    font-family: var(--font-source-sans-3), "Source Sans 3", system-ui, sans-serif;
+    font-size: 18px;
+    font-weight: 600;
     color: $font-color-bold;
 }
 
 @mixin member-title-smsx {
-    font-family: poppins;
+    font-family: var(--font-source-sans-3), "Source Sans 3", system-ui, sans-serif;
     font-size: 1.4rem;
-    font-weight: 600;
+    font-weight: 400;
     color: $font-color-normal;
 }
 

--- a/app/projects/ar-story-teller/components/TitleParagraph.scss
+++ b/app/projects/ar-story-teller/components/TitleParagraph.scss
@@ -8,7 +8,7 @@
             padding-top: 20px;
             padding-bottom: 10px;
             text-align: center;
-            font-family: var(--font-poppins);
+            font-family: var(--font-satoshi), sans-serif;
             font-size: 1.8rem;
             font-weight: 600;
         }
@@ -25,7 +25,7 @@
             padding-top: 1.5rem;
             padding-bottom: 3rem;
             text-align: center;
-            font-family: var(--font-poppins);
+            font-family: var(--font-satoshi), sans-serif;
             font-size: 1.75rem;
             font-weight: 600;
         }
@@ -39,16 +39,13 @@
         text-align: center;
 
         .title-paragraph {
-            font-family: poppins;
+            font-family: var(--font-satoshi), sans-serif;
             font-size: 1.5rem;
             font-weight: 600;
             color: #040B35;
             padding-top: 20px;
             padding-bottom: 10px;
             text-align: center;
-            font-family: var(--font-poppins);
-            font-size: 1.5rem;
-            font-weight: 600;
         }
     }
 }

--- a/app/projects/ar-story-teller/components/demo/SolutionDemo.scss
+++ b/app/projects/ar-story-teller/components/demo/SolutionDemo.scss
@@ -23,7 +23,7 @@
 
         span {
             text-align: center;
-            font-family: var(--font-poppins);
+            font-family: var(--font-satoshi), sans-serif;
             font-size: 1.8rem;
             font-weight: 600;
             color: #03133C;
@@ -40,7 +40,7 @@
 }
 
 @mixin desktop-title-text {
-    font-family: poppins;
+    font-family: var(--font-satoshi), sans-serif;
     font-size: 3rem;
     font-weight: 600;
     color: #102764;
@@ -62,7 +62,7 @@
 
 
 @mixin lgmd-title-text {
-    font-family: poppins;
+    font-family: var(--font-satoshi), sans-serif;
     font-size: 1.5rem;
     font-weight: 600;
     color: #102764;

--- a/app/projects/ar-story-teller/components/demo/SolutionDemo.scss
+++ b/app/projects/ar-story-teller/components/demo/SolutionDemo.scss
@@ -24,15 +24,15 @@
         span {
             text-align: center;
             font-family: var(--font-satoshi), sans-serif;
-            font-size: 1.8rem;
-            font-weight: 600;
+            font-size: 40px;
+            font-weight: 700;
             color: #03133C;
         }
 
         p {
             padding-top: 2rem;
-            font-family: var(--font-poppins);
-            font-size: 1.2rem;
+            font-family: var(--font-source-sans-3), "Source Sans 3", system-ui, sans-serif;
+            font-size: 24px;
             font-weight: 400;
             color: #03133C;
         }
@@ -41,20 +41,20 @@
 
 @mixin desktop-title-text {
     font-family: var(--font-satoshi), sans-serif;
-    font-size: 3rem;
+    font-size: 40px;
     font-weight: 600;
     color: #102764;
 }
 
 @mixin desktop-section-text {
-    font-family: poppins;
+    font-family: var(--font-source-sans-3), "Source Sans 3", system-ui, sans-serif;
     font-size: 2rem;
     font-weight: 400;
     color: #102764;
 }
 
 @mixin desktop-annotation-text {
-    font-family: poppins;
+    font-family: var(--font-source-sans-3), "Source Sans 3", system-ui, sans-serif;
     font-size: 2rem;
     font-weight: 400;
     color: #102764;
@@ -63,14 +63,14 @@
 
 @mixin lgmd-title-text {
     font-family: var(--font-satoshi), sans-serif;
-    font-size: 1.5rem;
+    font-size: 30px;
     font-weight: 600;
     color: #102764;
 }
 
 @mixin lgmd-section-text {
-    font-family: poppins;
-    font-size: 1.2rem;
+    font-family: var(--font-source-sans-3), "Source Sans 3", system-ui, sans-serif;
+    font-size: 24px;
     font-weight: 400;
     color: #102764;
 }

--- a/app/projects/ar-story-teller/components/sections/CaseStudyOverviewSection.scss
+++ b/app/projects/ar-story-teller/components/sections/CaseStudyOverviewSection.scss
@@ -102,7 +102,7 @@
     margin: 0;
     padding-top: 1.5rem;
     padding-bottom: 0;
-    font-family: var(--font-poppins);
+    font-family: var(--font-satoshi), sans-serif;
     font-size: clamp(1.3rem, 3vw, 2rem);
     font-weight: 600;
     color: #ffffff;

--- a/app/projects/ar-story-teller/components/sections/ProjectOverviewSection.tsx
+++ b/app/projects/ar-story-teller/components/sections/ProjectOverviewSection.tsx
@@ -1,13 +1,19 @@
 import ProjectOverview from '../ProjectOverview';
 import styles from '../../ArStoryTeller.module.scss';
+import type { ProjectOverviewSectionData } from '@/app/projects/ar-story-teller/types/arStoryTellerContent';
 
-export function ProjectOverviewSection() {
+interface ProjectOverviewSectionProps {
+    data: ProjectOverviewSectionData;
+}
+
+export function ProjectOverviewSection({ data }: ProjectOverviewSectionProps) {
     return (
         <section className={styles['project-container']}>
-            <ProjectOverview 
-               data-aos="fade-up"
-               data-aos-duration="1000"
-               data-aos-anchor-placement="top-center"
+            <ProjectOverview
+                data={data.projectOverview}
+                data-aos="fade-up"
+                data-aos-duration="1000"
+                data-aos-anchor-placement="top-center"
             />
         </section>
     );

--- a/app/projects/ar-story-teller/lib/parseArStoryTellerContent.ts
+++ b/app/projects/ar-story-teller/lib/parseArStoryTellerContent.ts
@@ -6,6 +6,8 @@ import type {
   MagicExperiences,
   NotificationsAttrac,
   OverviewBlock,
+  ProjectOverviewData,
+  ProjectOverviewColumn,
   SolutionBlock,
   TeamData,
   TeamMember,
@@ -140,6 +142,37 @@ function parseMagicExperiences(value: unknown, path: string): MagicExperiences {
   };
 }
 
+function parseProjectOverview(
+  value: unknown,
+  path: string,
+): ProjectOverviewData {
+  if (!isRecord(value)) {
+    throw new Error(`Invalid ${path}: expected object`);
+  }
+  if (!Array.isArray(value.columns)) {
+    throw new Error(`Invalid ${path}.columns: expected array`);
+  }
+
+  const columns: ProjectOverviewColumn[] = value.columns.map((column, index) => {
+    if (!isRecord(column)) {
+      throw new Error(`Invalid ${path}.columns[${index}]: expected object`);
+    }
+    if (!Array.isArray(column.items)) {
+      throw new Error(`Invalid ${path}.columns[${index}].items: expected array`);
+    }
+    return {
+      icon: requireString(column.icon, `${path}.columns[${index}].icon`),
+      title: requireString(column.title, `${path}.columns[${index}].title`),
+      items: parseStringArray(column.items, `${path}.columns[${index}].items`),
+    };
+  });
+
+  return {
+    title: requireString(value.title, `${path}.title`),
+    columns,
+  };
+}
+
 function parseCaseStudy(value: unknown, path: string): ArStoryTellerCaseStudy {
   if (!isRecord(value)) {
     throw new Error(`Invalid ${path}: expected object`);
@@ -212,6 +245,7 @@ export function parseArStoryTellerContent(raw: unknown): ArStoryTellerContent {
     theProblem: parseOverviewBlock(raw.theProblem, "theProblem"),
     solution: parseSolutionBlock(raw.solution, "solution"),
     team: parseTeamData(raw.team, "team"),
+    projectOverview: parseProjectOverview(raw.projectOverview, "projectOverview"),
     caseStudy: parseCaseStudy(raw.caseStudy, "caseStudy"),
   };
 }

--- a/app/projects/ar-story-teller/sections/DesignSystemSection.tsx
+++ b/app/projects/ar-story-teller/sections/DesignSystemSection.tsx
@@ -101,9 +101,7 @@ export function DesignSystemSection({ data }: DesignSystemSectionProps) {
                     <ParagraphImg
                         imagesSrc={userResearchJourney.images}
                         alt={designSystem.alt}
-                        data-aos="fade-up"
-                        data-aos-duration="1000"
-                        data-aos-anchor-placement="top-center"
+                        widthPercent={80}
                         style={{ paddingTop: '2rem', paddingBottom: '2rem' }}
                     />
                 </div>

--- a/app/projects/ar-story-teller/types/arStoryTellerContent.ts
+++ b/app/projects/ar-story-teller/types/arStoryTellerContent.ts
@@ -25,6 +25,19 @@ export type TeamData = {
   members: TeamMember[];
 };
 
+/** Firestore `content.projectOverview` — roles, timeline, category columns. */
+export type ProjectOverviewColumn = {
+  /** Storage object path, e.g. `projects/project_1/MyRolesIcon.png`. */
+  icon: string;
+  title: string;
+  items: string[];
+};
+
+export type ProjectOverviewData = {
+  title: string;
+  columns: ProjectOverviewColumn[];
+};
+
 export type CaseStudyOverview = {
   title: string;
   paragraphs: string[];
@@ -79,6 +92,7 @@ export type ArStoryTellerContent = {
   theProblem: OverviewBlock;
   solution: SolutionBlock;
   team: TeamData;
+  projectOverview: ProjectOverviewData;
   caseStudy: ArStoryTellerCaseStudy;
 };
 
@@ -88,6 +102,11 @@ export type OverviewSectionData = Pick<
 >;
 
 export type TeamSectionData = Pick<ArStoryTellerContent, "team">;
+
+export type ProjectOverviewSectionData = Pick<
+  ArStoryTellerContent,
+  "projectOverview"
+>;
 
 export type CaseStudyOverviewSectionData = Pick<
   ArStoryTellerContent,


### PR DESCRIPTION
### Summary
This branch polishes AR Story Teller typography and moves the Project Overview block onto Firestore-driven content.

**Typography**

- Titles use Satoshi (--font-satoshi) across section titles, overview headings, hero headline, case study banner, and solution block.
- Subtitles use Satoshi for SectionSubTitle, SubTitle1/SubTitle2, hero taglines, and related mixins.
- Body copy in the overview area uses Source Sans 3 (--font-source-sans-3) in OverviewParagraphBlock and aligned styles.
- Overview section headings now use the shared SectionTitle component (desktop / tablet / mobile) instead of ad-hoc <span> markup.

**Project Overview → Firestore**

- Added content.projectOverview with title and columns[] (icon, title, items).
- Icons load from Storage via ProjectImage (e.g. projects/project_1/MyRolesIcon.png, TimelineIcon.png, CategoryIcon.png) — removed bundled PNG imports.
- Types + parseProjectOverview() validation; ProjectOverviewSection receives data from ArStoryTellerPage.

**Other UI tweaks**

- ParagraphImg: optional widthPercent prop for responsive image/caption width.
- Minor spacing/typography alignment in ParagraphImg, SolutionDemo, and case study banner styles.