### PR TITLE
Landing page/what i do section improvements

### DIFF
--- a/app/home/BackgroundCard.tsx
+++ b/app/home/BackgroundCard.tsx
@@ -42,67 +42,58 @@ export default function BackgroundCard({ info }: BackgroundCardProps) {
         onClose={handleClose}
         aria-labelledby="background-dialog-title"
         aria-describedby="background-dialog-description"
+        slotProps={{
+          paper: {
+            className: styles.dialogPaper,
+            sx: { position: "relative" },
+          },
+        }}
       >
-        {/* Header: icon + title */}
-        <div
-          style={{
-            position: "relative",
-            display: "flex",
-            justifyContent: "center",
-            flexDirection: "row",
-            alignItems: "center",
-            padding: "1rem 1.5rem 0",
-            gap: "1.5rem",
-          }}
-        >
+        <div className={styles.dialogCloseSlot}>
           <Tooltip title="Close">
             <IconButton
               aria-label="Close dialog"
               onClick={handleClose}
               size="small"
-              sx={{
-                position: "absolute",
-                top: 8,
-                right: 8,
-                color: "#011114",
-              }}
+              sx={{ color: "#011114" }}
             >
               <CloseIcon fontSize="small" />
             </IconButton>
           </Tooltip>
+        </div>
 
-          <div
-            style={{
-              position: "relative",
-              width: 65,
-              height: 65,
-              flexShrink: 0,
-            }}
-          >
-            <Image
-              src={img}
-              alt={title}
-              fill
-              style={{ objectFit: "contain", opacity: DIALOG_ICON_OPACITY }}
-            />
+        {/* Header: icon + title */}
+        <div className={styles.dialogHeader}>
+          <div className={styles.dialogHeaderMain}>
+            <div className={styles.dialogIcon}>
+              <Image
+                src={img}
+                alt={title}
+                fill
+                style={{ objectFit: "contain", opacity: DIALOG_ICON_OPACITY }}
+              />
+            </div>
+
+            <DialogTitle
+              id="background-dialog-title"
+              className={styles.dialogTitle}
+              sx={{
+                padding: 0,
+                margin: 0,
+                fontSize: {
+                  xs: "1.2rem",
+                  sm: "1.5rem",
+                  md: "1.6rem",
+                  lg: "1.7rem",
+                },
+                fontWeight: 500,
+                fontFamily: "Poppins, sans-serif",
+                color: "#011114",
+              }}
+            >
+              {title}
+            </DialogTitle>
           </div>
-
-          <DialogTitle
-            id="background-dialog-title"
-            sx={{
-              fontSize: {
-                xs: "1.2rem",
-                sm: "1.5rem",
-                md: "1.6rem",
-                lg: "1.7rem",
-              },
-              fontWeight: 500,
-              fontFamily: "Poppins, sans-serif",
-              color: "#011114",
-            }}
-          >
-            {title}
-          </DialogTitle>
         </div>
 
         {/* Body: paragraphs */}

--- a/app/home/BackgroundCard.tsx
+++ b/app/home/BackgroundCard.tsx
@@ -154,21 +154,8 @@ export default function BackgroundCard({ info }: BackgroundCardProps) {
         raised
       >
         <CardActionArea sx={{ height: "100%" }}>
-          {/* Icon */}
-          <div
-            style={{
-              display: "flex",
-              justifyContent: "center",
-              paddingTop: "1rem",
-            }}
-          >
-            <div
-              style={{
-                position: "relative",
-                width: 120,
-                height: 120,
-              }}
-            >
+          <div className={styles.cardIconArea}>
+            <div className={styles.cardIcon}>
               <Image
                 src={img}
                 alt={title}

--- a/app/home/BackgroundCard.tsx
+++ b/app/home/BackgroundCard.tsx
@@ -22,10 +22,6 @@ const CARD_ICON_OPACITY = 0.80;
 
 type BackgroundCardProps = {
   info: BackgroundItem;
-  dimensions?: {
-    width: string | number;
-    height: string | number;
-  };
 };
 
 export default function BackgroundCard({ info }: BackgroundCardProps) {
@@ -143,7 +139,6 @@ export default function BackgroundCard({ info }: BackgroundCardProps) {
         onClick={handleClickOpen}
         className={styles.fullHeightCard}
         sx={{
-          // width/height are controlled by SCSS via fluid-card-size mixin
           cursor: "pointer",
           borderRadius: 3,
           boxShadow: "0 4px 18px rgba(0, 0, 0, 0.08)",

--- a/app/home/background.module.scss
+++ b/app/home/background.module.scss
@@ -1,6 +1,7 @@
 .fullHeightCard {
-  @include fluid-card-size(190px, 260px, 220px, 260px); // example values
-  //max-width: 100%;
+  width: 212px;
+  height: 260px;
+  max-width: 100%;
   display: flex;
   flex-direction: column;
 }

--- a/app/home/background.module.scss
+++ b/app/home/background.module.scss
@@ -1,9 +1,35 @@
 .fullHeightCard {
-  width: 212px;
-  height: 260px;
+  width: 168px;
+  height: 206px;
   max-width: 100%;
   display: flex;
   flex-direction: column;
+
+  @media screen and (min-width: $tablet-min) {
+    width: 212px;
+    height: 260px;
+  }
+}
+
+.cardIconArea {
+  display: flex;
+  justify-content: center;
+  padding-top: 0.75rem;
+
+  @media screen and (min-width: $tablet-min) {
+    padding-top: 1rem;
+  }
+}
+
+.cardIcon {
+  position: relative;
+  width: 95px;
+  height: 95px;
+
+  @media screen and (min-width: $tablet-min) {
+    width: 120px;
+    height: 120px;
+  }
 }
 
 @media screen and #{$mobile} {

--- a/app/home/background.module.scss
+++ b/app/home/background.module.scss
@@ -32,6 +32,69 @@
   }
 }
 
+.dialogPaper {
+  position: relative;
+}
+
+.dialogCloseSlot {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.dialogHeader {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  padding: 2.75rem 16px 0;
+
+  @media screen and (min-width: $tablet-min) {
+    padding: 2.75rem 1.5rem 0;
+  }
+
+  @media screen and (min-width: $desktop-min) {
+    padding: 2.75rem 2rem 0;
+  }
+}
+
+.dialogHeaderMain {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+
+  @media screen and (min-width: $tablet-min) {
+    flex-direction: row;
+    align-items: center;
+    gap: 1.5rem;
+    width: auto;
+  }
+}
+
+.dialogIcon {
+  position: relative;
+  width: 65px;
+  height: 65px;
+  flex-shrink: 0;
+}
+
+.dialogTitle {
+  padding: 0;
+  margin: 0;
+  width: 100%;
+  text-align: center;
+
+  @media screen and (min-width: $tablet-min) {
+    width: auto;
+    text-align: left;
+  }
+}
+
 @media screen and #{$mobile} {
   .backgroundTitle {
     text-align: center;

--- a/app/home/latest-projects.module.scss
+++ b/app/home/latest-projects.module.scss
@@ -64,9 +64,15 @@
         var(--selected-work-card-width, 294px)
       );
       gap: 2rem;
-      justify-content: start;
-      align-items: start;
-      width: 100%;
+      justify-content: center;
+      align-items: center;
+      width: min(
+        100%,
+        calc(
+          var(--selected-work-card-width, 294px) * 3 + 2rem * 2
+        )
+      );
+      margin-inline: auto;
     }
   }
 
@@ -74,6 +80,33 @@
     display: flex;
     width: var(--selected-work-card-width, 294px);
     min-width: 0;
+    justify-content: center;
+    transform: scale(var(--selected-work-carousel-inactive-scale, 0.94));
+    opacity: 0.88;
+    transform-origin: center center;
+    transition:
+      transform 0.35s ease,
+      opacity 0.35s ease;
+
+  }
+
+  /* Default: first card matches carousel active slide (full size). */
+  .projectsGrid .projectsGridItem:first-child {
+    transform: scale(var(--selected-work-carousel-active-scale, 1));
+    opacity: 1;
+  }
+
+  /* Hover: emphasized card grows to active size; others shrink like inactive slides. */
+  .projectsGrid:hover .projectsGridItem {
+    transform: scale(var(--selected-work-carousel-inactive-scale, 0.94));
+    opacity: 0.88;
+  }
+
+  .projectsGrid:hover .projectsGridItem:hover {
+    transform: scale(var(--selected-work-carousel-active-scale, 1));
+    opacity: 1;
+    position: relative;
+    z-index: 1;
   }
 
   .projectsSwiper {
@@ -125,7 +158,8 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .latestProjectsSection .carouselCardShell {
+  .latestProjectsSection .carouselCardShell,
+  .latestProjectsSection .projectsGridItem {
     transform: none !important;
     opacity: 1 !important;
     transition: none !important;

--- a/app/home/my-background.module.scss
+++ b/app/home/my-background.module.scss
@@ -55,44 +55,46 @@
     gap: 5%;
 }
 
+$what-i-do-card-width: 212px;
+$what-i-do-gap-mobile: 24px;
+$what-i-do-gap-tablet: 24px;
+$what-i-do-gap-desktop: 32px;
+
 .cardsGrid {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  width: min(100%, $what-i-do-card-width);
+  margin-inline: auto;
   justify-content: center;
-  gap: 1.5rem;
+  justify-items: center;
+  gap: $what-i-do-gap-mobile;
+  grid-template-columns: minmax(0, $what-i-do-card-width);
 
-  width: 100%;
-  max-width: 1200px;
-  margin: 0 auto;   // <— center within .content
-
-  //justify-content: center;
-
-  /* Desktop */
-  @media screen and #{$desktop-device} {
-    justify-content: center;
-    flex-wrap: nowrap;
-    gap: 1rem;
-}
-
-  /* Tablet — two per row naturally */
+  /* Tablet — 2×2, 24px gap (proportional to desktop 32px) */
   @media screen and #{$tablet} {
-    gap: 1rem;
-    justify-content: center;
-    align-items: center;
+    gap: $what-i-do-gap-tablet;
+    grid-template-columns: repeat(2, minmax(0, $what-i-do-card-width));
+    width: min(
+      100%,
+      calc(#{$what-i-do-card-width} * 2 + #{$what-i-do-gap-tablet})
+    );
   }
 
-  /* Mobile */
-  @media screen and #{$mobile} {
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    flex-wrap: wrap;
-    gap: 1.5rem;
+  /* Desktop — 1×4 row, 32px gap */
+  @media screen and #{$desktop-device} {
+    gap: $what-i-do-gap-desktop;
+    grid-template-columns: repeat(4, minmax(0, $what-i-do-card-width));
+    width: min(
+      100%,
+      calc(
+        #{$what-i-do-card-width} * 4 + #{$what-i-do-gap-desktop} * 3
+      )
+    );
   }
 }
 
 .cardWrapper {
-  max-width: 340px;
+  width: $what-i-do-card-width;
+  max-width: 100%;
   opacity: 0;
   transform: translateY(24px);
   transition:

--- a/app/home/my-background.module.scss
+++ b/app/home/my-background.module.scss
@@ -55,19 +55,22 @@
     gap: 5%;
 }
 
+$what-i-do-card-width-mobile: 168px;
+$what-i-do-card-height-mobile: 206px;
 $what-i-do-card-width: 212px;
+$what-i-do-card-height: 260px;
 $what-i-do-gap-mobile: 24px;
 $what-i-do-gap-tablet: 24px;
 $what-i-do-gap-desktop: 32px;
 
 .cardsGrid {
   display: grid;
-  width: min(100%, $what-i-do-card-width);
+  width: min(100%, $what-i-do-card-width-mobile);
   margin-inline: auto;
   justify-content: center;
   justify-items: center;
   gap: $what-i-do-gap-mobile;
-  grid-template-columns: minmax(0, $what-i-do-card-width);
+  grid-template-columns: minmax(0, $what-i-do-card-width-mobile);
 
   /* Tablet — 2×2, 24px gap (proportional to desktop 32px) */
   @media screen and #{$tablet} {
@@ -93,8 +96,12 @@ $what-i-do-gap-desktop: 32px;
 }
 
 .cardWrapper {
-  width: $what-i-do-card-width;
+  width: $what-i-do-card-width-mobile;
   max-width: 100%;
+
+  @media screen and (min-width: $tablet-min) {
+    width: $what-i-do-card-width;
+  }
   opacity: 0;
   transform: translateY(24px);
   transition:

--- a/app/home/my-background.tsx
+++ b/app/home/my-background.tsx
@@ -148,13 +148,7 @@ export default function MyBackground() {
         <div className={styles.cardsGrid}>
           {backgroundItems.map((item, index) => (
             <AnimatedCardWrapper key={item.title} index={index}>
-              <BackgroundCard
-                info={item}
-                dimensions={{
-                  width: "100%",
-                  height: "260px",
-                }}
-              />
+              <BackgroundCard info={item} />
             </AnimatedCardWrapper>
           ))}
         </div>


### PR DESCRIPTION
### Summary

**What I do**

- Replaced flex layout with a CSS grid: 1 column (mobile), 2×2 (tablet), 1×4 (desktop)
- Fixed card sizes: 168×206px mobile, 212×260px tablet/desktop
- Gaps: 24px mobile/tablet, 32px desktop
- Centered the card group on screen at each breakpoint
- What I do — detail dialog
- Mobile header: icon on its own row, title below (centered)
- Close button pinned to the top-right of the dialog on all screen sizes
- Moved inline styles into background.module.scss
- Scaled down card icons on mobile (95px vs 120px)

**Selected Work**

- Desktop grid centered on screen (3 equal 294px cards)
- Hover scale effect: first card full size by default; hovering any card scales it up (like the carousel active slide); others shrink to 0.94
- Respects prefers-reduced-motion