### PR TITLE
improved Software Prototypes with expandable accordions

### DIFF
--- a/app/projects/ar-story-teller/components/PanelAccordionList.tsx
+++ b/app/projects/ar-story-teller/components/PanelAccordionList.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import ExpandLessIcon from "@mui/icons-material/ExpandLess";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import {
+  Box,
+  Collapse,
+  Divider,
+  List,
+  ListItemButton,
+  Stack,
+  Typography,
+} from "@mui/material";
+import { useState } from "react";
+
+import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
+import { bodyTypeSx, titleTypeSx } from "../typography";
+
+const DESKTOP_LAYOUT_MQ = breakpointMediaQuery.desktopUp;
+
+const accordionTitleSx = titleTypeSx("cardTitle", {
+  flex: 1,
+  lineHeight: "normal !important",
+  letterSpacing: 0,
+});
+
+const accordionBodySx = bodyTypeSx("smallBody", {
+  letterSpacing: 0,
+  maxWidth: "100%",
+});
+
+export interface PanelAccordionItem {
+  title: string;
+  description?: string;
+  /** Legacy seed typo — prefer `description`. */
+  desciption?: string;
+}
+
+export interface PanelAccordionListProps {
+  items: PanelAccordionItem[];
+  /** Which item is open on first render — defaults to `0`. */
+  defaultExpandedIndex?: number;
+  /** Optional desktop max-width for expanded body copy (Interaction Design panel). */
+  bodyMaxWidthDesktop?: number;
+  /** Optional title width cap for the first row only. */
+  firstItemTitleMaxWidth?: number;
+}
+
+function itemDescription(item: PanelAccordionItem): string {
+  return (item.description ?? item.desciption ?? "").trim();
+}
+
+/**
+ * Expandable list — same interaction model as `InteractionDesignPrinciples` /
+ * `UsabilityFindingsInsights` (first item open by default; one expanded at a time).
+ */
+export function PanelAccordionList({
+  items,
+  defaultExpandedIndex = 0,
+  bodyMaxWidthDesktop,
+  firstItemTitleMaxWidth,
+}: PanelAccordionListProps) {
+  const [expandedIndex, setExpandedIndex] = useState(defaultExpandedIndex);
+
+  if (!items.length) {
+    return null;
+  }
+
+  return (
+    <List disablePadding>
+      {items.map((item, index) => {
+        const isExpanded = expandedIndex === index;
+        const description = itemDescription(item);
+
+        return (
+          <Box key={`${item.title}-${index}`}>
+            {index !== 0 ? (
+              <Divider sx={{ borderColor: "#d9d9d9" }} />
+            ) : null}
+            <ListItemButton
+              onClick={() => setExpandedIndex(isExpanded ? -1 : index)}
+              sx={{
+                px: 0,
+                py: 3.5,
+                alignItems: "flex-start",
+                borderRadius: 0,
+              }}
+            >
+              <Stack
+                direction="row"
+                justifyContent="space-between"
+                alignItems="flex-start"
+                spacing={2}
+                sx={{ width: "100%" }}
+              >
+                <Typography
+                  component="h2"
+                  sx={{
+                    ...accordionTitleSx,
+                    maxWidth:
+                      index === 0 && firstItemTitleMaxWidth !== undefined
+                        ? firstItemTitleMaxWidth
+                        : "100%",
+                  }}
+                >
+                  {item.title}
+                </Typography>
+                {isExpanded ? (
+                  <ExpandLessIcon sx={{ color: "#5f5f5f", mt: 0.5 }} />
+                ) : (
+                  <ExpandMoreIcon sx={{ color: "#5f5f5f", mt: 0.5 }} />
+                )}
+              </Stack>
+            </ListItemButton>
+            <Collapse
+              in={isExpanded}
+              timeout="auto"
+              unmountOnExit={index !== defaultExpandedIndex}
+            >
+              {description ? (
+                <Box sx={{ pt: 0.5, pb: 3 }}>
+                  <Typography
+                    component="p"
+                    sx={{
+                      ...accordionBodySx,
+                      ...(bodyMaxWidthDesktop !== undefined
+                        ? {
+                            [DESKTOP_LAYOUT_MQ]: {
+                              maxWidth: bodyMaxWidthDesktop,
+                            },
+                          }
+                        : {}),
+                    }}
+                  >
+                    {description}
+                  </Typography>
+                </Box>
+              ) : null}
+            </Collapse>
+          </Box>
+        );
+      })}
+    </List>
+  );
+}
+
+export default PanelAccordionList;

--- a/app/projects/ar-story-teller/components/PrototypingMethodPanel.tsx
+++ b/app/projects/ar-story-teller/components/PrototypingMethodPanel.tsx
@@ -6,6 +6,7 @@ import ParagraphBlock from "./ParagraphBlock";
 import ProjectImage from "@/lib/media/ProjectImage";
 import ProjectImageLightbox from "@/lib/media/ProjectImageLightbox";
 import { PrototypingImageCarousel } from "./PrototypingImageCarousel";
