### PR TITLE
Main banner/fetching data fromfirestore

### DIFF
--- a/app/home/data/main-banner-data.ts
+++ b/app/home/data/main-banner-data.ts
@@ -1,0 +1,10 @@
+export type MainBannerData = {
+  title: string;
+  description: string;
+};
+
+export const mainBannerFallback: MainBannerData = {
+  title: "UX Engineer · Full-stack applications · AI-powered products",
+  description:
+    "I design and build intelligent products that connect human needs, business goals, and emerging technologies. My work spans UX engineering, frontend development, data visualization, AI-powered experiences, and human-centered systems.",
+};

--- a/app/home/home-panels.tsx
+++ b/app/home/home-panels.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 import gsap from "gsap";
 import { ScrollTrigger } from "gsap/ScrollTrigger";
 
@@ -15,6 +15,11 @@ import { Footer } from "@/components/Footer";
 import { LandingSplash } from "@/components/LandingSplash/LandingSplash";
 import { preloadLandingImages } from "@/lib/home/preloadLandingAssets";
 import { useLoadingSplash } from "@/lib/loadingSplash/useLoadingSplash";
+import {
+  homePageFallback,
+  type HomePageData,
+} from "@/app/home/lib/home-page-data";
+import { subscribeHomePageData } from "@/app/home/lib/main-page.firestore";
 
 gsap.registerPlugin(ScrollTrigger);
 
