### PR TITLE
implemnented dialog to display recognition certificate

### DIFF
--- a/app/projects/finding-nemo/components/ProjectHeader.tsx
+++ b/app/projects/finding-nemo/components/ProjectHeader.tsx
@@ -1,8 +1,13 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Box, Stack, Typography } from "@mui/material";
 import type { SxProps, Theme } from "@mui/material/styles";
+
+import RecognitionDialog, {
+  recognitionAwardButtonSx,
+  recognitionLinkSx,
+} from "@/app/projects/finding-nemo/components/RecognitionDialog";
 
 import {
   HEADER_BAND_COLOR,
@@ -138,11 +143,35 @@ const HEADER_FONT_SIZE = {
 } as const;
 
 export default function ProjectHeader({ data, onReady }: ProjectHeaderProps) {
+  const [recognitionOpen, setRecognitionOpen] = useState(false);
+
   useEffect(() => {
     onReady?.();
   }, [onReady]);
 
-  const { boundingBoxesOverlay } = data;
+  const { boundingBoxesOverlay, recognition } = data;
+
+  const { awardHeadlineLines, viewRecognitionLine } = useMemo(() => {
+    const headline: string[] = [];
+    let viewLine: string | undefined;
+
+    for (const line of data.awardLines) {
+      if (/view recognition/i.test(line)) {
+        viewLine = line;
+      } else {
+        headline.push(line);
+      }
+    }
+
+    return {
+      awardHeadlineLines: headline,
+      viewRecognitionLine: viewLine,
+    };
+  }, [data.awardLines]);
+
+  const recognitionDialogTitle = `🏆 ${awardHeadlineLines.join(" ")}`;
+  const openRecognition = () => setRecognitionOpen(true);
+  const closeRecognition = () => setRecognitionOpen(false);
 
   return (
     <Box
@@ -233,34 +262,99 @@ export default function ProjectHeader({ data, onReady }: ProjectHeaderProps) {
             ))}
           </Stack>
           <Stack spacing={0.25} alignItems="center" sx={{ pt: 1 }}>
-            <Typography
-              component="p"
-              sx={{
-                color: "#02305d",
-                fontSize: HEADER_FONT_SIZE.award,
-                lineHeight: 1.2,
-                fontWeight: 500,
-              }}
-            >
-              <Box component="span" sx={{ fontWeight: 700, mr: 0.5 }}>
-                🏆
-              </Box>
-              {data.awardLines[0]}
-            </Typography>
-            {data.awardLines.slice(1).map((line) => (
-              <Typography
-                key={line}
-                component="p"
-                sx={{
-                  color: "#02305d",
-                  fontSize: HEADER_FONT_SIZE.award,
-                  lineHeight: 1.2,
-                  fontWeight: 500,
-                }}
-              >
-                {line}
-              </Typography>
-            ))}
+            {recognition ? (
+              <>
+                <Box
+                  component="button"
+                  type="button"
+                  onClick={openRecognition}
+                  aria-label="View datathon recognition details"
+                  sx={{
+                    ...recognitionAwardButtonSx,
+                    display: "inline-flex",
+                    flexDirection: "column",
+                    alignItems: "center",
+                    gap: 0.25,
+                  }}
+                >
+                  <Typography
+                    component="span"
+                    sx={{
+                      color: "inherit",
+                      fontSize: HEADER_FONT_SIZE.award,
+                      lineHeight: 1.2,
+                      fontWeight: 500,
+                    }}
+                  >
+                    <Box component="span" sx={{ fontWeight: 700, mr: 0.5 }}>
+                      🏆
+                    </Box>
+                    {awardHeadlineLines[0]}
+                  </Typography>
+                  {awardHeadlineLines.slice(1).map((line) => (
+                    <Typography
+                      key={line}
+                      component="span"
+                      sx={{
+                        color: "inherit",
+                        fontSize: HEADER_FONT_SIZE.award,
+                        lineHeight: 1.2,
+                        fontWeight: 500,
+                      }}
+                    >
+                      {line}
+                    </Typography>
+                  ))}
+                </Box>
+                {viewRecognitionLine ? (
+                  <Box
+                    component="button"
+                    type="button"
+                    onClick={openRecognition}
+                    aria-label="View recognition"
+                    sx={{
+                      ...recognitionLinkSx,
+                      fontSize: HEADER_FONT_SIZE.award,
+                      lineHeight: 1.2,
+                      fontWeight: 500,
+                    }}
+                  >
+                    {viewRecognitionLine}
+                  </Box>
+                ) : null}
+              </>
+            ) : (
+              <>
+                <Typography
+                  component="p"
+                  sx={{
+                    color: "#02305d",
+                    fontSize: HEADER_FONT_SIZE.award,
+                    lineHeight: 1.2,
+                    fontWeight: 500,
+                  }}
+                >
+                  <Box component="span" sx={{ fontWeight: 700, mr: 0.5 }}>
+                    🏆
+                  </Box>
+                  {data.awardLines[0]}
+                </Typography>
+                {data.awardLines.slice(1).map((line) => (
+                  <Typography
+                    key={line}
+                    component="p"
+                    sx={{
+                      color: "#02305d",
+                      fontSize: HEADER_FONT_SIZE.award,
+                      lineHeight: 1.2,
+                      fontWeight: 500,
+                    }}
+                  >
+                    {line}
+                  </Typography>
+                ))}
+              </>
+            )}
           </Stack>
         </Stack>
         <Box sx={sceneStageShellSx()}>
@@ -333,6 +427,14 @@ export default function ProjectHeader({ data, onReady }: ProjectHeaderProps) {
           </Box>
         </Box>
       </Stack>
+      {recognition ? (
+        <RecognitionDialog
+          open={recognitionOpen}
+          onClose={closeRecognition}
+          title={recognitionDialogTitle}
+          data={recognition}
+        />
+      ) : null}
     </Box>
   );
 }

