### PR TITLE
implemented demo image carousel

### DIFF
--- a/app/projects/finding-nemo/FindingNemoPage.tsx
+++ b/app/projects/finding-nemo/FindingNemoPage.tsx
@@ -17,6 +17,7 @@ import FullBleedBand from "@/app/projects/finding-nemo/components/FullBleedBand"
 import MobileExperienceMockup from "@/app/projects/finding-nemo/components/MobileExperienceMockup";
 import MyContributions from "@/app/projects/finding-nemo/components/MyContributions";
 import Overview from "@/app/projects/finding-nemo/components/Overview";
+import ProblemDemoPanel from "@/app/projects/finding-nemo/components/ProbleDemoCarousel";
 import PanelSection from "@/app/projects/finding-nemo/components/PanelSection";
 import Persona from "@/app/projects/finding-nemo/components/Persona";
 import ProjectHeader from "@/app/projects/finding-nemo/components/ProjectHeader";
@@ -171,6 +172,9 @@ export function FindingNemoPage({
             onReady={onProjectHeaderReady}
           />
           <Overview data={project.overview} />
+          {project.problemDemoPanel ? (
+            <ProblemDemoPanel data={project.problemDemoPanel} />
+          ) : null}
           <MyContributions data={project.myContributions} />
           <FullBleedBand backgroundColor={BAND_COLORS.businessOpportunities}>
             <Stack spacing={{ xs: 4, md: 6 }}>

--- a/app/projects/finding-nemo/components/MyContributions.tsx
+++ b/app/projects/finding-nemo/components/MyContributions.tsx
@@ -8,7 +8,7 @@ import {
 } from "@mui/material";
 import type { SxProps, Theme } from "@mui/material/styles";
 
-import { LAYOUT_DIMENSIONS } from "@/app/projects/finding-nemo/layoutConfig";
+import { INTRO_SECTIONS_BACKGROUND, LAYOUT_DIMENSIONS } from "@/app/projects/finding-nemo/layoutConfig";
 import { bodyTypeSx, titleTypeSx } from "@/app/projects/finding-nemo/typography";
 import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
 import type { FindingNemoDataProjectDocument } from "@/scripts/project-2.data";
@@ -22,7 +22,7 @@ export default function MyContributions({ data }: MyContributionsProps) {
     <Box
       component="section"
       sx={{
-        bgcolor: "#f3f3f3",
+        bgcolor: INTRO_SECTIONS_BACKGROUND,
         py: { xs: 10, md: 12, lg: 16 },
         px: LAYOUT_DIMENSIONS.mobile.margin,
         [breakpointMediaQuery.tabletUp]: {

--- a/app/projects/finding-nemo/components/Overview.tsx
+++ b/app/projects/finding-nemo/components/Overview.tsx
@@ -1,6 +1,6 @@
 import { Box, Container, Typography } from "@mui/material";
 
-import { LAYOUT_DIMENSIONS } from "@/app/projects/finding-nemo/layoutConfig";
+import { INTRO_SECTIONS_BACKGROUND, LAYOUT_DIMENSIONS } from "@/app/projects/finding-nemo/layoutConfig";
 import { bodyTypeSx, titleTypeSx } from "@/app/projects/finding-nemo/typography";
 import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
 import type { FindingNemoDataProjectDocument } from "@/scripts/project-2.data";
@@ -14,7 +14,7 @@ export default function OverviewSection({ data }: OverviewSectionProps) {
     <Box
       component="section"
       sx={{
-        bgcolor: "#f3f3f3",
+        bgcolor: INTRO_SECTIONS_BACKGROUND,
         py: { xs: 8, md: 10, lg: 12 },
         px: LAYOUT_DIMENSIONS.mobile.margin,
         [breakpointMediaQuery.tabletUp]: {

--- a/app/projects/finding-nemo/components/ProbleDemoCarousel.tsx
+++ b/app/projects/finding-nemo/components/ProbleDemoCarousel.tsx
@@ -1,0 +1,297 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
+import { Box, Container, IconButton, Stack, Typography } from "@mui/material";
+
+import {
+  INTRO_SECTIONS_BACKGROUND,
+  LAYOUT_DIMENSIONS,
+  PANEL_CONTENT_MAX_WIDTH_PX,
+  PROBLEM_DEMO_CAROUSEL_IMAGE_DISPLAY,
+  PROBLEM_DEMO_PANEL_COPY_MIN_WIDTH_PX,
+  PROBLEM_DEMO_PANEL_COPY_WIDTH,
+  PROBLEM_DEMO_PANEL_GAP,
+  PROBLEM_DEMO_PANEL_SIDE_BY_SIDE_MIN_WIDTH_PX,
+  PROBLEM_DEMO_PANEL_TITLE_GAP,
+  PROBLEM_DEMO_CAROUSEL_CAPTION_FONT_SIZE,
+} from "@/app/projects/finding-nemo/layoutConfig";
+import { bodyTypeSx, FINDING_NEMO_BODY_FONT, titleTypeSx } from "@/app/projects/finding-nemo/typography";
+import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
+import ProjectImage from "@/lib/media/ProjectImage";
+import type { FindingNemoDataProjectDocument } from "@/scripts/project-2.data";
+
+type ProblemDemoPanelProps = {
+  data: NonNullable<FindingNemoDataProjectDocument["problemDemoPanel"]>;
+};
+
+const { desktop, tablet, mobile } = PROBLEM_DEMO_CAROUSEL_IMAGE_DISPLAY;
+const copyWidth = PROBLEM_DEMO_PANEL_COPY_WIDTH;
+const panelGap = PROBLEM_DEMO_PANEL_GAP;
+const captionFontSize = PROBLEM_DEMO_CAROUSEL_CAPTION_FONT_SIZE;
+
+const carouselCaptionSx = {
+  fontFamily: FINDING_NEMO_BODY_FONT,
+  color: "#000",
+  fontSize: captionFontSize.mobile,
+  lineHeight: 1.3,
+  fontWeight: 400,
+  textAlign: "center",
+  flex: { xs: "1 1 auto", md: "0 1 auto" },
+  px: 1,
+  [breakpointMediaQuery.tabletUp]: {
+    fontSize: captionFontSize.tablet,
+  },
+  [breakpointMediaQuery.desktopUp]: {
+    fontSize: captionFontSize.desktop,
+  },
+} as const;
+
+const sectionContentStackSx = {
+  width: "100%",
+  alignItems: "center",
+  gap: PROBLEM_DEMO_PANEL_TITLE_GAP.mobile,
+  [breakpointMediaQuery.tabletUp]: {
+    gap: PROBLEM_DEMO_PANEL_TITLE_GAP.tablet,
+  },
+  [breakpointMediaQuery.desktopUp]: {
+    gap: PROBLEM_DEMO_PANEL_TITLE_GAP.desktop,
+  },
+} as const;
+
+const problemDemoPanelSideBySideMq = `@media (min-width: ${PROBLEM_DEMO_PANEL_SIDE_BY_SIDE_MIN_WIDTH_PX}px)`;
+
+/** Stacked below 1260px — copy width matches carousel; side-by-side uses fixed copy column. */
+const copyColumnSx = {
+  width: "100%",
+  maxWidth: mobile.width,
+  flexShrink: 0,
+  [breakpointMediaQuery.tabletUp]: {
+    maxWidth: tablet.width,
+  },
+  [problemDemoPanelSideBySideMq]: {
+    width: copyWidth.desktop,
+    maxWidth: copyWidth.desktop,
+    minWidth: PROBLEM_DEMO_PANEL_COPY_MIN_WIDTH_PX,
+    flexShrink: 0,
+  },
+} as const;
+
+const panelRowSx = {
+  flexDirection: "column",
+  alignItems: "center",
+  justifyContent: "space-between",
+  gap: `${panelGap.stacked}px`,
+  [problemDemoPanelSideBySideMq]: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: `${panelGap.sideBySide}px`,
+  },
+} as const;
+
+const carouselImageSizes = [
+  `(max-width: 767px) ${mobile.width}px`,
+  `(max-width: 1023px) ${tablet.width}px`,
+  `${desktop.width}px`,
+].join(", ");
+
+/** Fixed frame per breakpoint — steps down at tablet / mobile, no fluid scaling between bands. */
+const carouselFrameSx = {
+  position: "relative",
+  width: mobile.width,
+  height: mobile.height,
+  maxWidth: "100%",
+  overflow: "hidden",
+  borderRadius: 5,
+  flexShrink: 0,
+  [breakpointMediaQuery.tabletUp]: {
+    width: tablet.width,
+    height: tablet.height,
+    maxWidth: tablet.width,
+  },
+  [breakpointMediaQuery.desktopUp]: {
+    width: desktop.width,
+    height: desktop.height,
+    maxWidth: desktop.width,
+  },
+} as const;
+
+const carouselColumnSx = {
+  flexShrink: 0,
+  width: mobile.width,
+  maxWidth: "100%",
+  alignItems: "stretch",
+  [breakpointMediaQuery.tabletUp]: {
+    width: tablet.width,
+    maxWidth: tablet.width,
+  },
+  [breakpointMediaQuery.desktopUp]: {
+    width: desktop.width,
+    maxWidth: desktop.width,
+  },
+} as const;
+
+const navigationButtons = [
+  {
+    key: "previous",
+    label: "Previous demo image",
+    icon: <ArrowBackIcon fontSize="small" />,
+  },
+  {
+    key: "next",
+    label: "Next demo image",
+    icon: <ArrowForwardIcon fontSize="small" />,
+  },
+] as const;
+
+export default function ProblemDemoPanel({ data }: ProblemDemoPanelProps) {
+  const { sectionTitle, description, slides } = data;
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const canNavigate = slides.length > 1;
+  const currentSlide = slides[currentIndex];
+
+  const goToPrevious = useCallback(() => {
+    if (!canNavigate) return;
+    setCurrentIndex((index) => (index - 1 + slides.length) % slides.length);
+  }, [canNavigate, slides.length]);
+
+  const goToNext = useCallback(() => {
+    if (!canNavigate) return;
+    setCurrentIndex((index) => (index + 1) % slides.length);
+  }, [canNavigate, slides.length]);
+
+  if (!currentSlide) {
+    return null;
+  }
+
+  return (
+    <Box
+      component="section"
+      sx={{
+        bgcolor: INTRO_SECTIONS_BACKGROUND,
+        px: LAYOUT_DIMENSIONS.mobile.margin,
+        pb: { xs: 8, md: 10, lg: 12 },
+        [breakpointMediaQuery.tabletUp]: {
+          px: LAYOUT_DIMENSIONS.tablet.margin,
+        },
+        [breakpointMediaQuery.desktopUp]: {
+          px: LAYOUT_DIMENSIONS.desktop.margin,
+        },
+      }}
+    >
+      <Container
+        maxWidth={false}
+        sx={{
+          maxWidth: {
+            xs: LAYOUT_DIMENSIONS.mobile.maxWidth,
+            md: LAYOUT_DIMENSIONS.tablet.maxWidth,
+            lg: LAYOUT_DIMENSIONS.desktop.maxWidth,
+          },
+        }}
+      >
+        <Stack sx={sectionContentStackSx}>
+          <Typography
+            component="h2"
+            align="center"
+            sx={titleTypeSx("sectionTitle", {
+              width: "100%",
+              color: "text.primary",
+              fontWeight: 700,
+              lineHeight: 1.2,
+              m: 0,
+            })}
+          >
+            {sectionTitle}
+          </Typography>
+          <Box
+            sx={{
+              width: "100%",
+              maxWidth: PANEL_CONTENT_MAX_WIDTH_PX,
+              mx: "auto",
+              bgcolor: "#f6faff",
+              borderRadius: 5,
+              px: { xs: 3, sm: 5, md: 8 },
+              py: { xs: 4, sm: 5, md: 8 },
+            }}
+          >
+            <Stack sx={panelRowSx}>
+              <Box component="article" sx={copyColumnSx}>
+                <Typography
+                  component="p"
+                  sx={bodyTypeSx("bodyText", {
+                    color: "common.black",
+                    fontSize: { xs: 20, md: 22 },
+                    lineHeight: 1.35,
+                    fontWeight: 400,
+                    m: 0,
+                  })}
+                >
+                  {description}
+                </Typography>
+              </Box>
+              <Stack spacing={3} sx={carouselColumnSx}>
+                <Box component="figure" sx={{ m: 0, width: "100%" }}>
+                  <Box sx={carouselFrameSx}>
+                    <ProjectImage
+                      objectPath={currentSlide.objectPath}
+                      alt={currentSlide.alt}
+                      width={desktop.width}
+                      height={desktop.height}
+                      sizes={carouselImageSizes}
+                      priority={currentIndex === 0}
+                      style={{
+                        display: "block",
+                        width: "100%",
+                        height: "100%",
+                        objectFit: "cover",
+                      }}
+                    />
+                  </Box>
+                </Box>
+                <Stack
+                  direction="row"
+                  alignItems="center"
+                  justifyContent="space-between"
+                  spacing={2}
+                  component="figcaption"
+                >
+                  <Box sx={{ flex: 1, minWidth: 0 }} aria-hidden />
+                  <Typography component="span" sx={carouselCaptionSx}>
+                    {currentSlide.caption}
+                  </Typography>
+                  <Stack
+                    direction="row"
+                    spacing={0.5}
+                    sx={{ flex: 1, minWidth: 0 }}
+                    justifyContent="flex-end"
+                  >
+                    {navigationButtons.map((button) => (
+                      <IconButton
+                        key={button.key}
+                        aria-label={button.label}
+                        disabled={!canNavigate}
+                        onClick={
+                          button.key === "previous" ? goToPrevious : goToNext
+                        }
+                        size="small"
+                        sx={{
+                          color: "#8a8a8a",
+                          "&.Mui-disabled": {
+                            color: "rgba(138, 138, 138, 0.35)",
+                          },
+                        }}
+                      >
+                        {button.icon}
+                      </IconButton>
+                    ))}
+                  </Stack>
+                </Stack>
+              </Stack>
+            </Stack>
+          </Box>
+        </Stack>
+      </Container>
+    </Box>
+  );
+}

--- a/app/projects/finding-nemo/components/ProbleDemoCarousel.tsx
+++ b/app/projects/finding-nemo/components/ProbleDemoCarousel.tsx
@@ -10,6 +10,7 @@ import {
   LAYOUT_DIMENSIONS,
   PANEL_CONTENT_MAX_WIDTH_PX,
   PROBLEM_DEMO_CAROUSEL_IMAGE_DISPLAY,
+  PROBLEM_DEMO_PANEL_BACKGROUND,
   PROBLEM_DEMO_PANEL_COPY_MIN_WIDTH_PX,
   PROBLEM_DEMO_PANEL_COPY_WIDTH,
   PROBLEM_DEMO_PANEL_GAP,
@@ -36,7 +37,7 @@ const carouselCaptionSx = {
   color: "#000",
   fontSize: captionFontSize.mobile,
   lineHeight: 1.3,
-  fontWeight: 400,
+  fontWeight: 600,
   textAlign: "center",
   flex: { xs: "1 1 auto", md: "0 1 auto" },
   px: 1,
@@ -209,7 +210,7 @@ export default function ProblemDemoPanel({ data }: ProblemDemoPanelProps) {
               width: "100%",
               maxWidth: PANEL_CONTENT_MAX_WIDTH_PX,
               mx: "auto",
-              bgcolor: "#f6faff",
+              bgcolor: PROBLEM_DEMO_PANEL_BACKGROUND,
               borderRadius: 5,
               px: { xs: 3, sm: 5, md: 8 },
               py: { xs: 4, sm: 5, md: 8 },
@@ -219,10 +220,9 @@ export default function ProblemDemoPanel({ data }: ProblemDemoPanelProps) {
               <Box component="article" sx={copyColumnSx}>
                 <Typography
                   component="p"
-                  sx={bodyTypeSx("bodyText", {
+                  sx={bodyTypeSx("sectionDescription", {
                     color: "common.black",
-                    fontSize: { xs: 20, md: 22 },
-                    lineHeight: 1.35,
+                    lineHeight: 1.5,
                     fontWeight: 400,
                     m: 0,
                   })}

--- a/app/projects/finding-nemo/layoutConfig.ts
+++ b/app/projects/finding-nemo/layoutConfig.ts
@@ -27,6 +27,9 @@ export const LAYOUT_DIMENSIONS = {
   desktop: { maxWidth: "1260px", margin: "80px" },
 } as const;
 
+/** Desktop usable content width (`1260 − 2 × 80`) — shared inset panel cap. */
+export const PANEL_CONTENT_MAX_WIDTH_PX = 1100 as const;
+
 /**
  * Padding for inset panel blocks (rounded grey sections, narrative panels, etc.).
  * Vertical values use the case study breakpoints (`variables.scss`): mobile (<768px),
@@ -75,9 +78,15 @@ export const PROJECT_HEADER_EXTRA_TOP_PADDING = {
 export const BAND_COLORS = {
   /** #DEE8F3 @ 80% opacity */
   businessOpportunities: "rgba(222, 232, 243, 0.5)",
-  /** #F3F3F3 — neutral panel (matches Overview / My Contributions) */
+  /** White inset / neutral full-bleed bands */
   neutralPanel: "#FFFFFF",
 } as const;
+
+/**
+ * Background for introductory full-width sections: Overview, problem demo panel,
+ * and My Contributions (above the first alternating full-bleed bands).
+ */
+export const INTRO_SECTIONS_BACKGROUND = "#ffffff" as const;
 
 /** Inset panel shell backgrounds (white panels inside full-bleed bands). */
 export const PANEL_COLORS = {
@@ -101,6 +110,55 @@ export const PANEL_SHELL_SX = {
 export const FULL_BLEED_BAND_PADDINGS = {
   y: SECTION_GAPS,
 } as const;
+
+/**
+ * Problem demo carousel frame (524:330 aspect ratio).
+ * Desktop matches Figma; tablet ~90%, mobile ~75%.
+ */
+export const PROBLEM_DEMO_CAROUSEL_IMAGE_DISPLAY = {
+  mobile: { width: 393, height: 248 },
+  tablet: { width: 472, height: 297 },
+  desktop: { width: 524, height: 330 },
+} as const;
+
+/** Problem demo panel — copy column width when side-by-side at desktop (1260px+). */
+export const PROBLEM_DEMO_PANEL_COPY_WIDTH = {
+  desktop: 360,
+} as const;
+
+/** Gap between copy and carousel — stacked (vertical) vs side-by-side (horizontal at 1260px+). */
+export const PROBLEM_DEMO_PANEL_GAP = {
+  stacked: 64,
+  sideBySide: 80,
+} as const;
+
+/**
+ * Gap between section title and inset panel (smaller than `SECTION_GAPS`, which
+ * separates major page sections). Aligns with Overview title spacing (~32–48px).
+ */
+export const PROBLEM_DEMO_PANEL_TITLE_GAP = {
+  mobile: "32px",
+  tablet: "40px",
+  desktop: "48px",
+} as const;
+
+/**
+ * Carousel slide caption (e.g. "Walking on Blue") — desktop 18px; tablet ~90%, mobile ~78%.
+ */
+export const PROBLEM_DEMO_CAROUSEL_CAPTION_FONT_SIZE = {
+  mobile: "14px",
+  tablet: "16px",
+  desktop: "18px",
+} as const;
+
+/**
+ * Side-by-side copy + carousel only at this viewport width and above
+ * (matches `LAYOUT_DIMENSIONS.desktop.maxWidth`).
+ */
+export const PROBLEM_DEMO_PANEL_SIDE_BY_SIDE_MIN_WIDTH_PX = 1260 as const;
+
+/** Copy column minimum width when side-by-side at the desktop band. */
+export const PROBLEM_DEMO_PANEL_COPY_MIN_WIDTH_PX = 321 as const;
 
 /**
  * Solution overview diagram display size (maintains 211:430 aspect ratio).
@@ -169,6 +227,7 @@ export type SectionGaps = typeof SECTION_GAPS;
 export type LayoutDimensions = typeof LAYOUT_DIMENSIONS;
 export type PanelBlockPaddings = typeof PANEL_BLOCK_PADDINGS;
 export type BandColors = typeof BAND_COLORS;
+export type IntroSectionsBackground = typeof INTRO_SECTIONS_BACKGROUND;
 export type PanelColors = typeof PANEL_COLORS;
 export type FullBleedBandPaddings = typeof FULL_BLEED_BAND_PADDINGS;
 export type SolutionOverviewImageDisplay = typeof SOLUTION_OVERVIEW_IMAGE_DISPLAY;
@@ -176,3 +235,10 @@ export type SystemWorkflowIllustrationDisplay =
   typeof SYSTEM_WORKFLOW_ILLUSTRATION_DISPLAY;
 export type ConceptualMvpArchitectureIllustrationDisplay =
   typeof CONCEPTUAL_MVP_ARCHITECTURE_ILLUSTRATION_DISPLAY;
+export type ProblemDemoCarouselImageDisplay =
+  typeof PROBLEM_DEMO_CAROUSEL_IMAGE_DISPLAY;
+export type ProblemDemoPanelCopyWidth = typeof PROBLEM_DEMO_PANEL_COPY_WIDTH;
+export type ProblemDemoPanelGap = typeof PROBLEM_DEMO_PANEL_GAP;
+export type ProblemDemoPanelTitleGap = typeof PROBLEM_DEMO_PANEL_TITLE_GAP;
+export type ProblemDemoCarouselCaptionFontSize =
+  typeof PROBLEM_DEMO_CAROUSEL_CAPTION_FONT_SIZE;

--- a/app/projects/finding-nemo/layoutConfig.ts
+++ b/app/projects/finding-nemo/layoutConfig.ts
@@ -121,6 +121,9 @@ export const PROBLEM_DEMO_CAROUSEL_IMAGE_DISPLAY = {
   desktop: { width: 524, height: 330 },
 } as const;
 
+/** Inset panel background for the problem demo carousel section. */
+export const PROBLEM_DEMO_PANEL_BACKGROUND = "#E8F0F8" as const;
+
 /** Problem demo panel — copy column width when side-by-side at desktop (1260px+). */
 export const PROBLEM_DEMO_PANEL_COPY_WIDTH = {
   desktop: 360,


### PR DESCRIPTION
### Summary

A “The Problem” demo section between Overview and My Contributions, with a 6-image carousel driven by Firestore project data (project.problemDemoPanel).

**Layout:**

- Centered section title → inset panel (#f6faff, max 1100px) on a white section background
- ≥1260px: copy left (360px) + carousel right, 80px gap
- <1260px: stacked; copy width matches carousel; 64px vertical gap
- Carousel: fixed frame per breakpoint (object-fit: cover), prev/next nav, centered captions (Source Sans 3)