### PR TITLE
Ar magic tours/narrative improvements

### DIFF
--- a/app/(public)/work/ar-story-teller/page.tsx
+++ b/app/(public)/work/ar-story-teller/page.tsx
@@ -7,7 +7,7 @@ import Typography from "@mui/material/Typography";
 import { ArStoryTellerPage } from "@/app/projects/ar-story-teller/ArStoryTellerPage";
 import { subscribeArStoryTellerProject } from "@/app/projects/ar-story-teller/lib/ar-story-teller.firestore";
 import { createProjectHeaderLayersReadyGate } from "@/app/projects/ar-story-teller/lib/projectHeaderLayersReady";
-import { preloadArStoryTellerCaseStudyBanner } from "@/app/projects/ar-story-teller/lib/preloadArStoryTellerAssets";
+import { preloadArStoryTellerCaseStudyBanner, preloadOverviewWaitingPeopleBackground, preloadProjectHeaderCloudLayers } from "@/app/projects/ar-story-teller/lib/preloadArStoryTellerAssets";
 import type { ViewportBand } from "@/app/projects/ar-story-teller/lib/projectHeaderPreloadUrls";
 import { LandingSplash } from "@/components/LandingSplash/LandingSplash";
 import ProjectAccessGate from "@/lib/access/ProjectAccessGate";
@@ -69,13 +69,25 @@ function ArStoryTellerRouteContent() {
   }, [viewportBand]);
 
   const bannerPreloadRef = useRef<Promise<void> | null>(null);
+  const cloudPreloadRef = useRef<Promise<void> | null>(null);
+  const overviewBgPreloadRef = useRef<Promise<void> | null>(null);
 
   useEffect(() => {
     bannerPreloadRef.current = preloadArStoryTellerCaseStudyBanner({
       projectKey,
       visibility,
     });
-  }, [projectKey, visibility]);
+    cloudPreloadRef.current = preloadProjectHeaderCloudLayers({
+      projectKey,
+      visibility,
+      viewportBand,
+    });
+    overviewBgPreloadRef.current = preloadOverviewWaitingPeopleBackground({
+      projectKey,
+      visibility,
+      viewportBand,
+    });
+  }, [projectKey, visibility, viewportBand]);
 
   useEffect(() => {
     const ready = contentReadyRef.current!;
@@ -105,8 +117,12 @@ function ArStoryTellerRouteContent() {
       headerLayersReadyRef.current.promise,
       bannerPreloadRef.current ??
         preloadArStoryTellerCaseStudyBanner({ projectKey, visibility }),
+      cloudPreloadRef.current ??
+        preloadProjectHeaderCloudLayers({ projectKey, visibility, viewportBand }),
+      overviewBgPreloadRef.current ??
+        preloadOverviewWaitingPeopleBackground({ projectKey, visibility, viewportBand }),
     ]);
-  }, [projectKey, visibility]);
+  }, [projectKey, visibility, viewportBand]);
 
   const handleSplashError = useCallback(() => {
     setHasError(true);

--- a/app/projects/ar-story-teller/ArStoryTellerPage.tsx
+++ b/app/projects/ar-story-teller/ArStoryTellerPage.tsx
@@ -4,7 +4,6 @@ import styles from './ArStoryTeller.module.scss';
 import { ProjectHeader } from './components/ProjectHeader';
 import { OverviewSection } from './components/sections/OverviewSection';
 import { TeamSection } from './components/sections/TeamSection';
-import { ProjectOverviewSection } from './components/sections/ProjectOverviewSection';
 import { CaseStudyOverviewSection } from './components/sections/CaseStudyOverviewSection';
 import { DesignSystemSection } from './sections/DesignSystemSection';
 import ConclusionsAndImpactSection from './components/sections/ConclusionsAndImpactSection';
@@ -15,7 +14,7 @@ import {
   defaultHeaderState,
   headerState,
 } from "@/components/Header/HeaderState";
-import { AR_STORY_TELLER_HEADER_LOGO } from "./headerTheme";
+import { AR_STORY_TELLER_HEADER_THEME } from "./headerTheme";
 import type { ArStoryTellerContent } from '@/app/projects/ar-story-teller/types/arStoryTellerContent';
 import BusinessGoals from './components/sections/BusinessGoals';
 import {
@@ -96,10 +95,7 @@ export function ArStoryTellerPage({
   useEffect(() => {
     setLayoutState({ isFullWidth: true });
     setHeaderState({
-      position: "absolute",
-      isDark: true,
-      logoPrimaryColor: "#D3D3D3",
-      logoAccentColor: AR_STORY_TELLER_HEADER_LOGO.accent,
+      ...AR_STORY_TELLER_HEADER_THEME,
     });
 
     return () => {
@@ -123,7 +119,6 @@ export function ArStoryTellerPage({
             }}
           />
           <BusinessGoals data={projectData.businessGoals} />
-          <ProjectOverviewSection data={{ projectOverview: projectData.projectOverview }} />
           <TeamSection data={{ team: projectData.team }} />
           <CaseStudyOverviewSection data={{ caseStudy: projectData.caseStudy }} />
           <DesignSystemSection data={{ caseStudy: projectData.caseStudy }} />

--- a/app/projects/ar-story-teller/_typography.scss
+++ b/app/projects/ar-story-teller/_typography.scss
@@ -12,7 +12,7 @@ $ar-st-body-font: var(--font-source-sans-3), "Source Sans 3", system-ui, sans-se
     font-family: $ar-st-body-font;
     font-style: normal;
     font-weight: 400;
-    line-height: 1.35;
+    line-height: 1.4;
 }
 
 @mixin ar-st-title-type($weight: 700) {

--- a/app/projects/ar-story-teller/components/ARMobileScreen.scss
+++ b/app/projects/ar-story-teller/components/ARMobileScreen.scss
@@ -42,7 +42,7 @@
             text-align: center;
             margin-bottom: 1rem;
             @include typo.ar-st-title-type(600);
-            font-size: 22px;
+            font-size: 24px;
             padding-top: 2rem;
         }
 
@@ -50,7 +50,7 @@
             padding-left: 15%;
             padding-right: 15%;
             @include typo.ar-st-body-type;
-            font-size: 18px;
+            font-size: 20px;
         }
     }
 }
@@ -69,14 +69,14 @@
             margin-bottom: 1rem;
             text-align: center;
             @include typo.ar-st-title-type(600);
-            font-size: 20px;
+            font-size: 22px;
         }
 
         .description {
             padding-left: 15%;
             padding-right: 15%;
             @include typo.ar-st-body-type;
-            font-size: 17px;
+            font-size: 18px;
         }
     }
 }

--- a/app/projects/ar-story-teller/components/ContextNotifications.tsx
+++ b/app/projects/ar-story-teller/components/ContextNotifications.tsx
@@ -5,7 +5,7 @@ import ArrowBackIosNewIcon from "@mui/icons-material/ArrowBackIosNew";
 import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
 import { Box, Container, IconButton, Stack, Typography } from "@mui/material";
 import ProjectImage from "@/lib/media/ProjectImage";
-import { getUsableLayoutWidth, PANEL_BLOCK_PADDINGS, LAYOUT_DIMENSIONS, cssLengthToPx } from "../layoutConfig";
+import { getUsableLayoutWidth, getPanelInnerWidthPx, PANEL_BLOCK_PADDINGS, LAYOUT_DIMENSIONS, cssLengthToPx } from "../layoutConfig";
 import { breakpointMediaQuery, breakpointPx } from "@/lib/responsive/breakpoints";
 import { bodyTypeSx } from "../typography";
 
@@ -15,20 +15,21 @@ import { bodyTypeSx } from "../typography";
    component looking right if it's ever rendered outside the page wrapper. */
 const CONTEXT_NOTIFICATIONS_MAX_WIDTH = getUsableLayoutWidth("desktop");
 const CONTEXT_NOTIFICATIONS_DESKTOP_STACK_GAP_PX = 64;
-const CONTEXT_NOTIFICATIONS_DESKTOP_COLUMN_MAX_WIDTH = `${
-  (getUsableLayoutWidth("desktop") -
-    CONTEXT_NOTIFICATIONS_DESKTOP_STACK_GAP_PX) /
-  2
-}px`;
+/** Desktop row split: text ~40%, image ~60% (text column ~20% narrower than 50/50). */
+const CONTEXT_NOTIFICATIONS_TEXT_COLUMN_FLEX = 2;
+const CONTEXT_NOTIFICATIONS_IMAGE_COLUMN_FLEX = 3;
 
-/** Notification mockup: `next/image` uses 400×323; layout caps below.
- *  - Mobile: fluid, full width of padded panel.
- *  - Tablet: max 360px wide (~90% of desktop) for stacked layout.
- *  - Desktop: 400×323 display. */
-const NOTIFICATION_IMAGE_INTRINSIC_WIDTH = 400;
-const NOTIFICATION_IMAGE_INTRINSIC_HEIGHT = 323;
-const NOTIFICATION_IMAGE_MAX_WIDTH_DESKTOP_PX = 400;
-const NOTIFICATION_IMAGE_MAX_WIDTH_TABLET_PX = 360;
+/** Notification carousel frames are 16:9 (uploaded assets: 1024×573). */
+const NOTIFICATION_IMAGE_ASPECT_RATIO = "16 / 9";
+const NOTIFICATION_IMAGE_MAX_WIDTH_DESKTOP_PX = Math.round(
+  ((getPanelInnerWidthPx("desktop", CONTEXT_NOTIFICATIONS_MAX_WIDTH) -
+    CONTEXT_NOTIFICATIONS_DESKTOP_STACK_GAP_PX) *
+    CONTEXT_NOTIFICATIONS_IMAGE_COLUMN_FLEX) /
+    (CONTEXT_NOTIFICATIONS_TEXT_COLUMN_FLEX +
+      CONTEXT_NOTIFICATIONS_IMAGE_COLUMN_FLEX),
+);
+
+const NOTIFICATION_IMAGE_BORDER_RADIUS_PX = 15;
 
 const NOTIFICATION_CAROUSEL_INTERVAL_MS = 3500;
 
@@ -39,9 +40,10 @@ const NOTIFICATION_IMAGE_SIZES = [
   `(max-width: ${breakpointPx.mobileMax}px) calc(100vw - ${
     cssLengthToPx(LAYOUT_DIMENSIONS.mobile.margin) * 2
   }px)`,
-  `(max-width: ${breakpointPx.tabletMax}px) min(calc(100vw - ${
-    cssLengthToPx(LAYOUT_DIMENSIONS.tablet.margin) * 2
-  }px), ${NOTIFICATION_IMAGE_MAX_WIDTH_TABLET_PX}px)`,
+  `(max-width: ${breakpointPx.tabletMax}px) calc(100vw - ${
+    cssLengthToPx(LAYOUT_DIMENSIONS.tablet.margin) * 2 +
+    cssLengthToPx(PANEL_BLOCK_PADDINGS.x.tablet) * 2
+  }px)`,
   `${NOTIFICATION_IMAGE_MAX_WIDTH_DESKTOP_PX}px`,
 ].join(", ");
 
@@ -149,7 +151,8 @@ export const ContextualNotifications = ({
               width: "100%",
               maxWidth: "100%",
               [DESKTOP_BREAKPOINT_MQ]: {
-                maxWidth: CONTEXT_NOTIFICATIONS_DESKTOP_COLUMN_MAX_WIDTH,
+                flex: `${CONTEXT_NOTIFICATIONS_TEXT_COLUMN_FLEX} 1 0`,
+                minWidth: 0,
               },
             }}
           >
@@ -165,42 +168,34 @@ export const ContextualNotifications = ({
           </Stack>
           <Stack
             spacing={3}
-            alignItems="center"
+            alignItems="stretch"
             sx={{
               flex: 1,
               width: "100%",
               maxWidth: "100%",
-              alignSelf: "center",
               [DESKTOP_BREAKPOINT_MQ]: {
-                maxWidth: CONTEXT_NOTIFICATIONS_DESKTOP_COLUMN_MAX_WIDTH,
-                alignSelf: "auto",
+                flex: `${CONTEXT_NOTIFICATIONS_IMAGE_COLUMN_FLEX} 1 0`,
+                minWidth: 0,
               },
             }}
           >
             {currentImage ? (
               <Box
                 sx={{
+                  position: "relative",
                   width: "100%",
-                  maxWidth: "100%",
-                  [TABLET_STACKED_MQ]: {
-                    maxWidth: NOTIFICATION_IMAGE_MAX_WIDTH_TABLET_PX,
-                    width: `min(100%, ${NOTIFICATION_IMAGE_MAX_WIDTH_TABLET_PX}px)`,
-                  },
-                  [DESKTOP_BREAKPOINT_MQ]: {
-                    maxWidth: NOTIFICATION_IMAGE_MAX_WIDTH_DESKTOP_PX,
-                  },
+                  aspectRatio: NOTIFICATION_IMAGE_ASPECT_RATIO,
+                  borderRadius: `${NOTIFICATION_IMAGE_BORDER_RADIUS_PX}px`,
+                  overflow: "hidden",
                 }}
               >
-                {/* `width` / `height` = intrinsic aspect for next/image; rendered width is
-                    the parent `Box`. `sizes` guides srcset when `unoptimized={false}` (public Storage). */}
                 <ProjectImage
                   objectPath={currentImage}
                   alt={`${alt} ${currentImageIndex + 1}`}
-                  width={NOTIFICATION_IMAGE_INTRINSIC_WIDTH}
-                  height={NOTIFICATION_IMAGE_INTRINSIC_HEIGHT}
+                  fill
                   sizes={NOTIFICATION_IMAGE_SIZES}
-                  unoptimized={false}
-                  style={{ display: "block", width: "100%", height: "auto" }}
+                  unoptimized
+                  style={{ objectFit: "cover" }}
                 />
               </Box>
             ) : null}

--- a/app/projects/ar-story-teller/components/IllustrationDiagram.scss
+++ b/app/projects/ar-story-teller/components/IllustrationDiagram.scss
@@ -12,7 +12,7 @@
 
     span {
         @include typo.ar-st-body-type;
-        font-size: 16px;
+        font-size: 17px;
         font-weight: 500;
     }
 
@@ -33,7 +33,7 @@
         width: 50%;
         padding-top: 1rem;
         @include typo.ar-st-body-type;
-        font-size: 20px;
+        font-size: 22px;
     }
 }
 
@@ -78,14 +78,14 @@
 
     .illustration-title {
         @include typo.ar-st-title-type(600);
-        font-size: 20px;
+        font-size: 22px;
     }
 
     .text-description {
         width: 80%;
         padding-top: 1rem;
         @include typo.ar-st-body-type;
-        font-size: 20px;
+        font-size: 22px;
     }
 }
 