--- a/app/projects/finding-nemo/components/RecognitionDialog.tsx
+++ b/app/projects/finding-nemo/components/RecognitionDialog.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import CloseIcon from "@mui/icons-material/Close";
+import {
+  Box,
+  Dialog,
+  DialogContent,
+  IconButton,
+  List,
+  ListItem,
+  ListItemText,
+  Stack,
+  Typography,
+} from "@mui/material";
+
+import type { FindingNemoDataProjectDocument } from "@/scripts/project-2.data";
+import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
+import ProjectImageLightbox from "@/lib/media/ProjectImageLightbox";
+
+const RECOGNITION_CERTIFICATE_LIGHTBOX_ID = "finding-nemo-recognition-certificate";
+
+export type RecognitionDialogProps = {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  data: NonNullable<FindingNemoDataProjectDocument["projectHeader"]["recognition"]>;
+};
+
+const recognitionLinkSx = {
+  color: "#02305d",
+  cursor: "pointer",
+  border: "none",
+  background: "none",
+  padding: 0,
+  font: "inherit",
+  textAlign: "inherit",
+  "&:hover": {
+    textDecoration: "underline",
+    textUnderlineOffset: "3px",
+  },
+  "&:focus-visible": {
+    outline: "2px solid #02305d",
+    outlineOffset: 3,
+    borderRadius: "4px",
+  },
+} as const;
+
+const recognitionAwardButtonSx = {
+  ...recognitionLinkSx,
+  "&:hover": {
+    opacity: 0.82,
+    textDecoration: "none",
+  },
+} as const;
+
+export { recognitionAwardButtonSx, recognitionLinkSx };
+
+const recognitionSectionTitleFontSx = {
+  fontWeight: 700,
+  fontSize: "20px",
+  lineHeight: 1.3,
+  [breakpointMediaQuery.tabletUp]: {
+    fontSize: "22px",
+  },
+  [breakpointMediaQuery.desktopUp]: {
+    fontSize: "24px",
+  },
+} as const;
+
+export default function RecognitionDialog({
+  open,
+  onClose,
+  title,
+  data,
+}: RecognitionDialogProps) {
+  const { dialogDescription, certificateImage, teamMembers } = data;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth={false}
+      scroll="paper"
+      aria-labelledby="finding-nemo-recognition-dialog-title"
+      slotProps={{
+        paper: {
+          elevation: 0,
+          sx: {
+            width: "100%",
+            maxWidth: 720,
+            borderRadius: "24px",
+            backgroundColor: "#edf3f8",
+            margin: 2,
+            display: "flex",
+            flexDirection: "column",
+            overflow: "hidden",
+          },
+        },
+      }}
+    >
+      <Box
+        component="header"
+        sx={{
+          flexShrink: 0,
+          px: { xs: 3, md: 5 },
+          pt: { xs: 3, md: 4 },
+          pb: 2,
+        }}
+      >
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: "37px 1fr 37px",
+            alignItems: "start",
+            columnGap: 1,
+            width: "100%",
+          }}
+        >
+          <Box aria-hidden />
+          <Typography
+            id="finding-nemo-recognition-dialog-title"
+            component="h2"
+            sx={{
+              width: "100%",
+              textAlign: "center",
+              color: "#02305d",
+              mx: "auto",
+              ...recognitionSectionTitleFontSx,
+            }}
+          >
+            {title}
+          </Typography>
+          <IconButton
+            aria-label="Close recognition dialog"
+            onClick={onClose}
+            size="small"
+            sx={{
+              width: 37,
+              height: 37,
+              justifySelf: "end",
+              backgroundColor: "#E8E8EC",
+              color: "#6E6E73",
+              "&:hover": {
+                backgroundColor: "#E0E0E5",
+              },
+            }}
+          >
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        </Box>
+      </Box>
+      <DialogContent
+        sx={{
+          px: { xs: 3, md: 5 },
+          pt: 3,
+          pb: { xs: 4, md: 5 },
+          backgroundColor: "#edf3f8",
+        }}
+      >
+        <Stack spacing={4.5} alignItems="center">
+          <Stack spacing={1.5} alignItems="center" width="100%">
+            <Box
+              sx={{
+                width: "100%",
+                maxWidth: 420,
+              }}
+            >
+              <ProjectImageLightbox
+                objectPath={certificateImage.objectPath}
+                alt={certificateImage.alt}
+                lightboxId={RECOGNITION_CERTIFICATE_LIGHTBOX_ID}
+                width={certificateImage.width}
+                height={certificateImage.height}
+                style={{
+                  display: "block",
+                  width: "100%",
+                  height: "auto",
+                }}
+              />
+            </Box>
+            <Typography
+              component="p"
+              align="center"
+              sx={{
+                color: "text.primary",
+                fontSize: { xs: "1rem", md: "1.125rem" },
+                lineHeight: 1.5,
+                maxWidth: 560,
+              }}
+            >
+              {dialogDescription}
+            </Typography>
+          </Stack>
+          <Stack spacing={1.5} alignItems="center">
+            <Typography
+              component="h3"
+              align="center"
+              sx={{
+                color: "text.primary",
+                width: "100%",
+                textAlign: "center",
+                ...recognitionSectionTitleFontSx,
+              }}
+            >
+              Datathon Team Members
+            </Typography>
+            <List dense disablePadding sx={{ listStyleType: "disc", pl: 3 }}>
+              {teamMembers.map((member) => (
+                <ListItem
+                  key={member}
+                  sx={{
+                    display: "list-item",
+                    py: 0,
+                    px: 0,
+                  }}
+                >
+                  <ListItemText
+                    primary={member}
+                    primaryTypographyProps={{
+                      sx: {
+                        color: "text.primary",
+                        fontSize: "1rem",
+                        fontWeight: 400,
+                        lineHeight: 1.4,
+                      },
+                    }}
+                  />
+                </ListItem>
+              ))}
+            </List>
+          </Stack>
+        </Stack>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
### Summary
Adds a Datathon recognition dialog to the Finding Nemo project header so visitors can view the award certificate and team details without leaving the case study.

**Recognition dialog (RecognitionDialog.tsx)**

- New MUI dialog with light blue panel styling (#edf3f8)
- Shows award title, certificate image, description copy, and Datathon team member list
- Click-to-zoom lightbox on the certificate via ProjectImageLightbox (same stack as other case study diagrams)
- Responsive section titles: 20px mobile, 22px tablet, 24px desktop (award title + “Datathon Team Members”)
- Award title stays visually centered using a balanced 3-column header grid (spacer | title | close button)

**Header integration (ProjectHeader.tsx)**

- Clicking the award lines (🏆 First Place Winner…) or “(View recognition)” opens the dialog
- Both triggers use accessible <button> elements with hover/focus styles
- Parses awardLines to separate headline copy from the “View recognition” link
- Graceful fallback: static award text when projectHeader.recognition is missing from Firestore

**Data**

- Dialog content is driven by projectHeader.recognition (certificate objectPath, description, teamMembers)
- Certificate image: projects/project_2/DatathonAward.png