### PR TITLE
Main pages/layout improvements

### DIFF
--- a/app/home/home-layout.scss
+++ b/app/home/home-layout.scss
@@ -48,13 +48,11 @@ $header-desktop-max: $home-layout-max-width-desktop;
 
 @mixin home-float-layer-bleed {
   position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 100vw;
+  inset: 0;
+  width: 100%;
   max-width: none;
   pointer-events: none;
   z-index: 0;
-  overflow: visible;
+  /* Clip floaters so they cannot create page-level horizontal scroll on mobile. */
+  overflow: hidden;
 }

--- a/app/home/main-banner.module.scss
+++ b/app/home/main-banner.module.scss
@@ -173,6 +173,13 @@
       /* ~10% of portrait height — margin avoids fighting GSAP transform on this node */
       margin: -1.875rem 0 0;
       filter: drop-shadow(0 16px 36px rgba(15, 23, 42, 0.2));
+
+      /* Wide mobile / large-phone edge (e.g. 767px): portrait was undersized vs full-width copy */
+      @media (min-width: 600px) {
+        height: clamp(300px, 56vh, 480px);
+        max-width: min(58vw, 440px);
+        margin: -1.25rem 0 0;
+      }
     }
   }
 

--- a/app/home/main-banner.module.scss
+++ b/app/home/main-banner.module.scss
@@ -160,17 +160,18 @@
     }
 
     @media screen and #{$mobile} {
-      /* ~25% larger than prior mobile cap; text reserve tightened to keep headline in view */
+      /* ~10% larger than prior mobile cap; shifted up so the 3 intro lines stay in view */
       height: clamp(
-        188px,
-        calc(100dvh - var(--header-height, 80px) - 8.25rem),
-        300px
+        207px,
+        calc(100dvh - var(--header-height, 80px) - 7.5rem),
+        330px
       );
       width: auto;
-      max-width: min(78vw, 263px);
+      max-width: min(86vw, 289px);
       aspect-ratio: 3 / 4;
       flex: 0 0 auto;
-      margin: 0;
+      /* ~10% of portrait height — margin avoids fighting GSAP transform on this node */
+      margin: -1.875rem 0 0;
       filter: drop-shadow(0 16px 36px rgba(15, 23, 42, 0.2));
     }
   }
@@ -304,7 +305,6 @@
 
 .floatLayer {
   @include home.home-float-layer-bleed;
-  overflow: hidden;
 }
 
 .floatImg {

--- a/app/home/my-background.module.scss
+++ b/app/home/my-background.module.scss
@@ -72,6 +72,16 @@ $what-i-do-gap-desktop: 32px;
   gap: $what-i-do-gap-mobile;
   grid-template-columns: minmax(0, $what-i-do-card-width-mobile);
 
+  /* Wide mobile — 2×2 with phone card size (168×206) */
+  @media screen and (min-width: 600px) and (max-width: $mobile-max) {
+    gap: $what-i-do-gap-mobile;
+    grid-template-columns: repeat(2, minmax(0, $what-i-do-card-width-mobile));
+    width: min(
+      100%,
+      calc(#{$what-i-do-card-width-mobile} * 2 + #{$what-i-do-gap-mobile})
+    );
+  }
+
   /* Tablet — 2×2, 24px gap (proportional to desktop 32px) */
   @media screen and #{$tablet} {
     gap: $what-i-do-gap-tablet;

--- a/app/mywork/mywork.module.scss
+++ b/app/mywork/mywork.module.scss
@@ -39,6 +39,11 @@
         max-width: 420px;
       }
 
+      /* Wide mobile: match 2×320px project cards + 1rem column-gap */
+      @media screen and (min-width: 600px) and (max-width: $mobile-max) {
+        max-width: min(100%, calc(2 * 320px + 1rem));
+      }
+
       @include fluid-type(16px, 20px, 24px);
       font-family: var(--font-figtree);
       color: $font-color-bold;

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -6,6 +6,9 @@ html, body {
   padding: 0;
   /* Token from `lib/theme/pageCanvas.ts` via `--page-canvas` on `<html>` */
   background-color: var(--page-canvas);
+  /* Prevent accidental sideways scroll on mobile (prefer clip over hidden for sticky). */
+  overflow-x: clip;
+  max-width: 100%;
 }
 
 /* Mobile hamburger + slide-out drawer — single navy (matches headerTheme.ts) */


### PR DESCRIPTION
### Summary
Mobile/wide-mobile layout polish for the home and My Work pages.

- Horizontal scroll fix — Float layers use width: 100% + clip instead of 100vw; html/body get overflow-x: clip.
- Home portrait — Larger on phones (~10%) and shifted up; further enlarged for wide mobile (600–767px).
- What I do cards — Wide mobile uses a 2×2 grid with phone-sized cards (168×206); phones stay 1 column.
- My Work summary — Wide mobile text width matches the two-card row (2×320px + gap).