### PR TITLE
Landing page/selected work cards

### DIFF
--- a/app/home/LatestProjectCard.tsx
+++ b/app/home/LatestProjectCard.tsx
@@ -8,29 +8,28 @@ import CardActionArea from "@mui/material/CardActionArea";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import type { StaticImageData } from "next/image";
+import { SELECTED_WORK_CARD } from "./selectedWorkCardLayout";
 
 export type LatestProjectProps = {
   title: string;
   thumbnailImg: StaticImageData;
   description: string[];
-  /** Desktop grid — fills the grid column width. */
-  fullWidth?: boolean;
 };
 
-function LatestProjectCard({
-  title,
-  thumbnailImg,
-  description,
-  fullWidth = false,
-}: LatestProjectProps) {
+function LatestProjectCard({ title, thumbnailImg, description }: LatestProjectProps) {
+  const { widthPx, heightPx, contentPaddingPx } = SELECTED_WORK_CARD;
+  const bleedX = contentPaddingPx * 2;
+
   return (
     <Card
       sx={{
-        width: fullWidth ? "100%" : "294px",
-        height: "390px",
+        width: `${widthPx}px`,
+        height: `${heightPx}px`,
+        flexShrink: 0,
         borderRadius: 1.5,
         boxShadow: "0 4px 14px rgba(0, 0, 0, 0.08)",
         transition: "transform 0.35s ease, box-shadow 0.35s ease, opacity 0.3s ease",
+        overflow: "hidden",
 
         "&:hover": {
           transform: "translateY(-4px)",
@@ -43,7 +42,17 @@ function LatestProjectCard({
       }}
       raised
     >
-      <CardActionArea sx={{ height: "100%" }}>
+      <CardActionArea
+        sx={{
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "stretch",
+          boxSizing: "border-box",
+          padding: `${contentPaddingPx}px`,
+          paddingBottom: 0,
+        }}
+      >
         <CardMedia
           component="img"
           className="project-media"
@@ -51,19 +60,33 @@ function LatestProjectCard({
           alt={title}
           sx={{
             display: "block",
-            margin: "0 auto",
+            width: `calc(100% + ${bleedX}px)`,
+            maxWidth: `calc(100% + ${bleedX}px)`,
+            height: "auto",
+            flexShrink: 0,
+            marginTop: `-${contentPaddingPx}px`,
+            marginLeft: `-${contentPaddingPx}px`,
+            marginRight: `-${contentPaddingPx}px`,
+            marginBottom: `${contentPaddingPx}px`,
             objectFit: "contain",
+            objectPosition: "top center",
             transition: "opacity 0.3s ease",
           }}
         />
 
         <CardContent
           sx={{
+            flex: 1,
             display: "flex",
             flexDirection: "column",
             gap: 1,
-            height: "100%",
-            padding: 2.5,
+            minHeight: 0,
+            boxSizing: "border-box",
+            padding: 0,
+            paddingBottom: `${contentPaddingPx}px`,
+            "&:last-child": {
+              paddingBottom: `${contentPaddingPx}px`,
+            },
           }}
         >
           <Box
@@ -87,7 +110,7 @@ function LatestProjectCard({
             </Typography>
           </Box>
 
-          <Box sx={{ textAlign: "left" }}>
+          <Box sx={{ textAlign: "left", flex: 1 }}>
             {description.map((paragraph, idx) => (
               <Typography
                 key={idx}

--- a/app/home/LatestProjectCard.tsx
+++ b/app/home/LatestProjectCard.tsx
@@ -13,32 +13,37 @@ export type LatestProjectProps = {
   title: string;
   thumbnailImg: StaticImageData;
   description: string[];
+  /** Desktop grid — fills the grid column width. */
+  fullWidth?: boolean;
 };
 
-function LatestProjectCard({ title, thumbnailImg, description }: LatestProjectProps) {
+function LatestProjectCard({
+  title,
+  thumbnailImg,
+  description,
+  fullWidth = false,
+}: LatestProjectProps) {
   return (
     <Card
       sx={{
-        //width: "100%",
-        width: { xs: "294px", sm: "294px", md: "294px", lg: "294px", xl: "294px" },
-        height:  { xs: "390px", sm: "390px", md: "390px", lg: "390px", xl: "390px" },
+        width: fullWidth ? "100%" : "294px",
+        height: "390px",
         borderRadius: 1.5,
         boxShadow: "0 4px 14px rgba(0, 0, 0, 0.08)",
         transition: "transform 0.35s ease, box-shadow 0.35s ease, opacity 0.3s ease",
 
         "&:hover": {
           transform: "translateY(-4px)",
-          boxShadow: "0 10px 26px rgba(0, 0, 0, 0.18)",   // soft elevated glow
+          boxShadow: "0 10px 26px rgba(0, 0, 0, 0.18)",
         },
 
         "&:hover .project-media": {
-          opacity: 0.92, // subtle responsive hover fade
+          opacity: 0.92,
         },
       }}
       raised
     >
       <CardActionArea sx={{ height: "100%" }}>
-        {/* ⭐ Full width image with hover fade handled by parent */}
         <CardMedia
           component="img"
           className="project-media"
@@ -48,12 +53,19 @@ function LatestProjectCard({ title, thumbnailImg, description }: LatestProjectPr
             display: "block",
             margin: "0 auto",
             objectFit: "contain",
-            transition: "opacity 0.3s ease",  // smooth fade on hover
+            transition: "opacity 0.3s ease",
           }}
         />
 
-        <CardContent sx={{ display: "flex", flexDirection: "column", gap: 1, height: "100%", padding: 2.5 }}>
-          {/* Title */}
+        <CardContent
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 1,
+            height: "100%",
+            padding: 2.5,
+          }}
+        >
           <Box
             sx={{
               display: "flex",
@@ -65,7 +77,7 @@ function LatestProjectCard({ title, thumbnailImg, description }: LatestProjectPr
             <Typography
               component="h3"
               sx={{
-                fontSize: { xs: "1rem", sm: "1rem", md: "1rem", lg: "1rem", xl: "1rem" },
+                fontSize: "1rem",
                 fontWeight: 500,
                 fontFamily: "Poppins, sans-serif",
                 color: "#011114",
@@ -75,13 +87,12 @@ function LatestProjectCard({ title, thumbnailImg, description }: LatestProjectPr
             </Typography>
           </Box>
 
-          {/* Description */}
           <Box sx={{ textAlign: "left" }}>
             {description.map((paragraph, idx) => (
               <Typography
                 key={idx}
                 sx={{
-                  fontSize: { xs: "0.8rem", sm: "0.8rem", md: "0.9rem", lg: "0.9rem", xl: "0.9rem" },
+                  fontSize: "0.9rem",
                   fontWeight: 400,
                   fontFamily: "Poppins, sans-serif",
                   color: "#011114",

--- a/app/home/latest-projects.module.scss
+++ b/app/home/latest-projects.module.scss
@@ -59,20 +59,29 @@
 
     @media screen and (min-width: $desktop-min) {
       display: grid;
-      grid-template-columns: repeat(3, 1fr);
+      grid-template-columns: repeat(
+        3,
+        var(--selected-work-card-width, 294px)
+      );
       gap: 2rem;
-      align-items: stretch;
+      justify-content: start;
+      align-items: start;
       width: 100%;
     }
   }
 
   .projectsGridItem {
     display: flex;
+    width: var(--selected-work-card-width, 294px);
     min-width: 0;
   }
 
   .projectsSwiper {
-    height: 440px;
+    width: 100%;
+    min-height: var(--selected-work-card-height, 390px);
+    height: auto;
+    padding-bottom: var(--selected-work-carousel-padding-bottom, 2.5rem);
+    box-sizing: border-box;
 
     @media screen and (min-width: $desktop-min) {
       display: none;
@@ -85,7 +94,7 @@
 
     :global(.swiper-slide) {
       display: flex;
-      width: 294px;
+      width: var(--selected-work-card-width, 294px);
       box-sizing: border-box;
       justify-content: center;
       height: auto;
@@ -94,18 +103,23 @@
         justify-content: flex-start;
       }
     }
+
+    :global(.swiper-pagination) {
+      bottom: 0 !important;
+    }
   }
 
   .carouselCardShell {
-    transform: scale(0.94);
+    transform: scale(var(--selected-work-carousel-inactive-scale, 0.94));
     opacity: 0.88;
+    transform-origin: center center;
     transition:
       transform 0.35s ease,
       opacity 0.35s ease;
   }
 
   .projectsSwiper :global(.swiper-slide-active) .carouselCardShell {
-    transform: scale(1);
+    transform: scale(var(--selected-work-carousel-active-scale, 1));
     opacity: 1;
   }
 }

--- a/app/home/latest-projects.module.scss
+++ b/app/home/latest-projects.module.scss
@@ -54,17 +54,67 @@
     }
   }
 
+  .projectsGrid {
+    display: none;
+
+    @media screen and (min-width: $desktop-min) {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 2rem;
+      align-items: stretch;
+      width: 100%;
+    }
+  }
+
+  .projectsGridItem {
+    display: flex;
+    min-width: 0;
+  }
+
   .projectsSwiper {
-   height: 440px;
+    height: 440px;
+
+    @media screen and (min-width: $desktop-min) {
+      display: none;
+    }
 
     :global(.swiper-wrapper) {
-      align-items: stretch;
+      align-items: center;
+      justify-content: flex-start;
     }
 
     :global(.swiper-slide) {
       display: flex;
+      width: 294px;
+      box-sizing: border-box;
       justify-content: center;
+      height: auto;
+
+      @media screen and (min-width: $tablet-min) {
+        justify-content: flex-start;
+      }
     }
+  }
+
+  .carouselCardShell {
+    transform: scale(0.94);
+    opacity: 0.88;
+    transition:
+      transform 0.35s ease,
+      opacity 0.35s ease;
+  }
+
+  .projectsSwiper :global(.swiper-slide-active) .carouselCardShell {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .latestProjectsSection .carouselCardShell {
+    transform: none !important;
+    opacity: 1 !important;
+    transition: none !important;
   }
 }
 

--- a/app/home/latest-projects.tsx
+++ b/app/home/latest-projects.tsx
@@ -94,48 +94,51 @@ function LatestProjects() {
           </span>
         </div>
 
-        <Swiper
-          className={styles.projectsSwiper}
-          centeredSlides={false}
-          slidesPerView={"auto"}
-          spaceBetween={10}
-          pagination={{ clickable: true, dynamicBullets: true }}
-          modules={[Pagination]}
-          // Breakpoints configuration
-          breakpoints={{
-            // when window width is >= 640px
-            640: {
-              slidesPerView: 1,
-              spaceBetween: 0,
-              centeredSlides: true
-            },
-            // when window width is >= 768px
-            768: {
-              slidesPerView: 2,
-              spaceBetween: 10,
-              centeredSlides: true
-            },
-            // when window width is >= 1024px
-            1024: {
-              slidesPerView: 3,
-              spaceBetween: 10,
-              centeredSlides: false
-            },
-            // when window width is >= 1280px
-            1280: {
-              slidesPerView: 3,
-              spaceBetween: 5,
-              centeredSlides: false
-            },
-        }}
-        >
+        {/* Desktop — equal grid when all 3 cards fit (≥1024px) */}
+        <div className={styles.projectsGrid}>
           {latestProjectsItems.map((item) => (
-            <SwiperSlide key={item.title}>
+            <div key={item.title} className={styles.projectsGridItem}>
               <LatestProjectCard
                 title={item.title}
                 description={item.description}
                 thumbnailImg={item.img}
+                fullWidth
               />
+            </div>
+          ))}
+        </div>
+
+        {/* Carousel when 3 cards cannot fit (<1024px) — active slide scales up */}
+        <Swiper
+          className={styles.projectsSwiper}
+          initialSlide={0}
+          centeredSlides={false}
+          slidesPerView="auto"
+          spaceBetween={16}
+          pagination={{ clickable: true, dynamicBullets: true }}
+          modules={[Pagination]}
+          breakpoints={{
+            360: {
+              slidesPerView: 1,
+              spaceBetween: 16,
+              centeredSlides: true,
+            },
+            768: {
+              slidesPerView: "auto",
+              spaceBetween: 24,
+              centeredSlides: false,
+            },
+          }}
+        >
+          {latestProjectsItems.map((item) => (
+            <SwiperSlide key={item.title}>
+              <div className={styles.carouselCardShell}>
+                <LatestProjectCard
+                  title={item.title}
+                  description={item.description}
+                  thumbnailImg={item.img}
+                />
+              </div>
             </SwiperSlide>
           ))}
         </Swiper>

--- a/app/home/latest-projects.tsx
+++ b/app/home/latest-projects.tsx
@@ -16,6 +16,7 @@ import { backgroundFloatImages } from "./background-float-images";
 import LatestProjectCard from "./LatestProjectCard";
 import { latestProjectsItems } from "./data/latestprojects-data";
 import { SectionTypewriterHeading } from "./components/SectionTypewriterHeading";
+import { selectedWorkLayoutStyle } from "./selectedWorkCardLayout";
 
 const FLOAT_COUNT = 14;
 
@@ -54,7 +55,11 @@ function LatestProjects() {
   }, []);
 
   return (
-    <section className={styles.latestProjectsSection} id="latest-projects">
+    <section
+      className={styles.latestProjectsSection}
+      id="latest-projects"
+      style={selectedWorkLayoutStyle}
+    >
       {/* Decorative floating images */}
       <div className={styles.floatLayer}>
         {floaters.map((f, i) => (
@@ -102,7 +107,6 @@ function LatestProjects() {
                 title={item.title}
                 description={item.description}
                 thumbnailImg={item.img}
-                fullWidth
               />
             </div>
           ))}

--- a/app/home/selectedWorkCardLayout.ts
+++ b/app/home/selectedWorkCardLayout.ts
@@ -1,0 +1,31 @@
+import type { CSSProperties } from "react";
+
+/** Selected Work project cards — single source of truth for dimensions. */
+export const SELECTED_WORK_CARD = {
+  widthPx: 294,
+  heightPx: 390,
+  contentPaddingPx: 20,
+} as const;
+
+/** Carousel — active slide full size; inactive slides scale down. */
+export const SELECTED_WORK_CAROUSEL = {
+  inactiveScale: 0.94,
+  activeScale: 1,
+} as const;
+
+/** Space below the carousel track for pagination + consistent section gutter. */
+export const SELECTED_WORK_CAROUSEL_GUTTER = {
+  paddingBottomRem: 2.5,
+} as const;
+
+export const selectedWorkLayoutStyle = {
+  "--selected-work-card-width": `${SELECTED_WORK_CARD.widthPx}px`,
+  "--selected-work-card-height": `${SELECTED_WORK_CARD.heightPx}px`,
+  "--selected-work-carousel-inactive-scale": String(
+    SELECTED_WORK_CAROUSEL.inactiveScale,
+  ),
+  "--selected-work-carousel-active-scale": String(
+    SELECTED_WORK_CAROUSEL.activeScale,
+  ),
+  "--selected-work-carousel-padding-bottom": `${SELECTED_WORK_CAROUSEL_GUTTER.paddingBottomRem}rem`,
+} as CSSProperties;


### PR DESCRIPTION
### Summary — LandingPage/SelectedWorkCards
Improvements to the Selected Work section on the landing page: layout, sizing, and carousel behavior across breakpoints.

**Layout & alignment**

- Desktop (≥1024px): Fixed 3-column grid with equal 294×390px cards, left-aligned with section copy (no awkward centered first card).
- Below 1024px: Swiper carousel when all three cards don’t fit; left-aligned on tablet, centered on mobile.

**Card sizing & visuals**

- selectedWorkCardLayout.ts — shared constants for card size, carousel scale, and spacing.
- Consistent card dimensions at all widths (no stretching on wide screens).
- Stable text padding (20px sides/bottom); images bleed to top/left/right card edges as before.
- Carousel scale effect only when not all cards fit: active slide full size, inactive slides slightly smaller (94% scale + fade); no scale on desktop when all three are visible.