@@ -22,9 +27,16 @@ const SCROLL_SEGMENTS_MULTIPLIER = 1; // one viewport height per panel transitio
 
 function HomePanels() {
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const [homePageData, setHomePageData] = useState<HomePageData>(homePageFallback);
   const { phase, isLocked, splashPhase, onFadeEnd } = useLoadingSplash({
     waitFor: preloadLandingImages,
   });
+
+  useEffect(() => {
+    return subscribeHomePageData((data) => {
+      setHomePageData(data);
+    });
+  }, []);
 
   useLayoutEffect(() => {
     if (!containerRef.current) return;
@@ -148,7 +160,7 @@ function HomePanels() {
         inert={isLocked ? true : undefined}
       >
         <section className={styles.panel} data-bg={PAGE_CANVAS}>
-          <MainBanner />
+          <MainBanner banner={homePageData.mainBanner} />
         </section>
 
         <section className={styles.panel} data-bg={PAGE_CANVAS}>

--- a/app/home/lib/home-page-data.ts
+++ b/app/home/lib/home-page-data.ts
@@ -1,0 +1,29 @@
+import {
+  mainBannerFallback,
+  type MainBannerData,
+} from "@/app/home/data/main-banner-data";
+
+export type { MainBannerData };
+
+/** Aggregated Firestore-backed content for landing-page panels. */
+export type HomePageData = {
+  mainBanner: MainBannerData;
+};
+
+export const homePageFallback: HomePageData = {
+  mainBanner: mainBannerFallback,
+};
+
+export function parseMainBannerDocument(
+  data: Record<string, unknown>,
+): MainBannerData {
+  const title = typeof data.title === "string" ? data.title.trim() : "";
+  const description =
+    typeof data.description === "string" ? data.description.trim() : "";
+
+  if (!title || !description) {
+    throw new Error("Missing 'title' or 'description' in main_page/main_banner");
+  }
+
+  return { title, description };
+}

--- a/app/home/lib/main-page.firestore.ts
+++ b/app/home/lib/main-page.firestore.ts
@@ -1,0 +1,97 @@
+import { db } from "@/firebase";
+import { doc, onSnapshot } from "firebase/firestore";
+
+import {
+  homePageFallback,
+  parseMainBannerDocument,
+  type HomePageData,
+} from "@/app/home/lib/home-page-data";
+
+export const MAIN_PAGE_COLLECTION = "main_page";
+
+export const MAIN_PAGE_DOC_IDS = {
+  mainBanner: "main_banner",
+} as const;
+
+type HomePagePanelKey = keyof typeof MAIN_PAGE_DOC_IDS;
+
+function reportPanelError(
+  panel: HomePagePanelKey,
+  error: Error,
+  onError?: (panel: HomePagePanelKey, error: Error) => void,
+) {
+  onError?.(panel, error);
+  console.warn(
+    `[home-panels] Firestore realtime read failed for "${panel}"; using local fallback.`,
+    error,
+  );
+}
+
+function subscribeMainPageDocument<T>(
+  docId: string,
+  parse: (data: Record<string, unknown>) => T,
+  onData: (value: T) => void,
+  onPanelError: (error: Error) => void,
+) {
+  const docRef = doc(db, MAIN_PAGE_COLLECTION, docId);
+
+  return onSnapshot(
+    docRef,
+    (snap) => {
+      try {
+        if (!snap.exists()) {
+          throw new Error(`Missing Firestore document: ${MAIN_PAGE_COLLECTION}/${docId}`);
+        }
+
+        const raw = snap.data() as Record<string, unknown> | undefined;
+        if (!raw) {
+          throw new Error(`Empty document: ${MAIN_PAGE_COLLECTION}/${docId}`);
+        }
+
+        onData(parse(raw));
+      } catch (err) {
+        onPanelError(
+          err instanceof Error ? err : new Error("Unknown snapshot parsing error"),
+        );
+      }
+    },
+    (firestoreError) => {
+      onPanelError(
+        firestoreError instanceof Error
+          ? firestoreError
+          : new Error("Firestore subscription failed"),
+      );
+    },
+  );
+}
+
+/**
+ * Subscribes to all home-page panel documents under `main_page/*`.
+ * Only `main_banner` is wired today; add more panels here as they are seeded.
+ */
+export function subscribeHomePageData(
+  onData: (data: HomePageData) => void,
+  onError?: (panel: HomePagePanelKey, error: Error) => void,
+) {
+  let latest = { ...homePageFallback };
+
+  const publish = () => {
+    onData(latest);
+  };
+
+  const unsubscribeMainBanner = subscribeMainPageDocument(
+    MAIN_PAGE_DOC_IDS.mainBanner,
+    parseMainBannerDocument,
+    (mainBanner) => {
+      latest = { ...latest, mainBanner };
+      publish();
+    },
+    (error) => reportPanelError("mainBanner", error, onError),
+  );
+
+  publish();
+
+  return () => {
+    unsubscribeMainBanner();
+  };
+}

--- a/app/home/main-banner.tsx
+++ b/app/home/main-banner.tsx
@@ -8,8 +8,10 @@ import gsap from "gsap";
 import ParticlePortrait from "@/components/ParticlePortrait/ParticlePortrait";
 import styles from "./main-banner.module.scss";
 import AntonioBannerPhoto from "./images/AntonioBannerPhoto.png";
-import Typewriter from 'typewriter-effect';
+import Typewriter from "typewriter-effect";
 import { backgroundFloatImages } from "./background-float-images";
+import { mainBannerFallback } from "./data/main-banner-data";
+import { subscribeMainBanner } from "./main-banner.firestore";
 
 function TypewriterComponent() {
   return (
@@ -44,7 +46,23 @@ function MainBanner() {
   const [typewriterKey, setTypewriterKey] = useState(() => 0);
   const prevPathRef = useRef<string | null>(null);
   const [floaters, setFloaters] = useState<FloaterConfig[]>([]);
+  const [banner, setBanner] = useState(mainBannerFallback);
 
+  useEffect(() => {
+    const unsubscribe = subscribeMainBanner(
+      (bannerFromDb) => {
+        setBanner(bannerFromDb);
+      },
+      (error) => {
+        console.warn(
+          "[main-banner] Firestore realtime read failed; using local fallback data.",
+          error,
+        );
+      },
+    );
+
+    return unsubscribe;
+  }, []);
 
   useLayoutEffect(() => {
     if (pathname === "/" && prevPathRef.current !== null && prevPathRef.current !== "/") {
@@ -153,15 +171,9 @@ function MainBanner() {
           <TypewriterComponent key={`hero-${typewriterKey}`} />
         </h1>
 
-        <h2 className={styles.backgroundText}>
-          UX Engineer · Full-stack applications · AI-powered products
-        </h2>
+        <h2 className={styles.backgroundText}>{banner.title}</h2>
 
-        <p className={styles.description}>
-          I ship modern web applications and AI-powered experiences—from
-          discovery to production—using human-centered design and design
-          thinking. I focus on clarity, performance, and impact.
-        </p>
+        <p className={styles.description}>{banner.description}</p>
 
         {/* LinkedIn button – last row in the text block */}
         <div className={styles.linkedinWrapper}>

--- a/app/home/main-banner.tsx
+++ b/app/home/main-banner.tsx
@@ -10,8 +10,7 @@ import styles from "./main-banner.module.scss";
 import AntonioBannerPhoto from "./images/AntonioBannerPhoto.png";
 import Typewriter from "typewriter-effect";
 import { backgroundFloatImages } from "./background-float-images";
-import { mainBannerFallback } from "./data/main-banner-data";
-import { subscribeMainBanner } from "./main-banner.firestore";
+import type { MainBannerData } from "./data/main-banner-data";
 
 function TypewriterComponent() {
   return (
@@ -39,30 +38,17 @@ type FloaterConfig = {
 
 const FLOAT_COUNT = 14;
 
-function MainBanner() {
+type MainBannerProps = {
+  banner: MainBannerData;
+};
+
+function MainBanner({ banner }: MainBannerProps) {
   const textRef = useRef<HTMLDivElement | null>(null);
   const photoRef = useRef<HTMLDivElement | null>(null);
   const pathname = usePathname();
   const [typewriterKey, setTypewriterKey] = useState(() => 0);
   const prevPathRef = useRef<string | null>(null);
   const [floaters, setFloaters] = useState<FloaterConfig[]>([]);
-  const [banner, setBanner] = useState(mainBannerFallback);
-
-  useEffect(() => {
-    const unsubscribe = subscribeMainBanner(
-      (bannerFromDb) => {
-        setBanner(bannerFromDb);
-      },
-      (error) => {
-        console.warn(
-          "[main-banner] Firestore realtime read failed; using local fallback data.",
-          error,
-        );
-      },
-    );
-
-    return unsubscribe;
-  }, []);
 
   useLayoutEffect(() => {
     if (pathname === "/" && prevPathRef.current !== null && prevPathRef.current !== "/") {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "eslint",
     "seed:project-1": "tsx scripts/seed-project-1.ts",
-    "seed:automatic-seater": "tsx scripts/seed-automatic-seater-assignments.ts"
+    "seed:automatic-seater": "tsx scripts/seed-automatic-seater-assignments.ts",
+    "seed:main-banner": "tsx scripts/seed-main-banner.ts"
   },
   "dependencies": {
     "@emailjs/browser": "^4.4.1",


### PR DESCRIPTION
### Summary

- Seeds the main banner copy into Firestore at main_page/main_banner (title, description).
- Adds a shared home-page data layer so landing panels can load from Firestore with local fallbacks.
- Wires MainBanner as the first panel through this flow; fetches run in home-panels.tsx and data is passed down as props.

**Changes**

- scripts/seed-main-banner.ts + npm run seed:main-banner — upserts banner copy to main_page/main_banner.
- app/home/data/main-banner-data.ts — local fallback data and MainBannerData type.
- app/home/lib/home-page-data.ts — aggregated HomePageData interface and Firestore parser for the banner.
- app/home/lib/main-page.firestore.ts — generic main_page/{docId} subscription and subscribeHomePageData() aggregator.
- app/home/home-panels.tsx — owns Firestore state and passes banner into MainBanner.
- app/home/main-banner.tsx — presentational only; renders props instead of fetching directly.

**Behavior**

- On load, fallback copy renders immediately (no empty state).
- When Firestore connects, the banner updates from main_page/main_banner.
- If a read fails, the UI keeps the fallback and logs a warning.