### PR TITLE
onboarded mockup images

### DIFF
--- a/app/projects/finding-nemo/FindingNemoPage.tsx
+++ b/app/projects/finding-nemo/FindingNemoPage.tsx
@@ -28,6 +28,7 @@ import {
   BAND_COLORS,
   LAYOUT_DIMENSIONS,
   MOBILE_EXPERIENCE_MOCKUP_GAPS,
+  PANEL_CONTENT_MAX_WIDTH_PX,
   PANEL_COLORS,
   PANEL_SECTION_GAPS,
   PANEL_SHELL_SX,
@@ -66,11 +67,13 @@ const solutionOverviewImageBoxSx = {
 
 const mobileExperienceMockupsRowSx = {
   width: "100%",
+  maxWidth: `${PANEL_CONTENT_MAX_WIDTH_PX}px`,
+  mx: "auto",
   display: "flex",
   flexDirection: { xs: "column", md: "row" },
-  flexWrap: { xs: "nowrap", md: "wrap" },
+  flexWrap: "wrap",
   justifyContent: "center",
-  alignItems: { xs: "center", md: "stretch" },
+  alignItems: { xs: "center", md: "flex-start" },
   gap: MOBILE_EXPERIENCE_MOCKUP_GAPS.mobile,
   [breakpointMediaQuery.tabletUp]: {
     gap: MOBILE_EXPERIENCE_MOCKUP_GAPS.tablet,
@@ -216,20 +219,41 @@ export function FindingNemoPage({
                   justifyContent: "center",
                 }}
               >
-                <Box sx={solutionOverviewImageBoxSx}>
-                  <ProjectImage
-                    objectPath={project.solutionOverview.image.objectPath}
-                    alt={project.solutionOverview.image.alt}
-                    width={project.solutionOverview.image.width}
-                    height={project.solutionOverview.image.height}
-                    sizes={solutionOverviewImageSizes}
-                    style={{
-                      display: "block",
-                      width: "100%",
-                      height: "auto",
-                    }}
-                  />
-                </Box>
+                <Stack
+                  alignItems="center"
+                  spacing={{ xs: 2, md: 2.5 }}
+                  sx={solutionOverviewImageBoxSx}
+                >
+                  <Box sx={{ width: "100%" }}>
+                    <ProjectImage
+                      objectPath={project.solutionOverview.image.objectPath}
+                      alt={project.solutionOverview.image.alt}
+                      width={project.solutionOverview.image.width}
+                      height={project.solutionOverview.image.height}
+                      sizes={solutionOverviewImageSizes}
+                      style={{
+                        display: "block",
+                        width: "100%",
+                        height: "auto",
+                      }}
+                    />
+                  </Box>
+                  {project.solutionOverview.image.annotation ? (
+                    <Typography
+                      component="p"
+                      sx={bodyTypeSx("smallCaption", {
+                        color: "common.black",
+                        fontWeight: 400,
+                        lineHeight: 1.5,
+                        textAlign: "center",
+                        m: 0,
+                        width: "100%",
+                      })}
+                    >
+                      {project.solutionOverview.image.annotation}
+                    </Typography>
+                  ) : null}
+                </Stack>
               </Box>
             </Stack>
           </FullBleedBand>
@@ -281,11 +305,31 @@ export function FindingNemoPage({
                 title={project.mobileExperienceConcepts.title}
                 body={project.mobileExperienceConcepts.paragraphs}
               />
-              <Box sx={mobileExperienceMockupsRowSx}>
-                {project.mobileExperienceConcepts.mockups.map((mockup) => (
-                  <MobileExperienceMockup key={mockup.title} {...mockup} />
-                ))}
-              </Box>
+              <Stack spacing={{ xs: 4, md: 6 }} sx={{ width: "100%" }}>
+                {project.mobileExperienceConcepts.mockups[0] ? (
+                  <Box
+                    sx={{
+                      width: "100%",
+                      display: "flex",
+                      justifyContent: "center",
+                    }}
+                  >
+                    <MobileExperienceMockup
+                      {...project.mobileExperienceConcepts.mockups[0]}
+                      variant="notification"
+                    />
+                  </Box>
+                ) : null}
+                {project.mobileExperienceConcepts.mockups.length > 1 ? (
+                  <Box sx={mobileExperienceMockupsRowSx}>
+                    {project.mobileExperienceConcepts.mockups
+                      .slice(1)
+                      .map((mockup) => (
+                        <MobileExperienceMockup key={mockup.title} {...mockup} />
+                      ))}
+                  </Box>
+                ) : null}
+              </Stack>
             </Stack>
           </FullBleedBand>
           <FullBleedBand backgroundColor={BAND_COLORS.businessOpportunities}>

--- a/app/projects/finding-nemo/components/MobileExperienceMockup.tsx
+++ b/app/projects/finding-nemo/components/MobileExperienceMockup.tsx
@@ -1,59 +1,87 @@
 import { Stack, Typography } from "@mui/material";
 
-import { MOBILE_EXPERIENCE_MOCKUP_DISPLAY } from "@/app/projects/finding-nemo/layoutConfig";
-import { titleTypeSx } from "@/app/projects/finding-nemo/typography";
+import {
+  MOBILE_EXPERIENCE_MOCKUP_DISPLAY,
+  MOBILE_EXPERIENCE_NOTIFICATION_DISPLAY,
+  PROBLEM_DEMO_CAROUSEL_CAPTION_FONT_SIZE,
+} from "@/app/projects/finding-nemo/layoutConfig";
+import { FINDING_NEMO_BODY_FONT } from "@/app/projects/finding-nemo/typography";
 import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
-import ProjectImage from "@/lib/media/ProjectImage";
+import ProjectImageLightbox from "@/lib/media/ProjectImageLightbox";
 import type { FindingNemoMobileMockupItem } from "@/scripts/project-2.data";
 
-export type MobileExperienceMockupProps = FindingNemoMobileMockupItem;
+export type MobileExperienceMockupProps = FindingNemoMobileMockupItem & {
+  /** Phone screen mockup vs landscape push-notification banner. */
+  variant?: "phone" | "notification";
+};
 
-const mockupImageSizes = [
-  `(max-width: 767px) ${MOBILE_EXPERIENCE_MOCKUP_DISPLAY.mobile.width}px`,
-  `(max-width: 1023px) ${MOBILE_EXPERIENCE_MOCKUP_DISPLAY.tablet.width}px`,
-  `${MOBILE_EXPERIENCE_MOCKUP_DISPLAY.desktop.width}px`,
-].join(", ");
+const mockupAnnotationSx = {
+  fontFamily: FINDING_NEMO_BODY_FONT,
+  color: "#000",
+  fontSize: PROBLEM_DEMO_CAROUSEL_CAPTION_FONT_SIZE.mobile,
+  lineHeight: 1.3,
+  fontWeight: 600,
+  textAlign: "center",
+  m: 0,
+  [breakpointMediaQuery.tabletUp]: {
+    fontSize: PROBLEM_DEMO_CAROUSEL_CAPTION_FONT_SIZE.tablet,
+  },
+  [breakpointMediaQuery.desktopUp]: {
+    fontSize: PROBLEM_DEMO_CAROUSEL_CAPTION_FONT_SIZE.desktop,
+  },
+} as const;
+
+function getDisplayConfig(variant: "phone" | "notification") {
+  return variant === "notification"
+    ? MOBILE_EXPERIENCE_NOTIFICATION_DISPLAY
+    : MOBILE_EXPERIENCE_MOCKUP_DISPLAY;
+}
+
+function mockupLightboxId(objectPath: string): string {
+  const fileStem =
+    objectPath
+      .split("/")
+      .pop()
+      ?.replace(/\.[^.]+$/, "") ?? "mockup";
+  return `finding-nemo-mobile-${fileStem}`;
+}
 
 export default function MobileExperienceMockup({
   title,
   objectPath,
   width,
   height,
+  variant = "phone",
 }: MobileExperienceMockupProps) {
+  const display = getDisplayConfig(variant);
+  const lightboxId = mockupLightboxId(objectPath);
+
   return (
     <Stack
       spacing={2}
       alignItems="center"
       sx={{
-        width: `${MOBILE_EXPERIENCE_MOCKUP_DISPLAY.mobile.width}px`,
+        width: `${display.mobile.width}px`,
         maxWidth: "100%",
         flexGrow: 0,
         flexShrink: 0,
         [breakpointMediaQuery.tabletUp]: {
-          width: `${MOBILE_EXPERIENCE_MOCKUP_DISPLAY.tablet.width}px`,
+          width: `${display.tablet.width}px`,
         },
         [breakpointMediaQuery.desktopUp]: {
-          width: `${MOBILE_EXPERIENCE_MOCKUP_DISPLAY.desktop.width}px`,
+          width: `${display.desktop.width}px`,
         },
       }}
     >
-      <ProjectImage
+      <ProjectImageLightbox
         objectPath={objectPath}
         alt={title}
+        lightboxId={lightboxId}
         width={width}
         height={height}
-        sizes={mockupImageSizes}
         style={{ display: "block", width: "100%", height: "auto" }}
       />
-      <Typography
-        component="p"
-        align="center"
-        sx={titleTypeSx("cardTitle", {
-          fontWeight: 700,
-          lineHeight: 1.1,
-          color: "common.black",
-        })}
-      >
+      <Typography component="p" sx={mockupAnnotationSx}>
         {title}
       </Typography>
     </Stack>

--- a/app/projects/finding-nemo/layoutConfig.ts
+++ b/app/projects/finding-nemo/layoutConfig.ts
@@ -164,26 +164,37 @@ export const PROBLEM_DEMO_PANEL_SIDE_BY_SIDE_MIN_WIDTH_PX = 1260 as const;
 export const PROBLEM_DEMO_PANEL_COPY_MIN_WIDTH_PX = 321 as const;
 
 /**
- * Solution overview diagram display size (maintains 211:430 aspect ratio).
- * Desktop matches design spec; tablet ~90%, mobile ~75%.
+ * Solution overview hi-fi mockup display (402:874 intrinsic aspect ratio).
+ * Desktop width scaled +30% from legacy 211px frame; tablet +30% from 190px; mobile ~75%.
  */
 export const SOLUTION_OVERVIEW_IMAGE_DISPLAY = {
-  mobile: { width: 158, height: 322 },
-  tablet: { width: 190, height: 387 },
-  desktop: { width: 211, height: 430 },
+  mobile: { width: 158, height: 343 },
+  tablet: { width: 284, height: 618 },
+  desktop: { width: 315, height: 685 },
 } as const;
 
-/** Mobile experience mockup display — same phone aspect ratio as solution overview diagram. */
-export const MOBILE_EXPERIENCE_MOCKUP_DISPLAY = SOLUTION_OVERVIEW_IMAGE_DISPLAY;
+/** Mobile experience mockup display — phone mockup row (402:874 hi-fi assets). */
+export const MOBILE_EXPERIENCE_MOCKUP_DISPLAY = {
+  mobile: { width: 158, height: 322 },
+  tablet: { width: 190, height: 387 },
+  desktop: { width: 240, height: 522 },
+} as const;
+
+/** Incident Alert notification banner (400:162 intrinsic; display ~60% of asset width). */
+export const MOBILE_EXPERIENCE_NOTIFICATION_DISPLAY = {
+  mobile: { width: 180, height: 73 },
+  tablet: { width: 216, height: 87 },
+  desktop: { width: 317, height: 128 },
+} as const;
 
 /**
  * Gap between mobile experience mockups in the flex row.
- * Desktop 64px; tablet/mobile use the same 3 : 5 : 8 ratio (24 / 40 / 64px).
+ * Desktop 46px fits 4 × 240px mockups in the 1100px band; tablet/mobile use 3 : 5 scale.
  */
 export const MOBILE_EXPERIENCE_MOCKUP_GAPS = {
   mobile: "24px",
   tablet: "40px",
-  desktop: "64px",
+  desktop: "46px",
 } as const;
 
 /**


### PR DESCRIPTION
### Summary
Onboards high-fidelity ParkWatch mockups on the Finding Nemo case study (/work/finding-nemo), with updated layout, labels, lightbox, and display sizing.

**Solution Overview**

- Replaces diagram with ParkWatchTrackingHFMockup.png (402×874)
- Scales display size for tablet/desktop (315px desktop width)
- Adds caption annotation for trajectory tracking copy

**Mobile Experience Concepts**

- Replaces all 5 mockups with ParkWatch hi-fi assets:
- Incident Notification (banner)
- Incident Alert, Summary & Evident Review, Trajectory Tracking, Incident Response Recommendations (phone screens)
- Layout: notification on its own row; 4 phone screens in a single row on desktop (wraps on smaller viewports)
- Lightbox: each mockup opens full-size independently via ProjectImageLightbox
- Labels: updated copy + Source Sans 3 semibold annotation typography (matches demo carousel captions)
- Sizing: phone mockups 240px desktop; notification banner at reduced landscape scale; gaps tuned so 4 phones fit in the 1100px band