--- a/app/projects/ar-story-teller/components/OverviewParagraphBlock.scss
+++ b/app/projects/ar-story-teller/components/OverviewParagraphBlock.scss
@@ -6,12 +6,25 @@
     gap: var(--title-content-gap);
 }
 
+@mixin overview-background {
+    background-image: var(--overview-bg-image);
+    background-repeat: no-repeat;
+    background-position: center center;
+    background-size: contain;
+}
+
+.overview-paragraph-block {
+    @include overview-background;
+}
+
 @media #{$desktop} {
-    .project-summary {
+    .overview-paragraph-block--desktop {
         margin-top: 200px;
+        /* Room for the Ferris wheel + crowd silhouette at `contain` scale. */
+        min-height: clamp(480px, 52vw, 720px);
     }
 
-    .project-summary .project-summary-container {
+    .overview-paragraph-block--desktop .project-summary-container {
         .storyteller-laptoplg-content-left {
             @include overview-content-column;
             justify-content: flex-start;
@@ -41,6 +54,10 @@
 }
 
 @media #{$tablet} {
+    .overview-paragraph-block--tablet {
+        min-height: clamp(420px, 70vw, 640px);
+    }
+
     .project-summary-container {
         padding-top: 4rem;
         margin: auto;
@@ -55,6 +72,10 @@
 }
 
 @media #{$mobile} {
+    .overview-paragraph-block--mobile {
+        min-height: clamp(360px, 95vw, 520px);
+    }
+
     .storyteller-mobile-paragraph-container {
         max-width: 428px;
         padding-top: 4rem;

--- a/app/projects/ar-story-teller/components/OverviewParagraphBlock.tsx
+++ b/app/projects/ar-story-teller/components/OverviewParagraphBlock.tsx
@@ -1,10 +1,11 @@
+'use client';
+
 import React from 'react';
 import './OverviewParagraphBlock.scss';
 import { SectionTitle } from './SectionTitle';
 import ParagraphText from './ParagraphText';
-import WaitingPeopleDesktop from '../Images/WaitingPeople-DesktopLg.png';
-import WaitingPeopleLgMd from '../Images/WaitingPeople-LgMd.png';
-import WaitingPeopleSMSX from '../Images/WaitingPeople-SMSX.png';
+import { OVERVIEW_WAITING_PEOPLE_OBJECT_PATHS } from '../lib/projectHeaderAssets';
+import { useProjectMediaUrl } from '@/lib/media/useProjectMediaUrl';
 import { useResponsive } from '@/lib/responsive/ResponsiveQueryProvider';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -27,6 +28,14 @@ function OverviewBody({ paragraphs }: { paragraphs: string[] }) {
     );
 }
 
+function overviewBackgroundStyle(url: string | null): React.CSSProperties | undefined {
+    if (!url) return undefined;
+
+    return {
+        ['--overview-bg-image' as string]: `url(${url})`,
+    };
+}
+
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function OverviewParagraphBlock({
@@ -35,18 +44,20 @@ export function OverviewParagraphBlock({
     ...props
 }: OverviewParagraphBlockProps) {
     const screenDevice = useResponsive();
+    const backgroundObjectPath = screenDevice.isMobile
+        ? OVERVIEW_WAITING_PEOPLE_OBJECT_PATHS.mobile
+        : screenDevice.isTablet
+          ? OVERVIEW_WAITING_PEOPLE_OBJECT_PATHS.tablet
+          : OVERVIEW_WAITING_PEOPLE_OBJECT_PATHS.desktop;
+    const { url: backgroundUrl } = useProjectMediaUrl(backgroundObjectPath);
+    const backgroundStyle = overviewBackgroundStyle(backgroundUrl);
 
     if (screenDevice.isDesktopOrLaptop) {
         return (
             <div
                 {...props}
-                className="project-summary"
-                style={{
-                    backgroundImage: `url(${WaitingPeopleDesktop.src})`,
-                    backgroundRepeat: 'no-repeat',
-                    backgroundPosition: 'center top 10%',
-                    backgroundSize: '60%',
-                }}
+                className="overview-paragraph-block overview-paragraph-block--desktop"
+                style={backgroundStyle}
             >
                 <div className="project-summary-container">
                     <div className="storyteller-laptoplg-content-left">
@@ -66,11 +77,8 @@ export function OverviewParagraphBlock({
         return (
             <div
                 {...props}
-                style={{
-                    backgroundImage: `url(${WaitingPeopleLgMd.src})`,
-                    backgroundRepeat: 'no-repeat',
-                    backgroundPosition: 'center center',
-                }}
+                className="overview-paragraph-block overview-paragraph-block--tablet"
+                style={backgroundStyle}
             >
                 <div className="project-summary-container">
                     <div className="content">
@@ -90,11 +98,8 @@ export function OverviewParagraphBlock({
         return (
             <div
                 {...props}
-                style={{
-                    backgroundImage: `url(${WaitingPeopleSMSX.src})`,
-                    backgroundRepeat: 'no-repeat',
-                    backgroundSize: 'auto',
-                }}
+                className="overview-paragraph-block overview-paragraph-block--mobile"
+                style={backgroundStyle}
             >
                 <div className="storyteller-mobile-paragraph-container">
                     <div className="storyteller-mobile-content">

--- a/app/projects/ar-story-teller/components/ParagraphBlock.scss
+++ b/app/projects/ar-story-teller/components/ParagraphBlock.scss
@@ -4,6 +4,16 @@
     text-align: center;
 }
 
+.paragraph-block__read-more {
+    font-size: 16px;
+}
+
+@media #{$tablet} {
+    .paragraph-block__read-more {
+        font-size: 18px;
+    }
+}
+
 .paragraph-block__subtitle {
     padding-top: 1.5rem;
     padding-bottom: 0.5rem;

--- a/app/projects/ar-story-teller/components/ParagraphBlock.tsx
+++ b/app/projects/ar-story-teller/components/ParagraphBlock.tsx
@@ -29,7 +29,8 @@ function ReadMoreButton({ onClick, isShowingFull = false }: ReadMoreButtonProps)
     return (
         <button
             onClick={onClick}
-            style={{ color: '#00577F', fontSize: '1rem' }}
+            style={{ color: '#00577F' }}
+            className="paragraph-block__read-more"
         >
             {isShowingFull ? 'Show less' : 'Read more ...'}
         </button>

--- a/app/projects/ar-story-teller/components/ParagraphImg.scss
+++ b/app/projects/ar-story-teller/components/ParagraphImg.scss
@@ -73,11 +73,11 @@
         }
 
         &__title {
-            @include paragraph-img-title-type(20px);
+            @include paragraph-img-title-type(22px);
         }
 
         &__description {
-            @include paragraph-img-description-type(20px);
+            @include paragraph-img-description-type(22px);
             text-align: left;
             padding-left: 10%;
             padding-right: 10%;
@@ -92,11 +92,11 @@
         }
 
         &__title {
-            @include paragraph-img-title-type(20px);
+            @include paragraph-img-title-type(22px);
         }
 
         &__description {
-            @include paragraph-img-description-type(20px);
+            @include paragraph-img-description-type(22px);
             padding-left: 15%;
             padding-right: 15%;
         }

--- a/app/projects/ar-story-teller/components/ParagraphText.scss
+++ b/app/projects/ar-story-teller/components/ParagraphText.scss
@@ -19,7 +19,7 @@
     .st-paragraph-text {
         margin: auto;
         width: 100%;
-        @include paragraph-text-type(20px);
+        @include paragraph-text-type(22px);
     }
 }
 
@@ -27,7 +27,7 @@
     .st-paragraph-text {
         margin: auto;
         width: 100%;
-        @include paragraph-text-type(20px);
+        @include paragraph-text-type(22px);
     }
 }
 

--- a/app/projects/ar-story-teller/components/ProjectHeader.scss
+++ b/app/projects/ar-story-teller/components/ProjectHeader.scss
@@ -123,7 +123,7 @@
 
 @media #{$desktop} {
   .storyteller-banner__hero .banner-text-subtitle {
-    max-width: 65%;
+    max-width: 70%;
     text-align: left;
   }
 }
@@ -139,7 +139,7 @@
 
     .storyteller-banner {
         /* Tweak vertical offset of hero copy; does not use `position: relative`. */
-        --banner-titles-overlay-top: -60%;
+        --banner-titles-overlay-top: -45%;
 
         .banner-titles {
             top: var(--banner-titles-overlay-top);

--- a/app/projects/ar-story-teller/components/ProjectHeader.scss
+++ b/app/projects/ar-story-teller/components/ProjectHeader.scss
@@ -164,7 +164,7 @@
                 font-family: typo.$ar-st-title-font;
                 font-size: 24px;
                 color: typo.$ar-st-hero-subtitle-color;
-                font-weight: 600;
+                font-weight: 550;
                 max-width: 65%;
             }
         }

--- a/app/projects/ar-story-teller/components/ProjectHeader.tsx
+++ b/app/projects/ar-story-teller/components/ProjectHeader.tsx
@@ -2,22 +2,22 @@
 import { useCallback, useEffect, useRef, type CSSProperties, type RefObject } from 'react';
 import './ProjectHeader.scss';
 import { PROJECT_HEADER_LAYER_COUNT } from '../lib/projectHeaderLayersReady';
-import CloudsLayer1 from '../Images/cloud-1.png';
-import CloudsLayer2 from '../Images/cloud-2.png';
-import CloudsLayer3 from '../Images/cloud-3.png';
-import CloudsLayer4 from '../Images/cloud-4.png';
-import CloudsLayerMobile1 from '../Images/clouds-layer-1.png';
-import CloudsLayerMobile2 from '../Images/clouds-layer-2.png';
-import CloudsLayerMobile3 from '../Images/clouds-layer-3.png';
-import CloudsLayerMobile4 from '../Images/clouds-layer-4.png';
-import CrowdsWaitingDesktop from '../Images/CrowdsWaiting-Desktop.png';
+import {
+  PROJECT_HEADER_CROWD_OBJECT_PATH,
+  PROJECT_HEADER_DESKTOP_CLOUD_OBJECT_PATHS,
+  PROJECT_HEADER_MOBILE_CLOUD_OBJECT_PATHS,
+} from '../lib/projectHeaderAssets';
+import ProjectImage from '@/lib/media/ProjectImage';
 import {
   Parallax,
   ParallaxBanner,
   ParallaxBannerLayer,
 } from 'react-scroll-parallax';
 import { useResponsive } from '@/lib/responsive/ResponsiveQueryProvider';
-import Image, { StaticImageData } from 'next/image';
+
+/** Intrinsic dimensions of `CrowdsWaiting-Desktop.png` in Storage. */
+const CROWD_IMAGE_INTRINSIC_WIDTH = 1628;
+const CROWD_IMAGE_INTRINSIC_HEIGHT = 875;
 
 function useReportImageReady(
   containerRef: RefObject<HTMLDivElement | null>,
@@ -70,7 +70,7 @@ function useReportImageReady(
 }
 
 type ParallaxCloudLayerProps = {
-  src: StaticImageData;
+  objectPath: string;
   alt: string;
   speed: number;
   onLayerReady?: () => void;
@@ -90,7 +90,7 @@ type ParallaxCloudLayerProps = {
 };
 
 function ParallaxCloudLayer({
-  src,
+  objectPath,
   alt,
   speed,
   onLayerReady,
@@ -103,7 +103,7 @@ function ParallaxCloudLayer({
   initialTop,
 }: ParallaxCloudLayerProps) {
   const layerRef = useRef<HTMLDivElement>(null);
-  useReportImageReady(layerRef, onLayerReady, src.src);
+  useReportImageReady(layerRef, onLayerReady, objectPath);
 
   /* Inline top/height so extra lift always wins (CSS var-only overrides were flaky in some cases). */
   const shiftStyle: CSSProperties | undefined =
@@ -137,8 +137,8 @@ function ParallaxCloudLayer({
           className="project-header-parallax__layer-shift"
           style={shiftStyle}
         >
-          <Image
-            src={src}
+          <ProjectImage
+            objectPath={objectPath}
             alt={alt}
             fill
             sizes="100vw"
@@ -164,7 +164,7 @@ function PeopleInLineCrowd({
   initialTop?: CSSProperties['marginTop'];
 }) {
   const crowdRef = useRef<HTMLDivElement>(null);
-  useReportImageReady(crowdRef, onLayerReady, CrowdsWaitingDesktop.src);
+  useReportImageReady(crowdRef, onLayerReady, PROJECT_HEADER_CROWD_OBJECT_PATH);
 
   const stripStyle: CSSProperties | undefined =
     initialTop != null ? { marginTop: initialTop } : undefined;
@@ -173,12 +173,12 @@ function PeopleInLineCrowd({
     <div className="people-in-line" style={stripStyle}>
       <Parallax speed={speed} className="people-in-line__parallax">
         <div ref={crowdRef}>
-          <Image
+          <ProjectImage
             className="people-in-line__crowd"
             alt="Crowds waiting in line"
-            src={CrowdsWaitingDesktop}
-            width={1600}
-            height={900}
+            objectPath={PROJECT_HEADER_CROWD_OBJECT_PATH}
+            width={CROWD_IMAGE_INTRINSIC_WIDTH}
+            height={CROWD_IMAGE_INTRINSIC_HEIGHT}
             priority
           />
         </div>
@@ -248,7 +248,7 @@ function ProjectHeaderDesktop({ onLayerReady }: HeaderVariantProps) {
         <BannerTitles />
         <ParallaxBanner className="project-header-parallax">
           <ParallaxCloudLayer
-            src={CloudsLayer4}
+            objectPath={PROJECT_HEADER_DESKTOP_CLOUD_OBJECT_PATHS.layer4}
             alt="Clouds Layer 4"
             speed={12}
             onLayerReady={onLayerReady}
@@ -256,7 +256,7 @@ function ProjectHeaderDesktop({ onLayerReady }: HeaderVariantProps) {
             objectPosition="center 15%"
           />
           <ParallaxCloudLayer
-            src={CloudsLayer3}
+            objectPath={PROJECT_HEADER_DESKTOP_CLOUD_OBJECT_PATHS.layer3}
             alt="Clouds Layer 3"
             speed={8}
             onLayerReady={onLayerReady}
@@ -264,16 +264,16 @@ function ProjectHeaderDesktop({ onLayerReady }: HeaderVariantProps) {
             objectPosition="center 17%"
           />
           <ParallaxCloudLayer
-            src={CloudsLayer2}
+            objectPath={PROJECT_HEADER_DESKTOP_CLOUD_OBJECT_PATHS.layer2}
             alt="Clouds Layer 2"
-            speed={3}
+            speed={1}
             onLayerReady={onLayerReady}
             layerLiftPx={150}
             objectFit="contain"
             objectPosition="center 28%"
           />
           <ParallaxCloudLayer
-            src={CloudsLayer1}
+            objectPath={PROJECT_HEADER_DESKTOP_CLOUD_OBJECT_PATHS.layer1}
             alt="Clouds Layer 1"
             speed={-3}
             onLayerReady={onLayerReady}
@@ -282,7 +282,7 @@ function ProjectHeaderDesktop({ onLayerReady }: HeaderVariantProps) {
           />
         </ParallaxBanner>
       </div>
-      <PeopleInLineCrowd initialTop="-30%" speed={32} onLayerReady={onLayerReady} />
+      <PeopleInLineCrowd initialTop="-35%" speed={12} onLayerReady={onLayerReady} />
     </div>
   );
 }
@@ -294,26 +294,26 @@ function ProjectHeaderTablet({ onLayerReady }: HeaderVariantProps) {
         <BannerTitles />
         <ParallaxBanner className="project-header-parallax">
           <ParallaxCloudLayer
-            src={CloudsLayer4}
+            objectPath={PROJECT_HEADER_DESKTOP_CLOUD_OBJECT_PATHS.layer4}
             alt="Clouds Layer 4"
             speed={4}
             onLayerReady={onLayerReady}
           />
           <ParallaxCloudLayer
-            src={CloudsLayer3}
+            objectPath={PROJECT_HEADER_DESKTOP_CLOUD_OBJECT_PATHS.layer3}
             alt="Clouds Layer 3"
             speed={2}
             onLayerReady={onLayerReady}
             layerLiftPx={50}
           />
           <ParallaxCloudLayer
-            src={CloudsLayer2}
+            objectPath={PROJECT_HEADER_DESKTOP_CLOUD_OBJECT_PATHS.layer2}
             alt="Clouds Layer 2"
             speed={0}
             onLayerReady={onLayerReady}
           />
           <ParallaxCloudLayer
-            src={CloudsLayer1}
+            objectPath={PROJECT_HEADER_DESKTOP_CLOUD_OBJECT_PATHS.layer1}
             alt="Clouds Layer 1"
             speed={-2}
             onLayerReady={onLayerReady}
@@ -335,7 +335,7 @@ function ProjectHeaderMobile({ onLayerReady }: HeaderVariantProps) {
         <BannerTitles />
         <ParallaxBanner className="project-header-parallax">
           <ParallaxCloudLayer
-            src={CloudsLayerMobile4}
+            objectPath={PROJECT_HEADER_MOBILE_CLOUD_OBJECT_PATHS.layer4}
             alt="Clouds Layer Mobile 4"
             speed={4}
             onLayerReady={onLayerReady}
@@ -343,7 +343,7 @@ function ProjectHeaderMobile({ onLayerReady }: HeaderVariantProps) {
             initialTop="15%"
           />
           <ParallaxCloudLayer
-            src={CloudsLayerMobile3}
+            objectPath={PROJECT_HEADER_MOBILE_CLOUD_OBJECT_PATHS.layer3}
             alt="Clouds Layer Mobile 3"
             speed={0}
             onLayerReady={onLayerReady}
@@ -352,7 +352,7 @@ function ProjectHeaderMobile({ onLayerReady }: HeaderVariantProps) {
             initialTop="12%"
           />
           <ParallaxCloudLayer
-            src={CloudsLayerMobile2}
+            objectPath={PROJECT_HEADER_MOBILE_CLOUD_OBJECT_PATHS.layer2}
             alt="Clouds Layer Mobile 2"
             speed={-2}
             onLayerReady={onLayerReady}
@@ -360,7 +360,7 @@ function ProjectHeaderMobile({ onLayerReady }: HeaderVariantProps) {
             initialTop="15%"
           />
           <ParallaxCloudLayer
-            src={CloudsLayerMobile1}
+            objectPath={PROJECT_HEADER_MOBILE_CLOUD_OBJECT_PATHS.layer1}
             alt="Clouds Layer Mobile 1"
             speed={-4}
             onLayerReady={onLayerReady}

--- a/app/projects/ar-story-teller/components/PrototypingMethodPanel.tsx
+++ b/app/projects/ar-story-teller/components/PrototypingMethodPanel.tsx
@@ -177,10 +177,7 @@ function CopyImageSplitLayout({
           }}
         >
           {hasAccordion && accordionSections ? (
-            <PanelAccordionList
-              items={accordionSections}
-              bodyMaxWidthDesktop={360}
-            />
+            <PanelAccordionList items={accordionSections} />
           ) : (
             <ParagraphBlock paragraphs={paragraphs} />
           )}

--- a/app/projects/ar-story-teller/components/SectionVideo.scss
+++ b/app/projects/ar-story-teller/components/SectionVideo.scss
@@ -25,12 +25,12 @@
     }
 
     .title {
-        @include video-title-type(26px);
+        @include video-title-type(28px);
         padding-top: 6rem;
     }
 
     .description {
-        @include video-description-type(20px);
+        @include video-description-type(22px);
         padding-top: 3rem;
     }
 }
@@ -43,13 +43,13 @@
     justify-content: center;
 
     .title {
-        @include video-title-type(24px);
+        @include video-title-type(26px);
         padding-top: 2rem;
         padding-bottom: 1rem;
     }
 
     .description {
-        @include video-description-type(20px);
+        @include video-description-type(22px);
     }
 }
 

--- a/app/projects/ar-story-teller/components/Storyboard.module.scss
+++ b/app/projects/ar-story-teller/components/Storyboard.module.scss
@@ -15,14 +15,14 @@
 @media (min-width: 768px) {
   .heading {
     text-align: left;
-    font-size: 24px;
+    font-size: 26px;
     margin-bottom: 32px;
   }
 }
 
 @media (min-width: 1024px) {
   .heading {
-    font-size: 26px;
+    font-size: 28px;
   }
 }
 
@@ -130,21 +130,21 @@
 
 @media (min-width: 768px) {
   .slideTitle {
-    font-size: 20px;
-  }
-
-  .slideDescription {
-    font-size: 17px;
-  }
-}
-
-@media (min-width: 1024px) {
-  .slideTitle {
     font-size: 22px;
   }
 
   .slideDescription {
     font-size: 18px;
+  }
+}
+
+@media (min-width: 1024px) {
+  .slideTitle {
+    font-size: 24px;
+  }
+
+  .slideDescription {
+    font-size: 20px;
   }
 }
 

--- a/app/projects/ar-story-teller/components/SubTitle.scss
+++ b/app/projects/ar-story-teller/components/SubTitle.scss
@@ -14,13 +14,13 @@
 .desktop-subtitle-container {
     max-width: 2500px;
     margin: auto;
-    @include subtitle-label-type(22px);
+    @include subtitle-label-type(24px);
 }
 
 .lgmd-subtitle-container {
     max-width: 1366px;
     margin: auto;
-    @include subtitle-label-type(20px);
+    @include subtitle-label-type(22px);
 }
 
 .xssm-subtitle-container {

--- a/app/projects/ar-story-teller/components/SubTitle1.scss
+++ b/app/projects/ar-story-teller/components/SubTitle1.scss
@@ -15,7 +15,7 @@
     .st-subtitle1-container {
         padding-top: 5rem;
         padding-bottom: 1.5rem;
-        @include subtitle1-label(26px);
+        @include subtitle1-label(28px);
     }
 }
 
@@ -23,7 +23,7 @@
     .st-subtitle1-container {
         margin: auto;
         padding-top: 3rem;
-        @include subtitle1-label(24px);
+        @include subtitle1-label(26px);
 
         .subtitle-paragraph {
             padding-top: 1.25rem;

--- a/app/projects/ar-story-teller/components/SubTitle2.scss
+++ b/app/projects/ar-story-teller/components/SubTitle2.scss
@@ -15,14 +15,14 @@
     .st-subtitle2-container {
         padding-top: 3rem;
         padding-bottom: 1.5rem;
-        @include subtitle2-label(26px);
+        @include subtitle2-label(28px);
     }
 }
 
 @media #{$tablet} {
     .st-subtitle2-container {
         padding-top: 3rem;
-        @include subtitle2-label(24px);
+        @include subtitle2-label(26px);
     }
 }
 

--- a/app/projects/ar-story-teller/components/Team.tsx
+++ b/app/projects/ar-story-teller/components/Team.tsx
@@ -3,6 +3,7 @@ import { SectionTitle } from "./SectionTitle";
 import { PANEL_BLOCK_PADDINGS } from "../layoutConfig";
 import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
 import type { TeamData, TeamMember } from "@/app/projects/ar-story-teller/types/arStoryTellerContent";
+import { overviewNarrativeBlockSx } from "../overviewNarrativeLayout";
 import { bodyTypeSx } from "../typography";
 import styles from "../ArStoryTeller.module.scss";
 
@@ -102,7 +103,12 @@ const Team = ({ data }: TeamProps) => {
   const memberRows = chunkRowPairs(members);
 
   return (
-    <section aria-labelledby={headingId} className={styles['panel-subsection']}>
+    <Box
+      component="section"
+      aria-labelledby={headingId}
+      className={styles['panel-subsection']}
+      sx={overviewNarrativeBlockSx}
+    >
       <SectionTitle id={headingId} title={title} />
       <Box
         sx={{
@@ -158,7 +164,7 @@ const Team = ({ data }: TeamProps) => {
           ))}
         </Stack>
       </Box>
-    </section>
+    </Box>
   );
 };
 

--- a/app/projects/ar-story-teller/components/TitleParagraph.scss
+++ b/app/projects/ar-story-teller/components/TitleParagraph.scss
@@ -14,7 +14,7 @@
         padding-top: 8rem;
         padding-bottom: 1.25rem;
         text-align: center;
-        @include title-paragraph-label(26px);
+        @include title-paragraph-label(28px);
 
         .title-paragraph {
             padding-top: 20px;
@@ -27,7 +27,7 @@
     .storyteller-lgmd-paragraph-title {
         margin: auto;
         padding-top: 3rem;
-        @include title-paragraph-label(24px);
+        @include title-paragraph-label(26px);
 
         .title-paragraph {
             padding-top: 1.5rem;

--- a/app/projects/ar-story-teller/components/main-demo/MainDemo.module.scss
+++ b/app/projects/ar-story-teller/components/main-demo/MainDemo.module.scss
@@ -47,7 +47,6 @@
 
 @media (min-width: 768px) {
     .canvas {
-        max-width: 900px;
         --iphone-frame-width: clamp(161px, 23%, 242px);
         --iphone-frame-left: 42%;
     }
@@ -55,7 +54,6 @@
 
 @media (min-width: 1024px) {
     .canvas {
-        max-width: 1100px;
         --iphone-frame-width: clamp(184px, 21%, 253px);
     }
 }

--- a/app/projects/ar-story-teller/components/main-demo/MainDemo.tsx
+++ b/app/projects/ar-story-teller/components/main-demo/MainDemo.tsx
@@ -7,6 +7,7 @@ import ProjectImage from '@/lib/media/ProjectImage';
 import { DemoVideo } from '../demo-video/DemoVideo';
 import styles from './MainDemo.module.scss';
 import { useMainDemoTimeline } from './useMainDemoTimeline';
+import { MAIN_DEMO_CANVAS } from '../../layoutConfig';
 
 const MAIN_DEMO_BACKGROUND_OBJECT_PATH =
     'projects/project_2/demo/TowerofTerrorFullShotParkImage.png';
@@ -38,8 +39,8 @@ const MAIN_DEMO_IPHONE_FRAME_INTRINSIC_HEIGHT = 1617;
 
 const mainDemoImageSizes = [
     '100vw',
-    '(min-width: 768px) 900px',
-    '(min-width: 1024px) 1100px',
+    `(min-width: 768px) ${MAIN_DEMO_CANVAS.tablet.width}px`,
+    `(min-width: 1024px) ${MAIN_DEMO_CANVAS.desktop.width}px`,
 ].join(', ');
 
 const mainDemoNotificationSizes = [

--- a/app/projects/ar-story-teller/components/sections/BusinessGoals.tsx
+++ b/app/projects/ar-story-teller/components/sections/BusinessGoals.tsx
@@ -3,6 +3,7 @@ import { SectionTitle } from "../SectionTitle";
 import { PANEL_BLOCK_PADDINGS } from "../../layoutConfig";
 import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
 import type { BusinessGoalsData } from "@/app/projects/ar-story-teller/types/arStoryTellerContent";
+import { overviewNarrativeBlockSx } from "../../overviewNarrativeLayout";
 import { bodyTypeSx } from "../../typography";
 import styles from "../../ArStoryTeller.module.scss";
 
@@ -18,7 +19,12 @@ const BusinessGoals = ({ data }: BusinessGoalsProps) => {
   const headingId = "business-goals-heading";
 
   return (
-    <section aria-labelledby={headingId} className={styles['panel-subsection']}>
+    <Box
+      component="section"
+      aria-labelledby={headingId}
+      className={styles['panel-subsection']}
+      sx={overviewNarrativeBlockSx}
+    >
       <SectionTitle id={headingId} title={title} />
       <Box
         sx={{
@@ -66,7 +72,7 @@ const BusinessGoals = ({ data }: BusinessGoalsProps) => {
           </Box>
         </Stack>
       </Box>
-    </section>
+    </Box>
   );
 };
 

--- a/app/projects/ar-story-teller/components/sections/BusinessGoals.tsx
+++ b/app/projects/ar-story-teller/components/sections/BusinessGoals.tsx
@@ -2,21 +2,100 @@ import { Box, Stack, Typography } from "@mui/material";
 import { SectionTitle } from "../SectionTitle";
 import { PANEL_BLOCK_PADDINGS } from "../../layoutConfig";
 import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
-import type { BusinessGoalsData } from "@/app/projects/ar-story-teller/types/arStoryTellerContent";
+import type {
+  BusinessGoalItem,
+  BusinessGoalsData,
+} from "@/app/projects/ar-story-teller/types/arStoryTellerContent";
+import {
+  DEFAULT_BUSINESS_GOAL_ITEMS,
+} from "../../lib/businessGoalsDefaults";
 import { overviewNarrativeBlockSx } from "../../overviewNarrativeLayout";
 import { bodyTypeSx } from "../../typography";
 import styles from "../../ArStoryTeller.module.scss";
 
 const DESKTOP_BREAKPOINT_MQ = breakpointMediaQuery.desktopUp;
 const TABLET_STACKED_MQ = breakpointMediaQuery.tabletOnly;
+const TABLET_UP_MQ = breakpointMediaQuery.tabletUp;
+
+const panelBodySx = bodyTypeSx("panelBody");
 
 interface BusinessGoalsProps {
   data: BusinessGoalsData;
 }
 
+function goalRowKey(item: BusinessGoalItem) {
+  return item.title;
+}
+
+function GoalRowDesktop({ item }: { item: BusinessGoalItem }) {
+  return (
+    <Stack
+      direction="row"
+      justifyContent="center"
+      alignItems="flex-start"
+      sx={{ width: "100%" }}
+    >
+      <Box sx={{ width: "40%", flexShrink: 0, pr: { xs: 1, md: 2 } }}>
+        <Typography
+          component="p"
+          sx={{
+            m: 0,
+            textAlign: "right",
+            ...panelBodySx,
+            fontWeight: 600,
+          }}
+        >
+          {item.title}
+        </Typography>
+      </Box>
+      <Box sx={{ width: "40%", flexShrink: 0, pl: { xs: 1, md: 2 } }}>
+        <Typography
+          component="p"
+          sx={{
+            m: 0,
+            textAlign: "left",
+            ...panelBodySx,
+          }}
+        >
+          {item.description}
+        </Typography>
+      </Box>
+    </Stack>
+  );
+}
+
+function GoalRowMobile({ item }: { item: BusinessGoalItem }) {
+  return (
+    <Box sx={{ width: "100%", textAlign: "center" }}>
+      <Typography
+        component="p"
+        sx={{
+          m: 0,
+          ...panelBodySx,
+          fontWeight: 600,
+        }}
+      >
+        {item.title}
+      </Typography>
+      <Typography
+        component="p"
+        sx={{
+          m: 0,
+          mt: 0.5,
+          ...panelBodySx,
+        }}
+      >
+        {item.description}
+      </Typography>
+    </Box>
+  );
+}
+
 const BusinessGoals = ({ data }: BusinessGoalsProps) => {
-  const { title, intro, goals } = data;
+  const { title, items } = data;
   const headingId = "business-goals-heading";
+  const goalItems =
+    items && items.length > 0 ? items : [...DEFAULT_BUSINESS_GOAL_ITEMS];
 
   return (
     <Box
@@ -44,32 +123,32 @@ const BusinessGoals = ({ data }: BusinessGoalsProps) => {
           width: "100%",
         }}
       >
-        <Stack spacing={2} sx={{ maxWidth: "100%" }}>
-          <Typography component="p" sx={{ m: 0, ...bodyTypeSx("panelBody") }}>
-            {intro}
-          </Typography>
-          <Box
-            component="ul"
-            sx={{
-              m: 0,
-              pl: { xs: 3, md: 4 },
-              listStyleType: "disc",
-            }}
-          >
-            {goals.map((goal) => (
-              <Typography
-                key={goal}
-                component="li"
-                sx={{
-                  ...bodyTypeSx("panelBody"),
-                  display: "list-item",
-                  "&:not(:first-of-type)": { mt: 1.5 },
-                }}
-              >
-                {goal}
-              </Typography>
-            ))}
-          </Box>
+        <Stack
+          spacing={3}
+          alignItems="center"
+          sx={{
+            display: "flex",
+            width: "100%",
+            [TABLET_UP_MQ]: { display: "none" },
+          }}
+        >
+          {goalItems.map((item) => (
+            <GoalRowMobile key={goalRowKey(item)} item={item} />
+          ))}
+        </Stack>
+
+        <Stack
+          spacing={2.5}
+          sx={{
+            display: "none",
+            width: "100%",
+            mx: "auto",
+            [TABLET_UP_MQ]: { display: "flex" },
+          }}
+        >
+          {goalItems.map((item) => (
+            <GoalRowDesktop key={goalRowKey(item)} item={item} />
+          ))}
         </Stack>
       </Box>
     </Box>

--- a/app/projects/ar-story-teller/components/sections/OverviewSection.tsx
+++ b/app/projects/ar-story-teller/components/sections/OverviewSection.tsx
@@ -5,8 +5,7 @@ import SectionTitle from '../SectionTitle';
 import ParagraphText from '../ParagraphText';
 import styles from '../../ArStoryTeller.module.scss';
 import { MainDemo } from '../main-demo/MainDemo';
-import { OVERVIEW_PROJECT_OVERVIEW_MAX_WIDTH_PX } from '../../layoutConfig';
-import { breakpointMediaQuery } from '@/lib/responsive/breakpoints';
+import { overviewNarrativeBlockSx } from '../../overviewNarrativeLayout';
 
 import type { OverviewSectionData } from '@/app/projects/ar-story-teller/types/arStoryTellerContent';
 
@@ -46,23 +45,13 @@ export function OverviewSection({ data }: OverviewSectionProps) {
                 data-aos="fade-up"
                 data-aos-duration="1000"
                 data-aos-once="true"
-                sx={{
-                    width: '100%',
-                    maxWidth: '100%',
-                    mx: 'auto',
-                    [breakpointMediaQuery.tabletUp]: {
-                        maxWidth: `${OVERVIEW_PROJECT_OVERVIEW_MAX_WIDTH_PX.tablet}px`,
-                    },
-                    [breakpointMediaQuery.desktopUp]: {
-                        maxWidth: `${OVERVIEW_PROJECT_OVERVIEW_MAX_WIDTH_PX.desktop}px`,
-                    },
-                }}
+                sx={overviewNarrativeBlockSx}
             >
                 <SectionTitle title="Project Overview" />
                 <ParagraphText text={PROJECT_OVERVIEW_COPY} />
             </Box>
 
-            <div className={styles['content-group']}>
+            <Box className={styles['content-group']} sx={overviewNarrativeBlockSx}>
                 {solution.title ? (
                     <SectionTitle
                         title={solution.title}
@@ -71,7 +60,7 @@ export function OverviewSection({ data }: OverviewSectionProps) {
                     />
                 ) : null}
                 <MainDemo />
-            </div>
+            </Box>
         </section>
     );
 }

--- a/app/projects/ar-story-teller/components/sections/OverviewSection.tsx
+++ b/app/projects/ar-story-teller/components/sections/OverviewSection.tsx
@@ -1,10 +1,17 @@
 import React from 'react';
+import { Box } from '@mui/material';
 import OverviewParagraphBlock from '../OverviewParagraphBlock';
 import SectionTitle from '../SectionTitle';
+import ParagraphText from '../ParagraphText';
 import styles from '../../ArStoryTeller.module.scss';
 import { MainDemo } from '../main-demo/MainDemo';
+import { OVERVIEW_PROJECT_OVERVIEW_MAX_WIDTH_PX } from '../../layoutConfig';
+import { breakpointMediaQuery } from '@/lib/responsive/breakpoints';
 
 import type { OverviewSectionData } from '@/app/projects/ar-story-teller/types/arStoryTellerContent';
+
+const PROJECT_OVERVIEW_COPY =
+    'This project originated as an innovation initiative at Disney to explore how emerging technologies could transform the theme park environment itself into an interactive attraction. Recognizing the opportunity to investigate the challenge through a human-centered design lens, I partnered with my faculty advisor in the University of Washington\'s Human Centered Design & Engineering program to develop the concept as a graduate research project. This collaboration allowed me to combine Disney\'s real-world guest experience challenges with academic research methods to explore how augmented reality could create meaningful storytelling experiences during attraction wait times.';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -33,6 +40,27 @@ export function OverviewSection({ data }: OverviewSectionProps) {
                     paragraph2={theProblem.paragraphs}
                 />
             </div>
+
+            <Box
+                className={styles['content-group']}
+                data-aos="fade-up"
+                data-aos-duration="1000"
+                data-aos-once="true"
+                sx={{
+                    width: '100%',
+                    maxWidth: '100%',
+                    mx: 'auto',
+                    [breakpointMediaQuery.tabletUp]: {
+                        maxWidth: `${OVERVIEW_PROJECT_OVERVIEW_MAX_WIDTH_PX.tablet}px`,
+                    },
+                    [breakpointMediaQuery.desktopUp]: {
+                        maxWidth: `${OVERVIEW_PROJECT_OVERVIEW_MAX_WIDTH_PX.desktop}px`,
+                    },
+                }}
+            >
+                <SectionTitle title="Project Overview" />
+                <ParagraphText text={PROJECT_OVERVIEW_COPY} />
+            </Box>
 
             <div className={styles['content-group']}>
                 {solution.title ? (

--- a/app/projects/ar-story-teller/headerTheme.ts
+++ b/app/projects/ar-story-teller/headerTheme.ts
@@ -1,7 +1,24 @@
+import type { ProjectHeaderTheme } from "@/components/Header/HeaderState";
 import { HEADER_LOGO_DEFAULT_COLORS } from "@/components/Header/HeaderLogo";
 
-/** Header logo colors while the AR Story Teller case study is mounted. */
+/** Hero gradient top on desktop (`ProjectHeader.scss`) — use for a solid nav bar over the hero. */
+export const AR_STORY_TELLER_HERO_HEADER_BG = "#153077";
+
+/** Page canvas while this case study is mounted (`pageCanvas.ts`). */
+export const AR_STORY_TELLER_PAGE_HEADER_BG = "#ffffff";
+
+/** Global top nav overrides while `ArStoryTellerPage` is mounted. */
+export const AR_STORY_TELLER_HEADER_THEME: ProjectHeaderTheme = {
+  position: "absolute",
+  isDark: true,
+  logoPrimaryColor: "#D3D3D3",
+  logoAccentColor: HEADER_LOGO_DEFAULT_COLORS.accent,
+  /** Transparent keeps the hero gradient visible under the absolute nav; swap to `AR_STORY_TELLER_HERO_HEADER_BG` for a solid bar. */
+  backgroundColor: "transparent",
+};
+
+/** @deprecated Use `AR_STORY_TELLER_HEADER_THEME.logoPrimaryColor` / accent fields. */
 export const AR_STORY_TELLER_HEADER_LOGO = {
-  primary: "#ffffff",
-  accent: HEADER_LOGO_DEFAULT_COLORS.accent,
+  primary: AR_STORY_TELLER_HEADER_THEME.logoPrimaryColor ?? "#ffffff",
+  accent: AR_STORY_TELLER_HEADER_THEME.logoAccentColor ?? HEADER_LOGO_DEFAULT_COLORS.accent,
 } as const;

--- a/app/projects/ar-story-teller/layoutConfig.ts
+++ b/app/projects/ar-story-teller/layoutConfig.ts
@@ -140,9 +140,9 @@ export const getUsableLayoutWidth = (
 export const PANEL_CONTENT_MAX_WIDTH_PX = getUsableLayoutWidth('desktop');
 
 /**
- * Centered overview narrative block (Project Overview copy).
+ * Centered overview narrative block (Project Overview copy + Solution demo).
  * Desktop 910px ≈ 82.7% of usable desktop width (`PANEL_CONTENT_MAX_WIDTH_PX`);
- * tablet scales by the same ratio on usable tablet width (944px → 780px).
+ * tablet scales by the same ratio on usable tablet width (944px → 781px).
  * Mobile uses full container width (16px side margins) — ~328px at 360px viewport.
  */
 export const OVERVIEW_PROJECT_OVERVIEW_MAX_WIDTH_PX = {
@@ -151,12 +151,18 @@ export const OVERVIEW_PROJECT_OVERVIEW_MAX_WIDTH_PX = {
 } as const;
 
 /**
- * Cinematic main demo canvas (16:9). Desktop 1100×620; tablet ~900×506.
+ * Cinematic main demo canvas (16:9) — capped to match `OVERVIEW_PROJECT_OVERVIEW_MAX_WIDTH_PX`.
  * Mobile fills available width at the same aspect ratio.
  */
 export const MAIN_DEMO_CANVAS = {
-    desktop: { width: 1100, height: 620 },
-    tablet: { width: 900, height: 506 },
+    desktop: {
+        width: OVERVIEW_PROJECT_OVERVIEW_MAX_WIDTH_PX.desktop,
+        height: Math.round((OVERVIEW_PROJECT_OVERVIEW_MAX_WIDTH_PX.desktop * 9) / 16),
+    },
+    tablet: {
+        width: OVERVIEW_PROJECT_OVERVIEW_MAX_WIDTH_PX.tablet,
+        height: Math.round((OVERVIEW_PROJECT_OVERVIEW_MAX_WIDTH_PX.tablet * 9) / 16),
+    },
 } as const;
 
 type PanelPaddingBreakpoint = keyof PanelBlockPaddings['x'];

--- a/app/projects/ar-story-teller/layoutConfig.ts
+++ b/app/projects/ar-story-teller/layoutConfig.ts
@@ -140,6 +140,17 @@ export const getUsableLayoutWidth = (
 export const PANEL_CONTENT_MAX_WIDTH_PX = getUsableLayoutWidth('desktop');
 
 /**
+ * Centered overview narrative block (Project Overview copy).
+ * Desktop 910px ≈ 82.7% of usable desktop width (`PANEL_CONTENT_MAX_WIDTH_PX`);
+ * tablet scales by the same ratio on usable tablet width (944px → 780px).
+ * Mobile uses full container width (16px side margins) — ~328px at 360px viewport.
+ */
+export const OVERVIEW_PROJECT_OVERVIEW_MAX_WIDTH_PX = {
+    tablet: Math.round((getUsableLayoutWidth('tablet') * 910) / PANEL_CONTENT_MAX_WIDTH_PX),
+    desktop: 910,
+} as const;
+
+/**
  * Cinematic main demo canvas (16:9). Desktop 1100×620; tablet ~900×506.
  * Mobile fills available width at the same aspect ratio.
  */

--- a/app/projects/ar-story-teller/lib/businessGoalsDefaults.ts
+++ b/app/projects/ar-story-teller/lib/businessGoalsDefaults.ts
@@ -1,0 +1,23 @@
+/** Default Business Goals rows — matches design spec when Firestore has no `items`. */
+export const DEFAULT_BUSINESS_GOAL_ITEMS = [
+  {
+    title: "Extend Storytelling",
+    description:
+      "Transform the surrounding environment into part of the attraction experience.",
+  },
+  {
+    title: "Increase Guest Engagement",
+    description:
+      "Turn unavoidable wait times into moments of discovery, exploration, and play.",
+  },
+  {
+    title: "Build a Scalable Platform",
+    description:
+      "Create a reusable AR framework adaptable to multiple attractions and use cases.",
+  },
+  {
+    title: "Support Sustainable Innovation",
+    description:
+      "Deliver immersive experiences that balance operational efficiency with Disney's commitment to exceptional guest experiences.",
+  },
+] as const;

--- a/app/projects/ar-story-teller/lib/parseArStoryTellerContent.ts
+++ b/app/projects/ar-story-teller/lib/parseArStoryTellerContent.ts
@@ -2,6 +2,7 @@ import type {
   ARAsNarrativeTool,
   ArStoryTellerCaseStudy,
   ArStoryTellerContent,
+  BusinessGoalItem,
   BusinessGoalsData,
   MagicExperience,
   MagicExperiences,
@@ -52,6 +53,19 @@ function parseSolutionBlock(value: unknown, path: string): SolutionBlock {
   return solution;
 }
 
+function parseBusinessGoalItem(
+  value: unknown,
+  path: string,
+): BusinessGoalItem {
+  if (!isRecord(value)) {
+    throw new Error(`Invalid ${path}: expected object`);
+  }
+  return {
+    title: requireString(value.title, `${path}.title`),
+    description: requireString(value.description, `${path}.description`),
+  };
+}
+
 function parseBusinessGoalsData(
   value: unknown,
   path: string,
@@ -59,11 +73,29 @@ function parseBusinessGoalsData(
   if (!isRecord(value)) {
     throw new Error(`Invalid ${path}: expected object`);
   }
-  return {
+
+  const data: BusinessGoalsData = {
     title: requireString(value.title, `${path}.title`),
-    intro: requireString(value.intro, `${path}.intro`),
-    goals: parseStringArray(value.goals, `${path}.goals`),
   };
+
+  if (value.items !== undefined) {
+    if (!Array.isArray(value.items)) {
+      throw new Error(`Invalid ${path}.items: expected array`);
+    }
+    data.items = value.items.map((item, index) =>
+      parseBusinessGoalItem(item, `${path}.items[${index}]`),
+    );
+  }
+
+  if (value.intro !== undefined) {
+    data.intro = requireString(value.intro, `${path}.intro`);
+  }
+
+  if (value.goals !== undefined) {
+    data.goals = parseStringArray(value.goals, `${path}.goals`);
+  }
+
+  return data;
 }
 
 function parseTeamData(value: unknown, path: string): TeamData {

--- a/app/projects/ar-story-teller/lib/preloadArStoryTellerAssets.ts
+++ b/app/projects/ar-story-teller/lib/preloadArStoryTellerAssets.ts
@@ -4,6 +4,11 @@ import { buildPublicStorageUrl } from "@/lib/firebase/publicStorageUrl";
 import { preloadOne } from "@/lib/media/preloadImages";
 
 import { CASE_STUDY_BANNER_OBJECT_PATH } from "./criticalAssets";
+import {
+  getOverviewWaitingPeoplePreloadObjectPath,
+  getProjectHeaderPreloadObjectPaths,
+  type ViewportBand,
+} from "./projectHeaderPreloadUrls";
 
 type PreloadBannerOptions = {
   projectKey: string;
@@ -50,6 +55,34 @@ export async function preloadArStoryTellerCaseStudyBanner({
   await preloadGatedMediaObject(
     projectKey,
     CASE_STUDY_BANNER_OBJECT_PATH,
+    visibility,
+  );
+}
+
+/** Parallax cloud layers for the active viewport band. */
+export async function preloadProjectHeaderCloudLayers({
+  projectKey,
+  visibility,
+  viewportBand,
+}: PreloadBannerOptions & { viewportBand: ViewportBand }): Promise<void> {
+  const objectPaths = getProjectHeaderPreloadObjectPaths(viewportBand);
+
+  await Promise.all(
+    objectPaths.map((objectPath) =>
+      preloadGatedMediaObject(projectKey, objectPath, visibility),
+    ),
+  );
+}
+
+/** Overview Ferris wheel background for the active viewport band. */
+export async function preloadOverviewWaitingPeopleBackground({
+  projectKey,
+  visibility,
+  viewportBand,
+}: PreloadBannerOptions & { viewportBand: ViewportBand }): Promise<void> {
+  await preloadGatedMediaObject(
+    projectKey,
+    getOverviewWaitingPeoplePreloadObjectPath(viewportBand),
     visibility,
   );
 }

--- a/app/projects/ar-story-teller/lib/projectHeaderAssets.ts
+++ b/app/projects/ar-story-teller/lib/projectHeaderAssets.ts
@@ -1,0 +1,34 @@
+/** Firebase Storage object paths for AR Story Teller hero + overview artwork (`projectKey`: project_1). */
+
+const PROJECT_1_PREFIX = "projects/project_1";
+
+/** Castle + queue strip below the hero parallax (`PeopleInLineCrowd`). */
+export const PROJECT_HEADER_CROWD_OBJECT_PATH =
+  `${PROJECT_1_PREFIX}/CrowdsWaiting-Desktop.png`;
+
+/** Ferris wheel silhouettes behind overview copy (`OverviewParagraphBlock`). */
+export const OVERVIEW_WAITING_PEOPLE_OBJECT_PATHS = {
+  desktop: `${PROJECT_1_PREFIX}/WaitingPeople-DesktopLg.png`,
+  tablet: `${PROJECT_1_PREFIX}/WaitingPeople-LgMd.png`,
+  mobile: `${PROJECT_1_PREFIX}/WaitingPeople-SMSX.png`,
+} as const;
+
+/** Desktop + tablet parallax layers (back → front render order is defined in `ProjectHeader`). */
+export const PROJECT_HEADER_DESKTOP_CLOUD_OBJECT_PATHS = {
+  layer1: `${PROJECT_1_PREFIX}/cloud-1.png`,
+  layer2: `${PROJECT_1_PREFIX}/cloud-2.png`,
+  layer3: `${PROJECT_1_PREFIX}/cloud-3.png`,
+  layer4: `${PROJECT_1_PREFIX}/cloud-4.png`,
+} as const;
+
+/** Mobile parallax layers. */
+export const PROJECT_HEADER_MOBILE_CLOUD_OBJECT_PATHS = {
+  layer1: `${PROJECT_1_PREFIX}/clouds-layer-1.png`,
+  layer2: `${PROJECT_1_PREFIX}/clouds-layer-2.png`,
+  layer3: `${PROJECT_1_PREFIX}/clouds-layer-3.png`,
+  layer4: `${PROJECT_1_PREFIX}/clouds-layer-4.png`,
+} as const;
+
+export type ProjectHeaderCloudObjectPaths =
+  | typeof PROJECT_HEADER_DESKTOP_CLOUD_OBJECT_PATHS
+  | typeof PROJECT_HEADER_MOBILE_CLOUD_OBJECT_PATHS;

--- a/app/projects/ar-story-teller/lib/projectHeaderPreloadUrls.ts
+++ b/app/projects/ar-story-teller/lib/projectHeaderPreloadUrls.ts
@@ -1,53 +1,46 @@
-import type { StaticImageData } from "next/image";
-
-import CloudsLayer1 from "../Images/cloud-1.png";
-import CloudsLayer2 from "../Images/cloud-2.png";
-import CloudsLayer3 from "../Images/cloud-3.png";
-import CloudsLayer4 from "../Images/cloud-4.png";
-import CloudsLayerMobile1 from "../Images/clouds-layer-1.png";
-import CloudsLayerMobile2 from "../Images/clouds-layer-2.png";
-import CloudsLayerMobile3 from "../Images/clouds-layer-3.png";
-import CloudsLayerMobile4 from "../Images/clouds-layer-4.png";
-import CrowdsWaitingDesktop from "../Images/CrowdsWaiting-Desktop.png";
+import {
+  OVERVIEW_WAITING_PEOPLE_OBJECT_PATHS,
+  PROJECT_HEADER_CROWD_OBJECT_PATH,
+  PROJECT_HEADER_DESKTOP_CLOUD_OBJECT_PATHS,
+  PROJECT_HEADER_MOBILE_CLOUD_OBJECT_PATHS,
+} from "./projectHeaderAssets";
 
 export type ViewportBand = "mobile" | "tablet" | "desktop";
 
-function staticSrc(image: StaticImageData): string {
-  return image.src;
+const DESKTOP_CLOUD_OBJECT_PATHS = [
+  PROJECT_HEADER_DESKTOP_CLOUD_OBJECT_PATHS.layer4,
+  PROJECT_HEADER_DESKTOP_CLOUD_OBJECT_PATHS.layer3,
+  PROJECT_HEADER_DESKTOP_CLOUD_OBJECT_PATHS.layer2,
+  PROJECT_HEADER_DESKTOP_CLOUD_OBJECT_PATHS.layer1,
+];
+
+const MOBILE_CLOUD_OBJECT_PATHS = [
+  PROJECT_HEADER_MOBILE_CLOUD_OBJECT_PATHS.layer4,
+  PROJECT_HEADER_MOBILE_CLOUD_OBJECT_PATHS.layer3,
+  PROJECT_HEADER_MOBILE_CLOUD_OBJECT_PATHS.layer2,
+  PROJECT_HEADER_MOBILE_CLOUD_OBJECT_PATHS.layer1,
+];
+
+/** Cloud layers + crowd strip for the active viewport band. */
+export function getProjectHeaderPreloadObjectPaths(
+  band: ViewportBand,
+): string[] {
+  const cloudPaths =
+    band === "mobile" ? MOBILE_CLOUD_OBJECT_PATHS : DESKTOP_CLOUD_OBJECT_PATHS;
+
+  return [...cloudPaths, PROJECT_HEADER_CROWD_OBJECT_PATH];
 }
 
-const DESKTOP_HEADER_IMAGES = [
-  CloudsLayer1,
-  CloudsLayer2,
-  CloudsLayer3,
-  CloudsLayer4,
-  CrowdsWaitingDesktop,
-];
+export function getOverviewWaitingPeoplePreloadObjectPath(
+  band: ViewportBand,
+): string {
+  if (band === "mobile") {
+    return OVERVIEW_WAITING_PEOPLE_OBJECT_PATHS.mobile;
+  }
 
-const TABLET_HEADER_IMAGES = [
-  CloudsLayer1,
-  CloudsLayer2,
-  CloudsLayer3,
-  CloudsLayer4,
-  CrowdsWaitingDesktop,
-];
+  if (band === "tablet") {
+    return OVERVIEW_WAITING_PEOPLE_OBJECT_PATHS.tablet;
+  }
 
-const MOBILE_HEADER_IMAGES = [
-  CloudsLayerMobile1,
-  CloudsLayerMobile2,
-  CloudsLayerMobile3,
-  CloudsLayerMobile4,
-  CrowdsWaitingDesktop,
-];
-
-/** Static `ProjectHeader` artwork for the active viewport band. */
-export function getProjectHeaderPreloadUrls(band: ViewportBand): string[] {
-  const images =
-    band === "mobile"
-      ? MOBILE_HEADER_IMAGES
-      : band === "tablet"
-        ? TABLET_HEADER_IMAGES
-        : DESKTOP_HEADER_IMAGES;
-
-  return images.map(staticSrc);
+  return OVERVIEW_WAITING_PEOPLE_OBJECT_PATHS.desktop;
 }

--- a/app/projects/ar-story-teller/overviewNarrativeLayout.ts
+++ b/app/projects/ar-story-teller/overviewNarrativeLayout.ts
@@ -1,0 +1,15 @@
+import { OVERVIEW_PROJECT_OVERVIEW_MAX_WIDTH_PX } from "./layoutConfig";
+import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
+
+/** Centered cap for overview narrative blocks (Project Overview, Solution, Business Goals). */
+export const overviewNarrativeBlockSx = {
+  width: "100%",
+  maxWidth: "100%",
+  mx: "auto",
+  [breakpointMediaQuery.tabletUp]: {
+    maxWidth: `${OVERVIEW_PROJECT_OVERVIEW_MAX_WIDTH_PX.tablet}px`,
+  },
+  [breakpointMediaQuery.desktopUp]: {
+    maxWidth: `${OVERVIEW_PROJECT_OVERVIEW_MAX_WIDTH_PX.desktop}px`,
+  },
+} as const;

--- a/app/projects/ar-story-teller/types/arStoryTellerContent.ts
+++ b/app/projects/ar-story-teller/types/arStoryTellerContent.ts
@@ -25,11 +25,20 @@ export type TeamData = {
   members: TeamMember[];
 };
 
-/** Firestore `content.businessGoals` — intro panel below overview. */
+/** Firestore `content.businessGoals` — two-column goal rows below overview. */
+export type BusinessGoalItem = {
+  title: string;
+  description: string;
+};
+
 export type BusinessGoalsData = {
   title: string;
-  intro: string;
-  goals: string[];
+  /** Two-column rows (title | description). Falls back to defaults when omitted. */
+  items?: BusinessGoalItem[];
+  /** @deprecated Legacy intro paragraph — no longer rendered. */
+  intro?: string;
+  /** @deprecated Legacy bullet list — no longer rendered. */
+  goals?: string[];
 };
 
 /** Firestore `content.projectOverview` — roles, timeline, category columns. */

--- a/app/projects/ar-story-teller/typography.ts
+++ b/app/projects/ar-story-teller/typography.ts
@@ -76,7 +76,7 @@ export type BodyTypographyScaleKey = Extract<
 
 const TITLE_FONT_WEIGHT: Record<TitleTypographyScaleKey, number> = {
   heroTitle: 600,
-  heroSubtitle: 600,
+  heroSubtitle: 550,
   sectionTitle: 700,
   sectionSubTitle: 700,
   panelHeading: 700,

--- a/app/projects/ar-story-teller/typography.ts
+++ b/app/projects/ar-story-teller/typography.ts
@@ -32,19 +32,19 @@ export const TYPOGRAPHY = {
   /** Subsections under a section (`SectionSubTitle`, e.g. “Developing Specifications”). */
   sectionSubTitle: { mobile: "24px", tablet: "28px", desktop: "32px" },
   /** Nested subtitles (`PanelSubTitle`) and in-panel headings (interaction design, user modes). */
-  panelHeading: { mobile: "22px", tablet: "24px", desktop: "26px" },
+  panelHeading: { mobile: "22px", tablet: "26px", desktop: "28px" },
   /** Card / column titles (AR mockups, research cards, mode titles). */
-  cardTitle: { mobile: "18px", tablet: "20px", desktop: "22px" },
+  cardTitle: { mobile: "18px", tablet: "22px", desktop: "24px" },
   /** Long-form prose (`ParagraphBlock`, overview copy). */
-  bodyText: { mobile: "18px", tablet: "20px", desktop: "20px" },
+  bodyText: { mobile: "18px", tablet: "22px", desktop: "22px" },
   /** Grey inset panels (`ArAsNarrative`, Business Goals, Team, etc.). */
-  panelBody: { mobile: "18px", tablet: "20px", desktop: "20px" },
+  panelBody: { mobile: "18px", tablet: "22px", desktop: "22px" },
   /** Emphasized body — list intros; use sparingly. */
-  bodyTextMedium: { mobile: "18px", tablet: "20px", desktop: "20px" },
+  bodyTextMedium: { mobile: "18px", tablet: "22px", desktop: "22px" },
   /** Dense UI copy (accordions, compact lists). */
-  smallBody: { mobile: "16px", tablet: "17px", desktop: "18px" },
+  smallBody: { mobile: "16px", tablet: "18px", desktop: "20px" },
   /** Image annotations and diagram labels. */
-  caption: { mobile: "14px", tablet: "15px", desktop: "16px" },
+  caption: { mobile: "14px", tablet: "16px", desktop: "17px" },
   /** White title on the case study banner image. */
   caseStudyBannerTitle: { mobile: "20px", tablet: "24px", desktop: "28px" },
   /** Optional labels / meta text. */
@@ -134,7 +134,7 @@ export function bodyTypeSx(
   const responsive: SxProps<Theme> = {
     fontFamily: AR_STORY_TELLER_BODY_FONT,
     fontWeight: BODY_FONT_WEIGHT[scaleKey],
-    lineHeight: 1.35,
+    lineHeight: 1.4,
     color: AR_STORY_TELLER_TEXT_COLOR,
     fontSize: TYPOGRAPHY[scaleKey].mobile,
     [breakpointMediaQuery.tabletUp]: {

--- a/components/Header/HeaderDesktop.tsx
+++ b/components/Header/HeaderDesktop.tsx
@@ -30,7 +30,7 @@ export function HeaderDesktop({
           </Link>
         </div>
 
-        <div className="primary_menu" id="menu">
+        <div className={styles.primary_menu} id="menu">
           <nav className={styles.main_menu} aria-label="Main navigation">
             <ul>
               {HEADER_NAV_ITEMS.map((item) => {

--- a/components/Header/HeaderState.ts
+++ b/components/Header/HeaderState.ts
@@ -9,7 +9,15 @@ export type HeaderStateValue = {
   logoPrimaryColor?: string;
   /** When set, overrides `HeaderLogo` default accent; omit to use brand cyan. */
   logoAccentColor?: string;
+  /** When set (project pages), paints the top nav bar; home sticky uses `--page-canvas` when unset. */
+  backgroundColor?: string;
 };
+
+/** Subset project routes pass via `setHeaderState` — landing defaults stay in `defaultHeaderState`. */
+export type ProjectHeaderTheme = Pick<
+  HeaderStateValue,
+  "position" | "isDark" | "logoPrimaryColor" | "logoAccentColor" | "backgroundColor"
+>;
 
 export const defaultHeaderState: HeaderStateValue = {
   position: "relative",

--- a/components/Header/header.module.scss
+++ b/components/Header/header.module.scss
@@ -3,11 +3,21 @@
 .header_area {
   position: relative;
   z-index: 100;
+  box-sizing: border-box;
+  width: 100%;
+}
+
+/* Project pages use `position: absolute` — without this, the bar shrink-wraps and nav sits beside the logo. */
+.header_area_full_bleed {
+  left: 0;
+  right: 0;
+  width: 100%;
 }
 
 .header_sticky {
   position: sticky;
   top: 0;
+  /* Only when no project `backgroundColor` inline override is set (see `Header/index.tsx`). */
   background-color: var(--page-canvas);
 }
 

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -6,6 +6,7 @@ import { defaultHeaderState, headerState } from "./HeaderState";
 import { useAtomValue } from "jotai";
 import { usePathname } from "next/navigation";
 import { clsx } from "clsx";
+import type { CSSProperties } from "react";
 import styles from "./header.module.scss";
 
 export type HeaderProps = {
@@ -24,7 +25,7 @@ export default function Header({
   logoFontColor: logoFontColorProp,
 }: HeaderProps) {
   const pathname = usePathname();
-  const { isDark, position, logoPrimaryColor, logoAccentColor } =
+  const { isDark, position, logoPrimaryColor, logoAccentColor, backgroundColor } =
     useAtomValue(headerState);
 
   let fontColor = fontColorProp || "#064c5f";
@@ -45,10 +46,23 @@ export default function Header({
   const useStickyHomeHeader =
     pathname === "/" && position === defaultHeaderState.position;
 
+  const isOverlayPosition =
+    !useStickyHomeHeader &&
+    (position === "absolute" || position === "fixed");
+
+  const headerStyle: CSSProperties = {
+    position: useStickyHomeHeader ? "sticky" : position,
+    ...(backgroundColor !== undefined ? { backgroundColor } : {}),
+  };
+
   return (
     <header
-      className={clsx(styles.header_area, useStickyHomeHeader && styles.header_sticky)}
-      style={{ position: useStickyHomeHeader ? "sticky" : position }}
+      className={clsx(
+        styles.header_area,
+        useStickyHomeHeader && styles.header_sticky,
+        isOverlayPosition && styles.header_area_full_bleed,
+      )}
+      style={headerStyle}
     >
       <div className={styles.headerContentCap}>
         <HeaderMobile

--- a/lib/media/ProjectImage.tsx
+++ b/lib/media/ProjectImage.tsx
@@ -25,6 +25,8 @@ type ProjectImageProps = {
   borderRadius?: React.CSSProperties["borderRadius"];
   /** When false, Next.js may resize remote images and honor `sizes` (requires `images.remotePatterns`). Default true preserves existing behavior. */
   unoptimized?: boolean;
+  /** Fill the positioned parent (`position: relative` required). */
+  fill?: boolean;
 };
 
 
@@ -40,6 +42,7 @@ export default function ProjectImage({
   fullViewportLoading = false,
   borderRadius,
   unoptimized = true,
+  fill = false,
 }: ProjectImageProps) {
   const { projectKey, visibility } = useProjectAccess();
   console.log("Project Access Context:", { projectKey, visibility });
@@ -64,8 +67,7 @@ export default function ProjectImage({
       <Image
         src={publicUrl}
         alt={alt}
-        width={width}
-        height={height}
+        {...(fill ? { fill: true } : { width, height })}
         className={className}
         style={mergedStyle}
         sizes={sizes}
@@ -87,6 +89,7 @@ export default function ProjectImage({
       sizes={sizes}
       priority={priority}
       fullViewportLoading={fullViewportLoading}
+      mode={fill ? "fill" : "intrinsic"}
     />
   );
 }

--- a/lib/media/useProjectMediaUrl.ts
+++ b/lib/media/useProjectMediaUrl.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { useProjectAccess } from "@/lib/access/ProjectAccessContext";
+import {
+  buildPublicStorageUrl,
+  stripLeadingSlash,
+} from "@/lib/firebase/publicStorageUrl";
+
+import { useSignedMediaUrl } from "./useSignedMediaUrl";
+
+/** Resolves a gated or public Storage URL for CSS backgrounds and non-`ProjectImage` use. */
+export function useProjectMediaUrl(objectPath: string) {
+  const { projectKey, visibility } = useProjectAccess();
+  const normalizedPath = stripLeadingSlash(objectPath);
+  const isPublic = visibility === "public";
+  const publicUrl = isPublic ? buildPublicStorageUrl(normalizedPath) : null;
+  const { url: signedUrl, error: signedError } = useSignedMediaUrl(
+    projectKey,
+    normalizedPath,
+    { enabled: !isPublic },
+  );
+
+  return {
+    url: publicUrl ?? signedUrl,
+    error: publicUrl ? null : signedError,
+  };
+}


### PR DESCRIPTION
### Summary

**Scope:** AR Story Teller case study — narrative, layout, and content panel improvements (27 files, +578 / −204)

**Overview & narrative layout**

- Added a Project Overview narrative block between the intro columns and the Solution section
- Introduced a shared 910px / 781px narrative column cap (overviewNarrativeLayout.ts) applied to Project Overview, Solution (MainDemo), Business Goals, and Team
- Resized the Main Demo canvas to 16:9 at the same width cap
- Removed the grey Project Overview panel (roles/timeline/category)

**Hero & header**

- Migrated hero/overview imagery from local imports to Firebase Storage (projectHeaderAssets.ts, preload helpers)
- Fixed full-bleed header alignment so the nav bar spans the viewport correctly
- Extended header theming (AR_STORY_TELLER_HEADER_THEME) with background and logo colors for the AR page

**Business Goals**

- Rebuilt the section as a two-column layout (title | description)
- Added support for a new Firestore items[] schema with UI defaults in businessGoalsDefaults.ts

**Contextual Notifications**

- Updated the carousel for new 16:9 notification mockups (SampleNotification1–3.png)
- Shifted desktop layout to 40% text / 60% image
- Enforced 16:9 aspect ratio with fill + object-fit: cover and 15px corner radius

**Supporting changes**

- ProjectImage gained a fill prop; added useProjectMediaUrl for Storage-backed assets
- Overview background silhouettes use background-size: contain for correct Ferris wheel rendering