+import { PanelAccordionList, type PanelAccordionItem } from "./PanelAccordionList";
 import { breakpointMediaQuery, breakpointPx } from "@/lib/responsive/breakpoints";
 import {
   cssLengthToPx,
@@ -121,15 +122,19 @@ function PanelImageFigure({
 
 function CopyImageSplitLayout({
   paragraphs,
+  accordionSections,
   image,
   carouselImages,
 }: {
   paragraphs?: string[];
+  accordionSections?: PanelAccordionItem[];
   image?: PrototypingPanelImage;
   carouselImages?: PrototypingPanelImage[];
 }) {
+  const hasAccordion = Boolean(accordionSections?.length);
   const hasCarousel = Boolean(carouselImages?.length);
   const hasRightColumn = Boolean(image || hasCarousel);
+  const hasLeftColumn = hasAccordion || Boolean(paragraphs?.length);
 
   return (
     <Stack
@@ -142,13 +147,13 @@ function CopyImageSplitLayout({
         },
         [DESKTOP_LAYOUT_MQ]: {
           flexDirection: "row",
-          alignItems: "center",
+          alignItems: "flex-start",
           justifyContent: hasCarousel ? "flex-start" : "space-between",
           gap: SPLIT_COLUMN_GAP.desktop,
         },
       }}
     >
-      {paragraphs?.length ? (
+      {hasLeftColumn ? (
         <Box
           sx={{
             width: "100%",
@@ -171,7 +176,14 @@ function CopyImageSplitLayout({
                   },
           }}
         >
-          <ParagraphBlock paragraphs={paragraphs} />
+          {hasAccordion && accordionSections ? (
+            <PanelAccordionList
+              items={accordionSections}
+              bodyMaxWidthDesktop={360}
+            />
+          ) : (
+            <ParagraphBlock paragraphs={paragraphs} />
+          )}
         </Box>
       ) : null}
       {hasCarousel && carouselImages ? (
@@ -186,7 +198,7 @@ function CopyImageSplitLayout({
               width: CAROUSEL_SPLIT_MEDIA_WIDTH,
               maxWidth: CAROUSEL_SPLIT_MEDIA_WIDTH,
               minWidth: 0,
-              alignSelf: "center",
+              alignSelf: "flex-start",
             },
           }}
         >
@@ -255,6 +267,8 @@ export interface PrototypingMethodPanelProps {
   children?: ReactNode;
   /** Copy left / image right (Wire-Flow panel). */
   paragraphs?: string[];
+  /** Expandable copy left / carousel right (Software Prototypes panel). */
+  accordionSections?: PanelAccordionItem[];
   copyImage?: PrototypingPanelImage;
   /** Copy left / carousel right (Software Prototypes panel). */
   carouselImages?: PrototypingPanelImage[];
@@ -267,13 +281,17 @@ export interface PrototypingMethodPanelProps {
 export function PrototypingMethodPanel({
   children,
   paragraphs,
+  accordionSections,
   copyImage,
   carouselImages,
   primaryImage,
   secondaryImage,
 }: PrototypingMethodPanelProps) {
   const hasCopyImageSplit = Boolean(
-    paragraphs?.length || copyImage || carouselImages?.length,
+    paragraphs?.length ||
+      accordionSections?.length ||
+      copyImage ||
+      carouselImages?.length,
   );
   const hasStackedImages = Boolean(primaryImage || secondaryImage);
 
@@ -290,6 +308,7 @@ export function PrototypingMethodPanel({
         {hasCopyImageSplit ? (
           <CopyImageSplitLayout
             paragraphs={paragraphs}
+            accordionSections={accordionSections}
             image={copyImage}
             carouselImages={carouselImages}
           />

--- a/app/projects/ar-story-teller/lib/parseDesignSystem.ts
+++ b/app/projects/ar-story-teller/lib/parseDesignSystem.ts
@@ -360,17 +360,26 @@ function parsePrototypingMethod(value: unknown, path: string): PrototypingMethod
   if (!Array.isArray(value.images)) {
     throw new Error(`Invalid ${path}.images: expected array`);
   }
-  return {
+  const method: PrototypingMethod = {
     title: requireString(value.title, `${path}.title`),
     alt: requireString(value.alt, `${path}.alt`),
-    paragraphs:
-      value.paragraphs !== undefined
-        ? parseStringArray(value.paragraphs, `${path}.paragraphs`)
-        : undefined,
     images: value.images.map((img, index) =>
       parsePrototypingImage(img, `${path}.images[${index}]`),
     ),
   };
+  if (value.paragraphs !== undefined) {
+    method.paragraphs = parseStringArray(value.paragraphs, `${path}.paragraphs`);
+  }
+  const accordionSource = value.accordionSections ?? value.sections;
+  if (accordionSource !== undefined) {
+    if (!Array.isArray(accordionSource)) {
+      throw new Error(`Invalid ${path}.accordionSections: expected array`);
+    }
+    method.accordionSections = accordionSource.map((item, index) =>
+      parseFeatureSpecification(item, `${path}.accordionSections[${index}]`),
+    );
+  }
+  return method;
 }
 
 function parsePrototyping(value: unknown, path: string): Prototyping {

--- a/app/projects/ar-story-teller/lib/softwarePrototypesAccordion.ts
+++ b/app/projects/ar-story-teller/lib/softwarePrototypesAccordion.ts
@@ -1,0 +1,29 @@
+import type { FeatureSpecification } from "../types/designSystemTypes";
+
+/** Default copy for the Software Prototypes accordion when CMS data omits `accordionSections`. */
+export const SOFTWARE_PROTOTYPES_ACCORDION_SECTIONS: FeatureSpecification[] = [
+  {
+    title: "Mobile Platform Architecture",
+    description:
+      "The prototype was developed for the iOS platform using ARKit and integrated machine learning powered by a convolutional neural network (CNN), a deep-learning algorithm for image recognition. The system architecture was designed to support future on-demand model delivery, enabling the application to fetch new or updated models from a publishing service without requiring app updates. This approach allows the AR experience to scale across multiple attractions by dynamically adapting models to each context.",
+  },
+  {
+    title: "Machine Learning Models",
+    description:
+      "The underlying machine learning model is MobileNetV2, a CNN architecture optimized for mobile devices. It processes image inputs through multiple layers, learning to identify and differentiate visual features with high accuracy. The model was trained on a dataset of images through iterative training to achieve strong precision and recall. Final model outputs were formatted for platform compatibility, including Core ML for iOS and ONNX for cross-platform use in Unity.",
+  },
+  {
+    title: "User Experience Interface",
+    description:
+      "Apple's iOS and ARKit frameworks were used as the front-end platform to deliver augmented reality experiences, with Core ML models integrated to enable real-time recognition and interaction with elements embedded in the attraction environment.",
+  },
+];
+
+export function resolveSoftwarePrototypesAccordionSections(
+  accordionSections?: FeatureSpecification[],
+): FeatureSpecification[] {
+  if (accordionSections?.length) {
+    return accordionSections;
+  }
+  return SOFTWARE_PROTOTYPES_ACCORDION_SECTIONS;
+}

--- a/app/projects/ar-story-teller/sections/DesignSystemSection.tsx
+++ b/app/projects/ar-story-teller/sections/DesignSystemSection.tsx
@@ -18,6 +18,7 @@ import {
 import { UsabilityFindingsInsights } from '../components/UsabilityFindingsInsights';
 import type { DesignSystemSectionData } from '../types/arStoryTellerContent';
 import type { StoryboardSlide } from '../types/designSystemTypes';
+import { resolveSoftwarePrototypesAccordionSections } from '../lib/softwarePrototypesAccordion';
 
 interface DesignSystemSectionProps {
     data: DesignSystemSectionData;
@@ -216,7 +217,9 @@ export function DesignSystemSection({ data }: DesignSystemSectionProps) {
                         <div className={styles['panel-subsection']}>
                             <PanelSubTitle title={prototypingMethod2.title} />
                             <PrototypingMethodPanel
-                                paragraphs={prototypingMethod2.paragraphs}
+                                accordionSections={resolveSoftwarePrototypesAccordionSections(
+                                    prototypingMethod2.accordionSections,
+                                )}
                                 carouselImages={prototypingMethod2.images}
                             />
                         </div>

--- a/app/projects/ar-story-teller/types/designSystemTypes.ts
+++ b/app/projects/ar-story-teller/types/designSystemTypes.ts
@@ -114,6 +114,8 @@ export type PrototypingMethod = {
   title: string;
   alt: string;
   paragraphs?: string[];
+  /** Expandable copy blocks (Software Prototypes panel). */
+  accordionSections?: FeatureSpecification[];
   images: PrototypingImage[];
 };
 


### PR DESCRIPTION
### Summary

The Software Prototypes panel now uses the same accordion + carousel layout as Interaction Design Principles & Specifications.

**What changed**

- PanelAccordionList — Reusable accordion (one section open at a time, first expanded by default).
- softwarePrototypesAccordion.ts — Default copy for all three sections:

- Mobile Platform Architecture (expanded by default)
- Machine Learning Models
- User Experience Interface
- PrototypingMethodPanel — When accordionSections is provided, the left column renders the accordion instead of flat paragraphs; the image carousel stays on the right with the same ~35% / ~65% desktop split and top alignment.
- DesignSystemSection — prototypingMethod2 (Software Prototypes) passes accordionSections via resolveSoftwarePrototypesAccordionSections() instead of flat paragraphs.
- CMS support — PrototypingMethod accepts optional accordionSections; if Firestore omits them, the defaults above are used.