### PR TITLE
Finding nemo/feature/information hierachy improvements

### DIFF
--- a/app/projects/finding-nemo/FindingNemoPage.tsx
+++ b/app/projects/finding-nemo/FindingNemoPage.tsx
@@ -8,18 +8,19 @@ import ListItem from "@mui/material/ListItem";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 
-import ContentCard, {
+import {
   CHALLENGES_CARD_HEIGHT_PX,
   PRIMARY_USERS_CARD_HEIGHT_PX,
   PRIMARY_USERS_CARD_WIDTH_PX,
 } from "@/app/projects/finding-nemo/components/ContentCard";
+import ContentCardsRow from "@/app/projects/finding-nemo/components/ContentCardsRow";
 import FullBleedBand from "@/app/projects/finding-nemo/components/FullBleedBand";
 import MobileExperienceMockup from "@/app/projects/finding-nemo/components/MobileExperienceMockup";
 import MyContributions from "@/app/projects/finding-nemo/components/MyContributions";
 import Overview from "@/app/projects/finding-nemo/components/Overview";
 import ProblemDemoPanel from "@/app/projects/finding-nemo/components/ProbleDemoCarousel";
 import PanelSection from "@/app/projects/finding-nemo/components/PanelSection";
-import Persona from "@/app/projects/finding-nemo/components/Persona";
+import PersonasRow from "@/app/projects/finding-nemo/components/PersonasRow";
 import ProjectHeader from "@/app/projects/finding-nemo/components/ProjectHeader";
 import SectionParagraph from "@/app/projects/finding-nemo/components/SectionParagraph";
 import { bodyTypeSx, titleTypeSx } from "@/app/projects/finding-nemo/typography";
@@ -46,16 +47,6 @@ import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
 import ProjectImage from "@/lib/media/ProjectImage";
 import ProjectImageLightbox from "@/lib/media/ProjectImageLightbox";
 
-const challengeCardsRowSx = {
-  width: "100%",
-  display: "flex",
-  flexDirection: { xs: "column", md: "row" },
-  flexWrap: { xs: "nowrap", md: "wrap" },
-  justifyContent: "center",
-  alignItems: { xs: "center", md: "stretch" },
-  gap: { xs: 3, md: 3, lg: 4 },
-} as const;
-
 const solutionOverviewImageSizes = [
   `(max-width: 767px) ${SOLUTION_OVERVIEW_IMAGE_DISPLAY.mobile.width}px`,
   `(max-width: 1023px) ${SOLUTION_OVERVIEW_IMAGE_DISPLAY.tablet.width}px`,
@@ -71,16 +62,6 @@ const solutionOverviewImageBoxSx = {
   [breakpointMediaQuery.desktopUp]: {
     width: `${SOLUTION_OVERVIEW_IMAGE_DISPLAY.desktop.width}px`,
   },
-} as const;
-
-const personaCardsRowSx = {
-  width: "100%",
-  display: "flex",
-  flexDirection: { xs: "column", md: "row" },
-  flexWrap: { xs: "nowrap", md: "wrap" },
-  justifyContent: "center",
-  alignItems: { xs: "center", md: "stretch" },
-  gap: { xs: 3, md: 3, lg: 4 },
 } as const;
 
 const mobileExperienceMockupsRowSx = {
@@ -189,16 +170,13 @@ export function FindingNemoPage({
                 body={project.challenges.paragraphs}
                 titleVariant="subtitle"
               />
-              <Box sx={challengeCardsRowSx}>
-                {project.challenges.cards.map((card) => (
-                  <ContentCard
-                    key={card.title}
-                    title={card.title}
-                    description={card.description}
-                    heightPx={CHALLENGES_CARD_HEIGHT_PX}
-                  />
-                ))}
-              </Box>
+              <ContentCardsRow
+                cards={project.challenges.cards.map((card) => ({
+                  title: card.title,
+                  description: card.description,
+                  heightPx: CHALLENGES_CARD_HEIGHT_PX,
+                }))}
+              />
             </Stack>
             <Stack
               spacing={{ xs: 4, md: 6 }}
@@ -217,15 +195,12 @@ export function FindingNemoPage({
                 body={project.businessOpportunities.paragraphs}
                 titleVariant="subtitle"
               />
-              <Box sx={challengeCardsRowSx}>
-                {project.businessOpportunities.cards.map((card) => (
-                  <ContentCard
-                    key={card.title}
-                    title={card.title}
-                    description={card.description}
-                  />
-                ))}
-              </Box>
+              <ContentCardsRow
+                cards={project.businessOpportunities.cards.map((card) => ({
+                  title: card.title,
+                  description: card.description,
+                }))}
+              />
             </Stack>
           </FullBleedBand>
           <FullBleedBand backgroundColor={BAND_COLORS.neutralPanel}>
@@ -271,17 +246,14 @@ export function FindingNemoPage({
                 body={project.primaryUsers.paragraphs}
                 titleVariant="subtitle"
               />
-              <Box sx={challengeCardsRowSx}>
-                {project.primaryUsers.cards.map((card) => (
-                  <ContentCard
-                    key={card.title}
-                    title={card.title}
-                    description={card.description}
-                    widthPx={PRIMARY_USERS_CARD_WIDTH_PX}
-                    heightPx={PRIMARY_USERS_CARD_HEIGHT_PX}
-                  />
-                ))}
-              </Box>
+              <ContentCardsRow
+                cards={project.primaryUsers.cards.map((card) => ({
+                  title: card.title,
+                  description: card.description,
+                  widthPx: PRIMARY_USERS_CARD_WIDTH_PX,
+                  heightPx: PRIMARY_USERS_CARD_HEIGHT_PX,
+                }))}
+              />
             </Stack>
             <Stack
               spacing={{ xs: 4, md: 6 }}
@@ -300,11 +272,7 @@ export function FindingNemoPage({
                 body={project.personas.paragraphs}
                 titleVariant="subtitle"
               />
-              <Box sx={personaCardsRowSx}>
-                {project.personas.items.map((persona) => (
-                  <Persona key={persona.title} {...persona} />
-                ))}
-              </Box>
+              <PersonasRow personas={project.personas.items} />
             </Stack>
           </FullBleedBand>
           <FullBleedBand backgroundColor={BAND_COLORS.neutralPanel}>

--- a/app/projects/finding-nemo/FindingNemoPage.tsx
+++ b/app/projects/finding-nemo/FindingNemoPage.tsx
@@ -177,17 +177,25 @@ export function FindingNemoPage({
           ) : null}
           <MyContributions data={project.myContributions} />
           <FullBleedBand backgroundColor={BAND_COLORS.businessOpportunities}>
-            <Stack spacing={{ xs: 4, md: 6 }}>
+            <SectionParagraph title={project.problemSpaceFraming.title} />
+            <Stack
+              spacing={{ xs: 4, md: 6 }}
+              sx={{
+                mt: { xs: 3, md: 4.5 },
+              }}
+            >
               <SectionParagraph
-                title={project.businessOpportunities.title}
-                body={project.businessOpportunities.paragraphs}
+                title={project.challenges.title}
+                body={project.challenges.paragraphs}
+                titleVariant="subtitle"
               />
               <Box sx={challengeCardsRowSx}>
-                {project.businessOpportunities.cards.map((card) => (
+                {project.challenges.cards.map((card) => (
                   <ContentCard
                     key={card.title}
                     title={card.title}
                     description={card.description}
+                    heightPx={CHALLENGES_CARD_HEIGHT_PX}
                   />
                 ))}
               </Box>
@@ -205,16 +213,16 @@ export function FindingNemoPage({
               }}
             >
               <SectionParagraph
-                title={project.challenges.title}
-                body={project.challenges.paragraphs}
+                title={project.businessOpportunities.title}
+                body={project.businessOpportunities.paragraphs}
+                titleVariant="subtitle"
               />
               <Box sx={challengeCardsRowSx}>
-                {project.challenges.cards.map((card) => (
+                {project.businessOpportunities.cards.map((card) => (
                   <ContentCard
                     key={card.title}
                     title={card.title}
                     description={card.description}
-                    heightPx={CHALLENGES_CARD_HEIGHT_PX}
                   />
                 ))}
               </Box>
@@ -251,10 +259,17 @@ export function FindingNemoPage({
             </Stack>
           </FullBleedBand>
           <FullBleedBand backgroundColor={BAND_COLORS.businessOpportunities}>
-            <Stack spacing={{ xs: 4, md: 6 }}>
+            <SectionParagraph title={project.understandingTheUsers.title} />
+            <Stack
+              spacing={{ xs: 4, md: 6 }}
+              sx={{
+                mt: { xs: 3, md: 4.5 },
+              }}
+            >
               <SectionParagraph
                 title={project.primaryUsers.title}
                 body={project.primaryUsers.paragraphs}
+                titleVariant="subtitle"
               />
               <Box sx={challengeCardsRowSx}>
                 {project.primaryUsers.cards.map((card) => (
@@ -280,7 +295,11 @@ export function FindingNemoPage({
                 },
               }}
             >
-              <SectionParagraph title={project.personas.title} />
+              <SectionParagraph
+                title={project.personas.title}
+                body={project.personas.paragraphs}
+                titleVariant="subtitle"
+              />
               <Box sx={personaCardsRowSx}>
                 {project.personas.items.map((persona) => (
                   <Persona key={persona.title} {...persona} />

--- a/app/projects/finding-nemo/components/ContentCard.tsx
+++ b/app/projects/finding-nemo/components/ContentCard.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, List, ListItem, Typography } from "@mui/material";
 import type { SxProps, Theme } from "@mui/material/styles";
 
+import { interactiveCardHoverSx } from "@/app/projects/finding-nemo/components/interactiveCardStyles";
 import { bodyTypeSx, titleTypeSx } from "@/app/projects/finding-nemo/typography";
 
 /** Fixed card width — consistent across mobile, tablet, and desktop. */
@@ -17,6 +18,8 @@ export type ContentCardProps = {
   widthPx?: number;
   /** Card height in px; defaults to 344. */
   heightPx?: number;
+  /** KPI-style surface, shadow, and hover lift (Defining Success cards). */
+  interactive?: boolean;
 };
 
 export default function ContentCard({
@@ -24,6 +27,7 @@ export default function ContentCard({
   description,
   widthPx = CARD_WIDTH_PX,
   heightPx = DEFAULT_CARD_HEIGHT_PX,
+  interactive = false,
 }: ContentCardProps) {
   const bulletItems = Array.isArray(description) ? description : null;
 
@@ -43,6 +47,15 @@ export default function ContentCard({
         borderRadius: "20px",
         bgcolor: "#fff",
         border: "1px solid transparent",
+        ...(interactive
+          ? {
+              ...interactiveCardHoverSx,
+              "&:hover": {
+                ...interactiveCardHoverSx["&:hover"],
+                bgcolor: "#fff",
+              },
+            }
+          : {}),
       }}
     >
       <CardContent

--- a/app/projects/finding-nemo/components/ContentCardsRow.tsx
+++ b/app/projects/finding-nemo/components/ContentCardsRow.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Box from "@mui/material/Box";
+
+import ContentCard, {
+  type ContentCardProps,
+} from "@/app/projects/finding-nemo/components/ContentCard";
+
+const contentCardsRowSx = {
+  width: "100%",
+  display: "flex",
+  flexDirection: { xs: "column", md: "row" },
+  flexWrap: { xs: "nowrap", md: "wrap" },
+  justifyContent: "center",
+  alignItems: { xs: "center", md: "stretch" },
+  gap: { xs: 3, md: 3, lg: 4 },
+} as const;
+
+const CARD_REVEAL_STAGGER_MS = 90;
+
+type ContentCardsRowProps = {
+  cards: ContentCardProps[];
+  /** Offsets stagger when multiple rows animate in sequence. */
+  rowIndex?: number;
+};
+
+/**
+ * Content card row with the same scroll-reveal + stagger pattern as `KpiCardsRow`.
+ */
+export default function ContentCardsRow({
+  cards,
+  rowIndex = 0,
+}: ContentCardsRowProps) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setInView(true);
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      {
+        root: null,
+        threshold: 0.15,
+        rootMargin: "0px 0px -10% 0px",
+      },
+    );
+
+    observer.observe(el);
+
+    return () => observer.disconnect();
+  }, []);
+
+  const rowStaggerOffset = rowIndex * cards.length * CARD_REVEAL_STAGGER_MS;
+
+  return (
+    <Box ref={ref} sx={contentCardsRowSx}>
+      {cards.map((card, cardIndex) => (
+        <Box
+          key={card.title}
+          sx={{
+            flexShrink: 0,
+            opacity: inView ? 1 : 0,
+            transform: inView ? "translateY(0)" : "translateY(24px)",
+            transition: "opacity 0.6s ease-out, transform 0.6s ease-out",
+            transitionDelay: inView
+              ? `${rowStaggerOffset + cardIndex * CARD_REVEAL_STAGGER_MS}ms`
+              : "0ms",
+          }}
+        >
+          <ContentCard {...card} interactive />
+        </Box>
+      ))}
+    </Box>
+  );
+}

--- a/app/projects/finding-nemo/components/KpiCard.tsx
+++ b/app/projects/finding-nemo/components/KpiCard.tsx
@@ -7,20 +7,14 @@ import {
 } from "@/app/projects/finding-nemo/typography";
 import type { FindingNemoKpiCardItem } from "@/scripts/project-2.data";
 
+import {
+  INTERACTIVE_CARD_BG_COLOR,
+  interactiveCardHoverSx,
+} from "@/app/projects/finding-nemo/components/interactiveCardStyles";
+
 export const KPI_CARD_WIDTH_PX = 300;
 export const KPI_CARD_HEIGHT_PX = 280;
-export const KPI_CARD_BG_COLOR = "#F2F6FA";
-
-const kpiCardHoverSx = {
-  boxShadow: "0 4px 18px rgba(0, 0, 0, 0.08)",
-  transition:
-    "transform 0.22s ease, box-shadow 0.22s ease, background-color 0.22s ease, opacity 0.22s ease",
-  "&:hover": {
-    transform: "translateY(-6px)",
-    boxShadow: "0 18px 45px rgba(0, 0, 0, 0.18)",
-    bgcolor: "#f7fbff",
-  },
-} as const;
+export const KPI_CARD_BG_COLOR = INTERACTIVE_CARD_BG_COLOR;
 
 export type KpiCardProps = FindingNemoKpiCardItem;
 
@@ -47,7 +41,7 @@ export default function KpiCard({ icon, title, description }: KpiCardProps) {
         borderRadius: "20px",
         overflow: "hidden",
         boxSizing: "border-box",
-        ...kpiCardHoverSx,
+        ...interactiveCardHoverSx,
       }}
     >
       <Box

--- a/app/projects/finding-nemo/components/PanelSection.tsx
+++ b/app/projects/finding-nemo/components/PanelSection.tsx
@@ -47,7 +47,7 @@ function PanelHeading({ title }: { title: string }) {
   return (
     <Typography
       component="h3"
-      sx={titleTypeSx("cardTitle", {
+      sx={titleTypeSx("sectionSubtitle", {
         fontWeight: 700,
         lineHeight: 1.1,
         color: "common.black",

--- a/app/projects/finding-nemo/components/Persona.tsx
+++ b/app/projects/finding-nemo/components/Persona.tsx
@@ -1,9 +1,15 @@
 import { Avatar, Box, Paper, Stack, Typography } from "@mui/material";
 
+import { interactiveCardHoverSx } from "@/app/projects/finding-nemo/components/interactiveCardStyles";
 import { bodyTypeSx, titleTypeSx } from "@/app/projects/finding-nemo/typography";
 import type { FindingNemoPersonaItem } from "@/scripts/project-2.data";
 
-export type PersonaProps = FindingNemoPersonaItem;
+export type PersonaProps = FindingNemoPersonaItem & {
+  /** White surface with shadow, hover lift, and scroll-reveal row support. */
+  interactive?: boolean;
+  /** Stretch to match sibling persona card height in a row. */
+  fillHeight?: boolean;
+};
 
 export default function Persona({
   title,
@@ -13,6 +19,8 @@ export default function Persona({
   goals,
   painPoints,
   quote,
+  interactive = false,
+  fillHeight = false,
 }: PersonaProps) {
   return (
     <Paper
@@ -21,6 +29,9 @@ export default function Persona({
       sx={{
         maxWidth: 490,
         width: "100%",
+        height: fillHeight ? "100%" : "auto",
+        display: fillHeight ? "flex" : "block",
+        flexDirection: fillHeight ? "column" : undefined,
         mx: "auto",
         px: 4,
         pt: 4,
@@ -28,9 +39,20 @@ export default function Persona({
         borderRadius: "15px",
         backgroundColor: "#fff",
         overflow: "hidden",
+        boxSizing: "border-box",
+        ...(interactive
+          ? {
+              ...interactiveCardHoverSx,
+              "&:hover": {
+                ...interactiveCardHoverSx["&:hover"],
+                bgcolor: "#fff",
+                backgroundColor: "#fff",
+              },
+            }
+          : {}),
       }}
     >
-      <Stack spacing={4}>
+      <Stack spacing={4} sx={fillHeight ? { flex: 1 } : undefined}>
         <Stack
           direction={{ xs: "column", sm: "row" }}
           spacing={3}
@@ -119,7 +141,7 @@ export default function Persona({
             </Box>
           </Stack>
         ) : null}
-        <Box display="flex" justifyContent="center">
+        <Box display="flex" justifyContent="center" sx={fillHeight ? { mt: "auto" } : undefined}>
           <Paper
             elevation={0}
             sx={{

--- a/app/projects/finding-nemo/components/PersonasRow.tsx
+++ b/app/projects/finding-nemo/components/PersonasRow.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Box from "@mui/material/Box";
+
+import Persona, { type PersonaProps } from "@/app/projects/finding-nemo/components/Persona";
+
+const personasRowSx = {
+  width: "100%",
+  display: "flex",
+  flexDirection: { xs: "column", md: "row" },
+  flexWrap: { xs: "nowrap", md: "wrap" },
+  justifyContent: "center",
+  alignItems: { xs: "center", md: "stretch" },
+  gap: { xs: 3, md: 3, lg: 4 },
+} as const;
+
+const CARD_REVEAL_STAGGER_MS = 90;
+
+type PersonasRowProps = {
+  personas: PersonaProps[];
+  /** Offsets stagger when multiple rows animate in sequence. */
+  rowIndex?: number;
+};
+
+/**
+ * Persona card row with the same scroll-reveal + stagger pattern as `ContentCardsRow`.
+ */
+export default function PersonasRow({ personas, rowIndex = 0 }: PersonasRowProps) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setInView(true);
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      {
+        root: null,
+        threshold: 0.15,
+        rootMargin: "0px 0px -10% 0px",
+      },
+    );
+
+    observer.observe(el);
+
+    return () => observer.disconnect();
+  }, []);
+
+  const rowStaggerOffset = rowIndex * personas.length * CARD_REVEAL_STAGGER_MS;
+
+  return (
+    <Box ref={ref} sx={personasRowSx}>
+      {personas.map((persona, personaIndex) => (
+        <Box
+          key={persona.title}
+          sx={{
+            flexShrink: 0,
+            width: { xs: "100%", md: 490 },
+            maxWidth: 490,
+            display: "flex",
+            flexDirection: "column",
+            opacity: inView ? 1 : 0,
+            transform: inView ? "translateY(0)" : "translateY(24px)",
+            transition: "opacity 0.6s ease-out, transform 0.6s ease-out",
+            transitionDelay: inView
+              ? `${rowStaggerOffset + personaIndex * CARD_REVEAL_STAGGER_MS}ms`
+              : "0ms",
+          }}
+        >
+          <Persona {...persona} interactive fillHeight />
+        </Box>
+      ))}
+    </Box>
+  );
+}

--- a/app/projects/finding-nemo/components/SectionParagraph.tsx
+++ b/app/projects/finding-nemo/components/SectionParagraph.tsx
@@ -7,26 +7,41 @@ export type SectionParagraphProps = {
   title?: string;
   /** Body copy — one or more paragraphs (Source Sans 3 / section description scale). */
   body?: string | string[];
+  /** Section title (h2) vs subtitle (h3) under a parent section heading. */
+  titleVariant?: "sectionTitle" | "subtitle";
 };
 
 function normalizeBodyParagraphs(body: string | string[]): string[] {
   return Array.isArray(body) ? body : [body];
 }
 
-export default function SectionParagraph({ title, body }: SectionParagraphProps) {
+const sectionTitleSx = titleTypeSx("sectionTitle", {
+  color: "common.black",
+  fontWeight: 700,
+  lineHeight: 1.1,
+});
+
+const subtitleSx = titleTypeSx("sectionSubtitle", {
+  color: "common.black",
+  fontWeight: 700,
+  lineHeight: 1.1,
+});
+
+export default function SectionParagraph({
+  title,
+  body,
+  titleVariant = "sectionTitle",
+}: SectionParagraphProps) {
   const paragraphs = body ? normalizeBodyParagraphs(body) : [];
   const hasBody = paragraphs.length > 0;
+  const isSubtitle = titleVariant === "subtitle";
 
   return (
     <Stack spacing={hasBody ? { xs: 3, md: 4.5 } : 0}>
       {title ? (
         <Typography
-          component="h2"
-          sx={titleTypeSx("sectionTitle", {
-            color: "common.black",
-            fontWeight: 700,
-            lineHeight: 1.1,
-          })}
+          component={isSubtitle ? "h3" : "h2"}
+          sx={isSubtitle ? subtitleSx : sectionTitleSx}
         >
           {title}
         </Typography>

--- a/app/projects/finding-nemo/components/interactiveCardStyles.ts
+++ b/app/projects/finding-nemo/components/interactiveCardStyles.ts
@@ -1,0 +1,14 @@
+/** Shared surface + hover treatment for KPI and interactive content cards. */
+export const INTERACTIVE_CARD_BG_COLOR = "#F2F6FA" as const;
+export const INTERACTIVE_CARD_HOVER_BG_COLOR = "#f7fbff" as const;
+
+export const interactiveCardHoverSx = {
+  boxShadow: "0 4px 18px rgba(0, 0, 0, 0.08)",
+  transition:
+    "transform 0.22s ease, box-shadow 0.22s ease, background-color 0.22s ease, opacity 0.22s ease",
+  "&:hover": {
+    transform: "translateY(-6px)",
+    boxShadow: "0 18px 45px rgba(0, 0, 0, 0.18)",
+    bgcolor: INTERACTIVE_CARD_HOVER_BG_COLOR,
+  },
+} as const;

--- a/app/projects/finding-nemo/typography.ts
+++ b/app/projects/finding-nemo/typography.ts
@@ -18,10 +18,12 @@ export const TYPOGRAPHY = {
   heroTitle: { mobile: "36px", tablet: "44px", desktop: "52px" },
   heroSubtitle: { mobile: "20px", tablet: "22px", desktop: "24px" },
   sectionTitle: { mobile: "28px", tablet: "32px", desktop: "36px" },
+  /** h3 subtitles under a section title (e.g. Business Opportunities, panel headings). */
+  sectionSubtitle: { mobile: "22px", tablet: "24px", desktop: "26px" },
   sectionDescription: { mobile: "18px", tablet: "20px", desktop: "22px" },
   cardTitle: { mobile: "20px", tablet: "22px", desktop: "24px" },
   /** `ContentCard` title — IBM Plex Sans Bold. */
-  contentCardTitle: { mobile: "20px", tablet: "22px", desktop: "24px" },
+  contentCardTitle: { mobile: "18px", tablet: "20px", desktop: "22px" },
   /** `ContentCard` body / bullets — Source Sans 3 Regular. */
   contentCardBody: { mobile: "16px", tablet: "17px", desktop: "18px" },
   /** `Persona` Goals / Pain Points headings — IBM Plex Sans Bold. */


### PR DESCRIPTION
### Summary
Improves information hierarchy and card presentation on the Finding Nemo case study page (/work/finding-nemo).

- **Section structure:** Adds parent section titles “Framing the Problem Space” and “Understanding the Users”, with former top-level headings (Challenges, Business Opportunities, Primary Users, Personas) demoted to subtitles via a new SectionParagraph titleVariant.
- **Typography:** Introduces sectionSubtitle (22 / 24 / 26px) and reduces contentCardTitle (18 / 20 / 22px) for clearer separation between subtitles and card titles.
- **Content order:** Challenges now appears before Business Opportunities in the problem-space band.
- **Interactive cards:** Shared hover/shadow styles (interactiveCardStyles.ts) applied to Challenges, Business Opportunities, Primary Users, and Persona cards — white #FFFFFF backgrounds with lift-on-hover and scroll-reveal stagger (ContentCardsRow, PersonasRow).
- **Persona layout:** Both persona cards match height on desktop, with quotes pinned to the bottom of the shorter card.
