### PR TITLE
Dcl rms/project preview page

### DIFF
--- a/app/(public)/work/dcl-revenue-management/page.tsx
+++ b/app/(public)/work/dcl-revenue-management/page.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+
+import { DclRevenueManagementPage } from "@/app/projects/dcl-revenue-management/DclRevenueManagementPage";
+import {
+  subscribeDclRevenueManagementProject,
+  type DclRevenueManagementProjectDocument,
+} from "@/app/projects/dcl-revenue-management/lib/dcl-revenue-management.firestore";
+import { createProjectHeaderReadyGate } from "@/app/projects/dcl-revenue-management/lib/projectHeaderReady";
+import { LandingSplash } from "@/components/LandingSplash/LandingSplash";
+import ProjectAccessGate from "@/lib/access/ProjectAccessGate";
+import { useLoadingSplash } from "@/lib/loadingSplash/useLoadingSplash";
+import { dclRevenueManagementDataProject } from "@/scripts/dcl-revenue-management.data";
+
+function DclRevenueManagementRouteContent() {
+  const [project, setProject] = useState<DclRevenueManagementProjectDocument | null>(
+    null,
+  );
+  const [hasError, setHasError] = useState(false);
+
+  const contentReadyRef = useRef<{
+    promise: Promise<void>;
+    resolve: () => void;
+    reject: (error: Error) => void;
+  } | null>(null);
+
+  if (contentReadyRef.current === null) {
+    let resolveReady!: () => void;
+    let rejectReady!: (error: Error) => void;
+    const promise = new Promise<void>((resolve, reject) => {
+      resolveReady = resolve;
+      rejectReady = reject;
+    });
+    contentReadyRef.current = {
+      promise,
+      resolve: resolveReady,
+      reject: rejectReady,
+    };
+  }
+
+  const headerReadyRef = useRef(createProjectHeaderReadyGate());
+
+  useEffect(() => {
+    const ready = contentReadyRef.current!;
+
+    const unsubscribe = subscribeDclRevenueManagementProject(
+      (projectFromDb) => {
+        setProject(projectFromDb);
+        setHasError(false);
+        ready.resolve();
+      },
+      (error) => {
+        console.warn(
+          "[dcl-revenue-management] Firestore realtime read failed; using local fallback data.",
+          error,
+        );
+        setProject(dclRevenueManagementDataProject);
+        setHasError(false);
+        ready.resolve();
+      },
+    );
+
+    return unsubscribe;
+  }, []);
+
+  const handleProjectHeaderReady = useCallback(() => {
+    headerReadyRef.current.markReady();
+  }, []);
+
+  const waitFor = useCallback(async () => {
+    await Promise.all([
+      contentReadyRef.current!.promise,
+      headerReadyRef.current.promise,
+    ]);
+  }, []);
+
+  const handleSplashError = useCallback(() => {
+    setHasError(true);
+  }, []);
+
+  useEffect(() => {
+    if (hasError) {
+      document.body.style.overflow = "";
+    }
+  }, [hasError]);
+
+  const { phase, isLocked, splashPhase, onFadeEnd } = useLoadingSplash({
+    waitFor,
+    onError: handleSplashError,
+  });
+
+  if (hasError) {
+    return (
+      <Box sx={{ minHeight: "60vh", display: "grid", placeItems: "center", px: 2 }}>
+        <Typography variant="body1" color="text.secondary" textAlign="center">
+          Unable to load this project. Please try again later.
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <>
+      <div aria-hidden={isLocked} inert={isLocked ? true : undefined}>
+        {project ? (
+          <DclRevenueManagementPage
+            project={project}
+            onProjectHeaderReady={handleProjectHeaderReady}
+          />
+        ) : null}
+      </div>
+
+      {phase !== "done" && !hasError && (
+        <LandingSplash
+          phase={splashPhase}
+          onFadeEnd={onFadeEnd}
+          label="Loading project"
+        />
+      )}
+    </>
+  );
+}
+
+export default function DclRevenueManagementRoute() {
+  return (
+    <ProjectAccessGate
+      projectId={dclRevenueManagementDataProject.project.projectId}
+      projectKey={dclRevenueManagementDataProject.project.projectKey}
+      title={dclRevenueManagementDataProject.gateTitle}
+    >
+      <DclRevenueManagementRouteContent />
+    </ProjectAccessGate>
+  );
+}

--- a/app/home/LatestProjectCard.tsx
+++ b/app/home/LatestProjectCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import Link from "next/link";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import CardMedia from "@mui/material/CardMedia";
@@ -14,9 +15,10 @@ export type LatestProjectProps = {
   title: string;
   thumbnailImg: StaticImageData;
   description: string[];
+  href?: string;
 };
 
-function LatestProjectCard({ title, thumbnailImg, description }: LatestProjectProps) {
+function LatestProjectCard({ title, thumbnailImg, description, href }: LatestProjectProps) {
   const { widthPx, heightPx, contentPaddingPx } = SELECTED_WORK_CARD;
   const bleedX = contentPaddingPx * 2;
 
@@ -43,6 +45,9 @@ function LatestProjectCard({ title, thumbnailImg, description }: LatestProjectPr
       raised
     >
       <CardActionArea
+        {...(href
+          ? { component: Link, href }
+          : { disableRipple: true })}
         sx={{
           height: "100%",
           display: "flex",
@@ -51,6 +56,7 @@ function LatestProjectCard({ title, thumbnailImg, description }: LatestProjectPr
           boxSizing: "border-box",
           padding: `${contentPaddingPx}px`,
           paddingBottom: 0,
+          ...(href ? {} : { cursor: "default" }),
         }}
       >
         <CardMedia

--- a/app/home/data/latestprojects-data.ts
+++ b/app/home/data/latestprojects-data.ts
@@ -9,6 +9,8 @@ export type LatestProjectItem = {
   title: string;
   img: StaticImageData;
   description: string[];
+  /** Optional route for Selected Work cards that already have a project page. */
+  href?: string;
 };
 
 export const latestProjectsItems: LatestProjectItem[] = [
@@ -25,6 +27,7 @@ export const latestProjectsItems: LatestProjectItem[] = [
     description: [
       "Led front-end redesign of dashboards, data grids, and ingestion workflows for pricing and inventory insights."
     ],
+    href: "/work/dcl-revenue-management",
   },
   {
     title: "R-3X – Automatic Seating Assignments",

--- a/app/home/latest-projects.tsx
+++ b/app/home/latest-projects.tsx
@@ -107,6 +107,7 @@ function LatestProjects() {
                 title={item.title}
                 description={item.description}
                 thumbnailImg={item.img}
+                href={item.href}
               />
             </div>
           ))}
@@ -141,6 +142,7 @@ function LatestProjects() {
                   title={item.title}
                   description={item.description}
                   thumbnailImg={item.img}
+                  href={item.href}
                 />
               </div>
             </SwiperSlide>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,7 +4,7 @@ import type { Metadata } from "next";
 import { AppProviders } from "./providers";
 import "../styles/globals.scss";
 import { PAGE_CANVAS } from "@/lib/theme/pageCanvas";
-import { IBM_Plex_Sans, Inter, Poppins, Montserrat, Figtree } from "next/font/google";
+import { IBM_Plex_Sans, Inter, Maven_Pro, Poppins, Montserrat, Figtree } from "next/font/google";
 import localFont from "next/font/local";
 import Header from '@/components/Header';
 import { AppRouterCacheProvider } from "@mui/material-nextjs/v16-appRouter";
@@ -41,6 +41,14 @@ const inter = Inter({
   subsets: ["latin"],
   weight: ["400", "600", "700"],
   variable: "--font-inter",
+  display: "swap",
+});
+
+/* Maven Pro — DCL Revenue Management project header. */
+const mavenPro = Maven_Pro({
+  subsets: ["latin"],
+  weight: ["600", "800"],
+  variable: "--font-maven-pro",
   display: "swap",
 });
 
@@ -108,7 +116,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html
       lang="en"
-      className={`${poppins.variable} ${montserrat.variable} ${figtree.variable} ${satoshi.variable} ${sourceSans3.variable} ${ibmPlexSans.variable} ${inter.variable}`}
+      className={`${poppins.variable} ${montserrat.variable} ${figtree.variable} ${satoshi.variable} ${sourceSans3.variable} ${ibmPlexSans.variable} ${inter.variable} ${mavenPro.variable}`}
       style={{ ["--page-canvas" as string]: PAGE_CANVAS }}
     >
       <Aos/>

--- a/app/projects/dcl-revenue-management/DclRevenueManagementPage.tsx
+++ b/app/projects/dcl-revenue-management/DclRevenueManagementPage.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useEffect } from "react";
+import { useSetAtom } from "jotai";
+import Stack from "@mui/material/Stack";
+
+import styles from "./dcl-revenue-management.module.scss";
+import FullBleedBand from "./components/FullBleedBand";
+import OverviewSection from "./components/OverviewSection";
+import PreviewNotice from "./components/PreviewNotice";
+import ProjectHeader from "./components/ProjectHeader";
+import SectionDelimiter from "./components/SectionDelimiter";
+import type { DclRevenueManagementProjectDocument } from "./lib/dcl-revenue-management.firestore";
+import {
+  INTRO_SECTIONS_BACKGROUND,
+  sectionRowGapSx,
+} from "./layoutConfig";
+import { DCL_HEADER_LOGO } from "./headerTheme";
+import { useResponsive } from "@/lib/responsive/ResponsiveQueryProvider";
+import { layoutState } from "@/app/(public)/layout-state";
+import {
+  defaultHeaderState,
+  headerState,
+} from "@/components/Header/HeaderState";
+
+type DclRevenueManagementPageProps = {
+  project: DclRevenueManagementProjectDocument;
+  onProjectHeaderReady?: () => void;
+};
+
+export function DclRevenueManagementPage({
+  project,
+  onProjectHeaderReady,
+}: DclRevenueManagementPageProps) {
+  const { isDesktopOrLaptop, isTablet, isMobile } = useResponsive();
+  const setLayoutState = useSetAtom(layoutState);
+  const setHeaderState = useSetAtom(headerState);
+
+  const viewportBand =
+    isMobile ? "mobile" : isTablet ? "tablet" : isDesktopOrLaptop ? "desktop" : "unknown";
+
+  useEffect(() => {
+    setLayoutState({ isFullWidth: true });
+    setHeaderState({
+      position: "absolute",
+      isDark: false,
+      logoPrimaryColor: DCL_HEADER_LOGO.primary,
+      logoAccentColor: DCL_HEADER_LOGO.accent,
+    });
+
+    return () => {
+      setLayoutState({ isFullWidth: false });
+      setHeaderState({ ...defaultHeaderState });
+    };
+  }, [setLayoutState, setHeaderState]);
+
+  return (
+    <div className={styles.pageClipViewport}>
+      <div className={styles.page} data-viewport-band={viewportBand}>
+        <ProjectHeader
+          data={project.projectHeader}
+          onReady={onProjectHeaderReady}
+        />
+
+        <FullBleedBand backgroundColor={INTRO_SECTIONS_BACKGROUND}>
+          <Stack alignItems="center" sx={{ ...sectionRowGapSx, width: "100%" }}>
+            <OverviewSection data={project.challengeSection} />
+            <OverviewSection data={project.previewProjectSnapshot} />
+            <OverviewSection data={project.aboutTheSystem} />
+            <SectionDelimiter data={project.sectionDelimiter} />
+            <PreviewNotice data={project.previewNotice} />
+          </Stack>
+        </FullBleedBand>
+      </div>
+    </div>
+  );
+}

--- a/app/projects/dcl-revenue-management/components/FullBleedBand.tsx
+++ b/app/projects/dcl-revenue-management/components/FullBleedBand.tsx
@@ -1,0 +1,74 @@
+import type { ReactNode } from "react";
+import Box from "@mui/material/Box";
+import Container from "@mui/material/Container";
+import type { SxProps, Theme } from "@mui/material/styles";
+
+import {
+  FULL_BLEED_BAND_PADDINGS,
+  layoutContentContainerSx,
+} from "@/app/projects/dcl-revenue-management/layoutConfig";
+import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
+
+type FullBleedBandProps = {
+  backgroundColor?: string;
+  children: ReactNode;
+  sx?: SxProps<Theme>;
+  /** When false, vertical band padding from `FULL_BLEED_BAND_PADDINGS` is omitted. */
+  withVerticalPadding?: boolean;
+  /**
+   * When true (default), children are wrapped in a `Container` using `LAYOUT_DIMENSIONS`.
+   * Set false when each child applies `layoutContentContainerSx` itself.
+   */
+  constrainContent?: boolean;
+};
+
+/**
+ * Edge-to-edge background band; children stay within `LAYOUT_DIMENSIONS`.
+ */
+export default function FullBleedBand({
+  backgroundColor,
+  children,
+  sx,
+  withVerticalPadding = true,
+  constrainContent = true,
+}: FullBleedBandProps) {
+  return (
+    <Box
+      component="section"
+      sx={
+        [
+          {
+            position: "relative",
+            width: "100vw",
+            maxWidth: "none",
+            ml: "calc(50% - 50vw)",
+            mr: "calc(50% - 50vw)",
+            overflowX: "hidden",
+            boxSizing: "border-box",
+            ...(backgroundColor ? { bgcolor: backgroundColor } : {}),
+            ...(withVerticalPadding
+              ? {
+                  py: FULL_BLEED_BAND_PADDINGS.y.mobile,
+                  [breakpointMediaQuery.tabletUp]: {
+                    py: FULL_BLEED_BAND_PADDINGS.y.tablet,
+                  },
+                  [breakpointMediaQuery.desktopUp]: {
+                    py: FULL_BLEED_BAND_PADDINGS.y.desktop,
+                  },
+                }
+              : {}),
+          },
+          ...(sx ? [sx] : []),
+        ] as SxProps<Theme>
+      }
+    >
+      {constrainContent ? (
+        <Container maxWidth={false} sx={layoutContentContainerSx}>
+          {children}
+        </Container>
+      ) : (
+        children
+      )}
+    </Box>
+  );
+}

--- a/app/projects/dcl-revenue-management/components/OverviewSection.tsx
+++ b/app/projects/dcl-revenue-management/components/OverviewSection.tsx
@@ -1,0 +1,40 @@
+import { Box, Stack, Typography } from "@mui/material";
+
+import { overviewParagraphMaxWidthSx } from "../layoutConfig";
+import { bodyTypeSx, titleTypeSx } from "../typography";
+
+export type OverviewSectionData = {
+  title: string;
+  paragraphs: string[];
+};
+
+type Props = {
+  data: OverviewSectionData;
+};
+
+export const OverviewSection = ({ data }: Props) => {
+  const { title, paragraphs } = data;
+
+  return (
+    <Stack spacing={4} alignItems="center" sx={{ width: "100%" }}>
+      <Typography component="h2" textAlign="center" sx={titleTypeSx("sectionTitle")}>
+        {title}
+      </Typography>
+      <Box sx={overviewParagraphMaxWidthSx}>
+        {paragraphs.map((text, index) => (
+          <Typography
+            key={index}
+            component="p"
+            sx={bodyTypeSx("overviewBody", {
+              mb: index < paragraphs.length - 1 ? 3 : 0,
+            })}
+          >
+            {text}
+          </Typography>
+        ))}
+      </Box>
+    </Stack>
+  );
+};
+
+export default OverviewSection;

--- a/app/projects/dcl-revenue-management/components/PreviewNotice.tsx
+++ b/app/projects/dcl-revenue-management/components/PreviewNotice.tsx
@@ -1,0 +1,31 @@
+import { Box, Stack, Typography } from "@mui/material";
+
+import { overviewParagraphMaxWidthSx } from "../layoutConfig";
+import { bodyTypeSx, titleTypeSx } from "../typography";
+
+export type PreviewNoticeData = {
+  title: string;
+  body: string;
+};
+
+type Props = {
+  data: PreviewNoticeData;
+};
+
+/**
+ * Lightweight “full case study coming soon” block for the production preview page.
+ */
+export default function PreviewNotice({ data }: Props) {
+  return (
+    <Stack spacing={4} alignItems="center" sx={{ width: "100%" }}>
+      <Typography component="h2" textAlign="center" sx={titleTypeSx("sectionTitle")}>
+        {data.title}
+      </Typography>
+      <Box sx={overviewParagraphMaxWidthSx}>
+        <Typography component="p" sx={bodyTypeSx("overviewBody")}>
+          {data.body}
+        </Typography>
+      </Box>
+    </Stack>
+  );
+}

--- a/app/projects/dcl-revenue-management/components/ProjectHeader.tsx
+++ b/app/projects/dcl-revenue-management/components/ProjectHeader.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import { Box, Stack, Typography } from "@mui/material";
+
+import {
+  LAYOUT_DIMENSIONS,
+  PROJECT_HEADER_EXTRA_TOP_PADDING,
+  PROJECT_HEADER_NAV_CLEARANCE,
+} from "@/app/projects/dcl-revenue-management/layoutConfig";
+import { titleTypeSx } from "@/app/projects/dcl-revenue-management/typography";
+import type { DclRevenueManagementDataProjectDocument } from "@/scripts/dcl-revenue-management.data";
+import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
+import ProjectImage from "@/lib/media/ProjectImage";
+
+type ProjectHeaderProps = {
+  data: DclRevenueManagementDataProjectDocument["projectHeader"];
+  onReady?: () => void;
+};
+
+/**
+ * Full-bleed illustrated banner hero with Maven Pro title / subtitle overlay
+ * matching the DCL RMS mockup (upper-left on the sky).
+ */
+export default function ProjectHeader({ data, onReady }: ProjectHeaderProps) {
+  const bannerRef = useRef<HTMLDivElement | null>(null);
+  const reportedReadyRef = useRef(false);
+
+  const reportReady = useCallback(() => {
+    if (reportedReadyRef.current) return;
+    reportedReadyRef.current = true;
+    onReady?.();
+  }, [onReady]);
+
+  useEffect(() => {
+    reportedReadyRef.current = false;
+
+    let cancelled = false;
+    let rafId = 0;
+    let img: HTMLImageElement | null = null;
+    let loadHandler: (() => void) | null = null;
+
+    const finish = (target: HTMLImageElement) => {
+      void target.decode?.().then(reportReady).catch(reportReady);
+    };
+
+    const attach = () => {
+      if (cancelled) return;
+      img = bannerRef.current?.querySelector("img") ?? null;
+      if (!img) {
+        rafId = requestAnimationFrame(attach);
+        return;
+      }
+
+      if (img.complete && img.naturalWidth > 0) {
+        finish(img);
+        return;
+      }
+
+      loadHandler = () => finish(img!);
+      img.addEventListener("load", loadHandler, { once: true });
+      img.addEventListener("error", reportReady, { once: true });
+    };
+
+    attach();
+
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(rafId);
+      if (img && loadHandler) {
+        img.removeEventListener("load", loadHandler);
+      }
+      if (img) {
+        img.removeEventListener("error", reportReady);
+      }
+    };
+  }, [data.banner.objectPath, reportReady]);
+
+  const { banner, title, subtitle } = data;
+
+  return (
+    <Box
+      component="section"
+      sx={{
+        position: "relative",
+        width: "100vw",
+        maxWidth: "none",
+        ml: "calc(50% - 50vw)",
+        mr: "calc(50% - 50vw)",
+        overflowX: "hidden",
+        boxSizing: "border-box",
+        bgcolor: "#FFFFFF",
+      }}
+    >
+      <Box
+        ref={bannerRef}
+        sx={{
+          position: "relative",
+          width: "100%",
+          maxWidth: LAYOUT_DIMENSIONS.desktop.maxWidth,
+          mx: "auto",
+          lineHeight: 0,
+          "& img": {
+            width: "100%",
+            height: "auto",
+            display: "block",
+          },
+        }}
+      >
+        <ProjectImage
+          objectPath={banner.objectPath}
+          alt={banner.alt}
+          width={banner.width}
+          height={banner.height}
+          priority
+          sizes="(max-width: 1260px) 100vw, 1260px"
+          style={{
+            width: "100%",
+            height: "auto",
+            objectFit: "contain",
+          }}
+        />
+
+        <Stack
+          component="header"
+          spacing={{ xs: 0.5, md: 0.75 }}
+          sx={{
+            position: "absolute",
+            zIndex: 1,
+            top: {
+              xs: `calc(${PROJECT_HEADER_NAV_CLEARANCE.mobile} + ${PROJECT_HEADER_EXTRA_TOP_PADDING.mobile} + 10%)`,
+              md: `calc(${PROJECT_HEADER_NAV_CLEARANCE.tablet} + ${PROJECT_HEADER_EXTRA_TOP_PADDING.tablet} + 10%)`,
+              lg: `calc(${PROJECT_HEADER_NAV_CLEARANCE.desktop} + ${PROJECT_HEADER_EXTRA_TOP_PADDING.desktop} + 10%)`,
+            },
+            left: {
+              xs: LAYOUT_DIMENSIONS.mobile.margin,
+              md: LAYOUT_DIMENSIONS.tablet.margin,
+              lg: LAYOUT_DIMENSIONS.desktop.margin,
+            },
+            right: {
+              xs: LAYOUT_DIMENSIONS.mobile.margin,
+              md: "auto",
+            },
+            maxWidth: { xs: "100%", md: 560, lg: 640 },
+            textAlign: "left",
+            pointerEvents: "none",
+            [breakpointMediaQuery.desktopUp]: {
+              left: LAYOUT_DIMENSIONS.desktop.margin,
+            },
+          }}
+        >
+          <Typography component="h1" sx={titleTypeSx("heroTitle")}>
+            {title}
+          </Typography>
+          <Typography component="p" sx={titleTypeSx("heroSubtitle")}>
+            {subtitle}
+          </Typography>
+        </Stack>
+      </Box>
+    </Box>
+  );
+}

--- a/app/projects/dcl-revenue-management/components/ProjectHeader.tsx
+++ b/app/projects/dcl-revenue-management/components/ProjectHeader.tsx
@@ -124,11 +124,13 @@ export default function ProjectHeader({ data, onReady }: ProjectHeaderProps) {
         <Stack
           component="header"
           spacing={{ xs: 0.5, md: 0.75 }}
+          alignItems={{ xs: "center", md: "flex-start" }}
           sx={{
             position: "absolute",
             zIndex: 1,
             top: {
-              xs: `calc(${PROJECT_HEADER_NAV_CLEARANCE.mobile} + ${PROJECT_HEADER_EXTRA_TOP_PADDING.mobile} + 10%)`,
+              // Mobile: 20% higher than the shared +10% offset → net −10% of banner height.
+              xs: `calc(${PROJECT_HEADER_NAV_CLEARANCE.mobile} + ${PROJECT_HEADER_EXTRA_TOP_PADDING.mobile} - 10%)`,
               md: `calc(${PROJECT_HEADER_NAV_CLEARANCE.tablet} + ${PROJECT_HEADER_EXTRA_TOP_PADDING.tablet} + 10%)`,
               lg: `calc(${PROJECT_HEADER_NAV_CLEARANCE.desktop} + ${PROJECT_HEADER_EXTRA_TOP_PADDING.desktop} + 10%)`,
             },
@@ -142,7 +144,7 @@ export default function ProjectHeader({ data, onReady }: ProjectHeaderProps) {
               md: "auto",
             },
             maxWidth: { xs: "100%", md: 560, lg: 640 },
-            textAlign: "left",
+            textAlign: { xs: "center", md: "left" },
             pointerEvents: "none",
             [breakpointMediaQuery.desktopUp]: {
               left: LAYOUT_DIMENSIONS.desktop.margin,

--- a/app/projects/dcl-revenue-management/components/SectionDelimiter.tsx
+++ b/app/projects/dcl-revenue-management/components/SectionDelimiter.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import Box from "@mui/material/Box";
+
+import ProjectImage from "@/lib/media/ProjectImage";
+
+export type SectionDelimiterData = {
+  objectPath: string;
+  alt: string;
+  width: number;
+  height: number;
+};
+
+type Props = {
+  data: SectionDelimiterData;
+};
+
+/**
+ * Decorative divider between narrative sections (Storage-backed image).
+ */
+export default function SectionDelimiter({ data }: Props) {
+  return (
+    <Box
+      component="figure"
+      aria-hidden={data.alt ? undefined : true}
+      sx={{
+        m: 0,
+        width: "100%",
+        maxWidth: { xs: 280, md: 360, lg: 420 },
+        mx: "auto",
+        lineHeight: 0,
+        "& img": {
+          width: "100%",
+          height: "auto",
+          display: "block",
+        },
+      }}
+    >
+      <ProjectImage
+        objectPath={data.objectPath}
+        alt={data.alt}
+        width={data.width}
+        height={data.height}
+        sizes="(max-width: 767px) 280px, (max-width: 1023px) 360px, 420px"
+        style={{
+          width: "100%",
+          height: "auto",
+          objectFit: "contain",
+        }}
+      />
+    </Box>
+  );
+}

--- a/app/projects/dcl-revenue-management/dcl-revenue-management.module.scss
+++ b/app/projects/dcl-revenue-management/dcl-revenue-management.module.scss
@@ -1,0 +1,30 @@
+@import "@/styles/variables";
+
+/* Layout floor matches `breakpointPx.mobileMin` / TS responsive bands. */
+.page {
+  min-height: 100vh;
+  width: 100%;
+  max-width: 100%;
+  min-width: $mobile-min;
+  margin: 0;
+  background-color: var(--page-canvas, #ffffff);
+  overflow-x: visible;
+}
+
+/**
+ * Break out of `global-container` (and any full-width parent) to viewport width.
+ * Horizontal clip for sub-$mobile-min viewports is on `.pageClipViewport`.
+ */
+%fullBleedBreakout {
+  position: relative;
+  width: 100vw;
+  max-width: none;
+  margin-left: calc(50% - 50vw);
+  margin-right: calc(50% - 50vw);
+}
+
+.pageClipViewport {
+  @extend %fullBleedBreakout;
+  overflow-x: clip;
+  box-sizing: border-box;
+}

--- a/app/projects/dcl-revenue-management/headerTheme.ts
+++ b/app/projects/dcl-revenue-management/headerTheme.ts
@@ -1,0 +1,18 @@
+import { HEADER_LOGO_DEFAULT_COLORS } from "@/components/Header/HeaderLogo";
+
+import { HEADER_BAND_COLOR } from "./layoutConfig";
+
+/** Header band + nav overlay colors while the DCL case study is mounted. */
+export const DCL_HEADER_BAND_COLOR = HEADER_BAND_COLOR;
+
+/** Accent bar / underline on the teal banner sky. */
+export const DCL_HEADER_LOGO_ACCENT = "#D5CDCD";
+
+/**
+ * Nav logo on the teal banner sky.
+ * Keep AAE letterforms (primary); accent bar uses `#D5CDCD` for contrast on the sky.
+ */
+export const DCL_HEADER_LOGO = {
+  primary: HEADER_LOGO_DEFAULT_COLORS.primary,
+  accent: DCL_HEADER_LOGO_ACCENT,
+} as const;

--- a/app/projects/dcl-revenue-management/layoutConfig.ts
+++ b/app/projects/dcl-revenue-management/layoutConfig.ts
@@ -1,0 +1,144 @@
+import type { SxProps, Theme } from "@mui/material/styles";
+
+import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
+
+/**
+ * Vertical spacing between top-level section children inside the case study content band.
+ *
+ * Breakpoint bands match `styles/variables.scss`:
+ *
+ * - `mobile`  -> 360 - 767px
+ * - `tablet`  -> 768 - 1023px
+ * - `desktop` -> 1024px +
+ */
+export const SECTION_GAPS = {
+  mobile: "3rem",
+  tablet: "5rem",
+  desktop: "8rem",
+} as const;
+
+/** Responsive `rowGap` sx for stacks of major page sections (uses `SECTION_GAPS`). */
+export const sectionRowGapSx: SxProps<Theme> = {
+  rowGap: SECTION_GAPS.mobile,
+  [breakpointMediaQuery.tabletUp]: { rowGap: SECTION_GAPS.tablet },
+  [breakpointMediaQuery.desktopUp]: { rowGap: SECTION_GAPS.desktop },
+};
+
+/** Responsive `gap` sx for flex columns separating major page sections (uses `SECTION_GAPS`). */
+export const sectionGapSx: SxProps<Theme> = {
+  gap: SECTION_GAPS.mobile,
+  [breakpointMediaQuery.tabletUp]: { gap: SECTION_GAPS.tablet },
+  [breakpointMediaQuery.desktopUp]: { gap: SECTION_GAPS.desktop },
+};
+
+/**
+ * Top/bottom padding for full-bleed section bands.
+ * Uses the same 3 : 5 : 8 rem scale as `SECTION_GAPS`.
+ */
+export const FULL_BLEED_BAND_PADDINGS = {
+  y: SECTION_GAPS,
+} as const;
+
+/**
+ * Standardized usable content dimensions for the DCL Revenue Management case study.
+ *
+ * `FullBleedBand` enforces these as `max-width` (outer container cap) and horizontal
+ * padding (inner side margins). Mobile is intentionally uncapped so the page fills
+ * larger phones while keeping 16px side margins.
+ */
+export const LAYOUT_DIMENSIONS = {
+  mobile: { maxWidth: "none", margin: "16px" },
+  tablet: { maxWidth: "1024px", margin: "40px" },
+  desktop: { maxWidth: "1260px", margin: "80px" },
+} as const;
+
+/** Shared background for intro / overview preview sections — continues from banner wave into white. */
+export const INTRO_SECTIONS_BACKGROUND = "#FFFFFF" as const;
+
+/** Project hero band — matches banner sky so letterboxing / edges blend. */
+export const HEADER_BAND_COLOR = "#7FB1B8" as const;
+
+/**
+ * Vertical clearance under the global top bar when `headerState.position` is
+ * `"absolute"`.
+ */
+export const PROJECT_HEADER_NAV_CLEARANCE = {
+  mobile: "80px",
+  tablet: "88px",
+  desktop: "96px",
+} as const;
+
+/**
+ * Padding below nav clearance on the project hero inner stack.
+ * Desktop is 40px less than tablet/mobile to balance overlay nav whitespace.
+ */
+export const PROJECT_HEADER_EXTRA_TOP_PADDING = {
+  mobile: "48px",
+  tablet: "48px",
+  desktop: "24px",
+} as const;
+
+export const cssLengthToPx = (value: string): number => Number.parseFloat(value);
+
+export const getUsableLayoutWidth = (
+  breakpoint: "tablet" | "desktop",
+): number => {
+  const { maxWidth, margin } = LAYOUT_DIMENSIONS[breakpoint];
+  return cssLengthToPx(maxWidth) - cssLengthToPx(margin) * 2;
+};
+
+/** Desktop usable content width (`1260 − 2 × 80`). */
+export const PANEL_CONTENT_MAX_WIDTH_PX = getUsableLayoutWidth("desktop");
+
+/**
+ * Narrative paragraph measure for Challenge / snapshot / about sections.
+ *
+ * Desktop: 920px (design target).
+ * Tablet / mobile scale from the same share of usable layout width
+ * (`920 / 1100 ≈ 84%` of desktop usable `1260 − 2×80`):
+ * - tablet usable `1024 − 2×40` → ≈790px
+ * - mobile: full content column (`100%`) with 16px side margins
+ */
+export const OVERVIEW_PARAGRAPH_MAX_WIDTH = {
+  mobile: "100%",
+  tablet: "790px",
+  desktop: "920px",
+} as const;
+
+/** Centered max-width for overview body copy. */
+export const overviewParagraphMaxWidthSx: SxProps<Theme> = {
+  width: "100%",
+  maxWidth: OVERVIEW_PARAGRAPH_MAX_WIDTH.mobile,
+  mx: "auto",
+  [breakpointMediaQuery.tabletUp]: {
+    maxWidth: OVERVIEW_PARAGRAPH_MAX_WIDTH.tablet,
+  },
+  [breakpointMediaQuery.desktopUp]: {
+    maxWidth: OVERVIEW_PARAGRAPH_MAX_WIDTH.desktop,
+  },
+};
+
+/**
+ * Standard `Container` constraints for case-study content inside a full-bleed band.
+ * Applies `LAYOUT_DIMENSIONS` max-width and horizontal margins per breakpoint.
+ */
+export const layoutContentContainerSx: SxProps<Theme> = {
+  width: "100%",
+  maxWidth: LAYOUT_DIMENSIONS.mobile.maxWidth,
+  mx: "auto",
+  boxSizing: "border-box",
+  px: LAYOUT_DIMENSIONS.mobile.margin,
+  [breakpointMediaQuery.tabletUp]: {
+    maxWidth: LAYOUT_DIMENSIONS.tablet.maxWidth,
+    px: LAYOUT_DIMENSIONS.tablet.margin,
+  },
+  [breakpointMediaQuery.desktopUp]: {
+    maxWidth: LAYOUT_DIMENSIONS.desktop.maxWidth,
+    px: LAYOUT_DIMENSIONS.desktop.margin,
+  },
+};
+
+export type SectionGaps = typeof SECTION_GAPS;
+export type FullBleedBandPaddings = typeof FULL_BLEED_BAND_PADDINGS;
+export type LayoutDimensions = typeof LAYOUT_DIMENSIONS;
+export type IntroSectionsBackground = typeof INTRO_SECTIONS_BACKGROUND;

--- a/app/projects/dcl-revenue-management/lib/dcl-revenue-management.firestore.ts
+++ b/app/projects/dcl-revenue-management/lib/dcl-revenue-management.firestore.ts
@@ -1,0 +1,90 @@
+import { db } from "@/firebase";
+import { doc, getDoc, onSnapshot } from "firebase/firestore";
+
+import {
+  dclRevenueManagementDataProject,
+  type DclRevenueManagementDataProjectDocument,
+} from "@/scripts/dcl-revenue-management.data";
+
+const COLLECTION = "projects_content";
+const PROJECT_KEY = dclRevenueManagementDataProject.project.projectKey;
+const NESTED_ARRAY_WRAPPER_KEY = "__firestoreNestedArray";
+
+export type DclRevenueManagementProjectDocument =
+  DclRevenueManagementDataProjectDocument;
+
+function decodeFirestoreNestedArrays(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(decodeFirestoreNestedArrays);
+  }
+
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    const wrappedArray = record[NESTED_ARRAY_WRAPPER_KEY];
+
+    if (Array.isArray(wrappedArray)) {
+      return wrappedArray.map(decodeFirestoreNestedArrays);
+    }
+
+    const decoded: Record<string, unknown> = {};
+    for (const [key, nestedValue] of Object.entries(record)) {
+      decoded[key] = decodeFirestoreNestedArrays(nestedValue);
+    }
+    return decoded;
+  }
+
+  return value;
+}
+
+export async function fetchDclRevenueManagementProject(): Promise<DclRevenueManagementDataProjectDocument> {
+  const docRef = doc(db, COLLECTION, PROJECT_KEY);
+  const snap = await getDoc(docRef);
+
+  if (!snap.exists()) {
+    throw new Error(`Missing Firestore document: ${COLLECTION}/${PROJECT_KEY}`);
+  }
+
+  const payload = snap.data() as { content?: unknown };
+  const content = payload?.content;
+
+  if (!content) {
+    throw new Error(`Missing 'content' field in ${COLLECTION}/${PROJECT_KEY}`);
+  }
+
+  return decodeFirestoreNestedArrays(content) as DclRevenueManagementDataProjectDocument;
+}
+
+export function subscribeDclRevenueManagementProject(
+  onData: (project: DclRevenueManagementDataProjectDocument) => void,
+  onError?: (error: Error) => void,
+) {
+  const docRef = doc(db, COLLECTION, PROJECT_KEY);
+
+  return onSnapshot(
+    docRef,
+    (snap) => {
+      try {
+        if (!snap.exists()) {
+          throw new Error(`Missing Firestore document: ${COLLECTION}/${PROJECT_KEY}`);
+        }
+
+        const payload = snap.data() as { content?: unknown };
+        const content = payload?.content;
+        if (!content) {
+          throw new Error(`Missing 'content' field in ${COLLECTION}/${PROJECT_KEY}`);
+        }
+
+        onData(
+          decodeFirestoreNestedArrays(content) as DclRevenueManagementDataProjectDocument,
+        );
+      } catch (err) {
+        const parsedError =
+          err instanceof Error ? err : new Error("Unknown snapshot parsing error");
+        onError?.(parsedError);
+      }
+    },
+    (firestoreError) => {
+      onError?.(firestoreError as Error);
+    },
+  );
+}

--- a/app/projects/dcl-revenue-management/lib/projectHeaderReady.ts
+++ b/app/projects/dcl-revenue-management/lib/projectHeaderReady.ts
@@ -1,0 +1,18 @@
+/** Tracks when the project header has mounted and reported ready (banner media loaded). */
+export function createProjectHeaderReadyGate() {
+  let settled = false;
+  let resolveReady!: () => void;
+
+  const promise = new Promise<void>((resolve) => {
+    resolveReady = () => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+  });
+
+  return {
+    promise,
+    markReady: () => resolveReady(),
+  };
+}

--- a/app/projects/dcl-revenue-management/typography.ts
+++ b/app/projects/dcl-revenue-management/typography.ts
@@ -1,0 +1,134 @@
+import type { SxProps, Theme } from "@mui/material/styles";
+
+import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
+
+/**
+ * DCL Revenue Management type tokens.
+ */
+
+/** Project header + section titles — Maven Pro. */
+export const DCL_TITLE_FONT =
+  'var(--font-maven-pro), "Maven Pro", Helvetica, sans-serif';
+
+/** Body copy — placeholder (Figtree) until body brand is finalized. */
+export const DCL_BODY_FONT =
+  'var(--font-figtree), "Figtree", Helvetica, sans-serif';
+
+/** Hero title on banner — mockup `#F6F6F6`. */
+export const DCL_HERO_TITLE_COLOR = "#F6F6F6";
+
+/** Hero subtitle on banner — mockup `#114578`. */
+export const DCL_HERO_SUBTITLE_COLOR = "#114578";
+
+/** Primary title color on light bands. Placeholder. */
+export const DCL_TITLE_COLOR = "#0B2A4A";
+
+/** Body copy on light bands. Placeholder. */
+export const DCL_BODY_COLOR = "#1F2937";
+
+/** Muted supporting / status copy. Placeholder. */
+export const DCL_MUTED_COLOR = "#4B5563";
+
+/**
+ * Responsive type scale (px).
+ *
+ * Breakpoints match `styles/variables.scss` / `lib/responsive/breakpoints.ts`:
+ *
+ * - `mobile`  -> 360–767px
+ * - `tablet`  -> 768–1023px
+ * - `desktop` -> 1024px+
+ */
+export const TYPOGRAPHY = {
+  /** Banner title — desktop Maven Pro ExtraBold 48px. */
+  heroTitle: { mobile: "24px", tablet: "34px", desktop: "38px" },
+  /** Banner subtitle — desktop Maven Pro SemiBold 36px. */
+  heroSubtitle: { mobile: "16px", tablet: "24px", desktop: "24px" },
+  /** Top-level section headings. */
+  sectionTitle: { mobile: "24px", tablet: "30px", desktop: "36px" },
+  /** Overview and preview body paragraphs. */
+  overviewBody: { mobile: "18px", tablet: "20px", desktop: "22px" },
+  /** Status / coming-soon notice. */
+  previewNotice: { mobile: "16px", tablet: "17px", desktop: "18px" },
+} as const;
+
+export type TypographyScaleKey = keyof typeof TYPOGRAPHY;
+
+export type TitleTypographyScaleKey = Extract<
+  TypographyScaleKey,
+  "heroTitle" | "heroSubtitle" | "sectionTitle"
+>;
+
+export type BodyTypographyScaleKey = Extract<
+  TypographyScaleKey,
+  "overviewBody" | "previewNotice"
+>;
+
+const TITLE_FONT_WEIGHT: Record<TitleTypographyScaleKey, number> = {
+  heroTitle: 800,
+  heroSubtitle: 600,
+  sectionTitle: 700,
+};
+
+const TITLE_COLOR: Partial<Record<TitleTypographyScaleKey, string>> = {
+  heroTitle: DCL_HERO_TITLE_COLOR,
+  heroSubtitle: DCL_HERO_SUBTITLE_COLOR,
+  sectionTitle: DCL_TITLE_COLOR,
+};
+
+const BODY_FONT_WEIGHT: Record<BodyTypographyScaleKey, number> = {
+  overviewBody: 500,
+  previewNotice: 500,
+};
+
+function buildResponsiveTypeSx(
+  scaleKey: TypographyScaleKey,
+  base: SxProps<Theme>,
+  extra?: SxProps<Theme>,
+): SxProps<Theme> {
+  const responsive = {
+    ...base,
+    fontSize: TYPOGRAPHY[scaleKey].mobile,
+    [breakpointMediaQuery.tabletUp]: {
+      fontSize: TYPOGRAPHY[scaleKey].tablet,
+    },
+    [breakpointMediaQuery.desktopUp]: {
+      fontSize: TYPOGRAPHY[scaleKey].desktop,
+    },
+  } satisfies SxProps<Theme>;
+
+  if (!extra) return responsive;
+
+  return { ...responsive, ...extra } as SxProps<Theme>;
+}
+
+export function titleTypeSx(
+  scaleKey: TitleTypographyScaleKey,
+  extra?: SxProps<Theme>,
+): SxProps<Theme> {
+  return buildResponsiveTypeSx(
+    scaleKey,
+    {
+      fontFamily: DCL_TITLE_FONT,
+      fontWeight: TITLE_FONT_WEIGHT[scaleKey],
+      lineHeight: 1.2,
+      ...(TITLE_COLOR[scaleKey] ? { color: TITLE_COLOR[scaleKey] } : {}),
+    },
+    extra,
+  );
+}
+
+export function bodyTypeSx(
+  scaleKey: BodyTypographyScaleKey,
+  extra?: SxProps<Theme>,
+): SxProps<Theme> {
+  return buildResponsiveTypeSx(
+    scaleKey,
+    {
+      fontFamily: DCL_BODY_FONT,
+      fontWeight: BODY_FONT_WEIGHT[scaleKey],
+      lineHeight: 1.6,
+      color: scaleKey === "previewNotice" ? DCL_MUTED_COLOR : DCL_BODY_COLOR,
+    },
+    extra,
+  );
+}

--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -5,6 +5,7 @@ import LinkedInIcon from '@mui/icons-material/LinkedIn';
 
 import { useResponsive } from '@/lib/responsive/ResponsiveQueryProvider';
 import { HeaderLogo } from '@/components/Header/HeaderLogo';
+import { isHomeNavActive, type HomeNavKey } from '@/lib/home/homeAnchors';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { clsx } from 'clsx';
@@ -20,6 +21,12 @@ type FooterProps = {
   logoAccentColor?: string;
   fontColor?: string;
   backgroundColor?: string;
+};
+
+type FooterMenuLink = {
+  path: string;
+  name: string;
+  navKey: HomeNavKey;
 };
 
 export function Footer(props: FooterProps = {}) {
@@ -38,15 +45,17 @@ export function Footer(props: FooterProps = {}) {
         logoAccentColor: props.logoAccentColor,
       });
 
-    const MenuLinks = [
-        { path: '/', name: 'Home' },
-        { path: '/aboutme', name: 'About Me' },
-        { path: '/mywork', name: 'My Work' },
-        { path: '/contact', name: 'Contact' },
-    ].map((link, index) =>
+    const menuLinks: FooterMenuLink[] = [
+        { path: '/', name: 'Home', navKey: 'home' },
+        { path: '/aboutme', name: 'About Me', navKey: 'about' },
+        { path: '/mywork', name: 'My Work', navKey: 'work' },
+        { path: '/contact', name: 'Contact', navKey: 'contact' },
+    ];
+
+    const MenuLinks = menuLinks.map((link, index) =>
         <span key={`menu-link-${index}`}>
             <Link
-                className={pathname === link.path
+                className={isHomeNavActive(pathname, '', link.navKey)
                     ? styles['active_link']
                     : ''}
                 href={link.path}>


### PR DESCRIPTION
### Summary

- Add a production preview page for Disney Cruise Line Revenue Management at /work/dcl-revenue-management (project_3), with banner header, Challenge / Snapshot / About sections, section delimiter, and coming-soon notice
- Wire Firestore content + Storage media, loading splash, home Selected Work link, Maven Pro hero type, and footer “My Work” active state on /work/* routes