### PR TITLE
About me page/improvement/labels capabilitymap

### DIFF
--- a/app/aboutme/components/CapabilityMap/CapabilityMapLabels.tsx
+++ b/app/aboutme/components/CapabilityMap/CapabilityMapLabels.tsx
@@ -1,0 +1,33 @@
+import styles from "./capability-map.module.scss";
+
+const expertiseLevels = [
+  { label: "Foundational", sizeClass: styles.capabilityMapLabelCircleSm },
+  { label: "Proficient", sizeClass: styles.capabilityMapLabelCircleMd },
+  { label: "Advanced", sizeClass: styles.capabilityMapLabelCircleLg },
+  { label: "Expert", sizeClass: styles.capabilityMapLabelCircleXl },
+] as const;
+
+export function CapabilityMapLabels() {
+  return (
+    <section
+      className={styles.capabilityMapLabels}
+      aria-labelledby="expertise-level-title"
+    >
+      <h3 id="expertise-level-title" className={styles.capabilityMapLabelsTitle}>
+        Expertise Level
+      </h3>
+      <ul className={styles.capabilityMapLabelsList} aria-label="Expertise level legend">
+        {expertiseLevels.map(({ label, sizeClass }) => (
+          <li key={label} className={styles.capabilityMapLabelsRow}>
+            <span className={styles.capabilityMapLabelCircleSlot} aria-hidden>
+              <span className={`${styles.capabilityMapLabelCircle} ${sizeClass}`} />
+            </span>
+            <span className={styles.capabilityMapLabelText}>{label}</span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export default CapabilityMapLabels;

--- a/app/aboutme/components/CapabilityMap/capability-map.module.scss
+++ b/app/aboutme/components/CapabilityMap/capability-map.module.scss
@@ -102,6 +102,209 @@
     height: 100%;
   }
 
+  &LabelsWrap {
+    // Compact legend card under the chart, right-aligned.
+    // Negative margin pulls it into the empty square below the circular map.
+    align-self: flex-end;
+    width: fit-content;
+    max-width: 100%;
+    margin-top: -4.5rem;
+    position: relative;
+    z-index: 1;
+
+    @media screen and (min-width: $tablet-min) {
+      margin-top: -7rem;
+    }
+
+    @media screen and (min-width: $desktop-min) {
+      margin-top: -11rem;
+    }
+  }
+
+  &Labels {
+    box-sizing: border-box;
+    width: fit-content;
+    max-width: 100%;
+    // Mobile-first; scale up at tablet / desktop.
+    padding: 0.55rem 0.7rem 0.6rem;
+    border: 0.75px solid #A9C4FA;
+    border-radius: 6px;
+    background-color: #f9fcff;
+
+    @media screen and (min-width: $tablet-min) {
+      padding: 0.7rem 0.85rem 0.75rem;
+      border-width: 1.25px;
+      border-radius: 7px;
+    }
+
+    @media screen and (min-width: $desktop-min) {
+      padding: 0.875rem 1.05rem 0.95rem;
+      border-width: 1.5px;
+      border-radius: 8px;
+    }
+  }
+
+  &LabelsTitle {
+    margin: 0 0 0.75rem;
+    text-align: center;
+    font-family: var(--font-montserrat);
+    font-size: 0.58rem;
+    font-weight: 600;
+    line-height: 1.2;
+    color: $font-color-bold;
+
+    @media screen and (min-width: $tablet-min) {
+      margin-bottom: 0.95rem;
+      font-size: 0.65rem;
+    }
+
+    @media screen and (min-width: $desktop-min) {
+      margin-bottom: 1.15rem;
+      font-size: 16px;
+    }
+  }
+
+  &LabelsList {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+
+    @media screen and (min-width: $tablet-min) {
+      gap: 0.5rem;
+    }
+
+    @media screen and (min-width: $desktop-min) {
+      gap: 0.63rem;
+    }
+  }
+
+  &LabelsRow {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.4rem;
+
+    @media screen and (min-width: $tablet-min) {
+      gap: 0.5rem;
+    }
+
+    @media screen and (min-width: $desktop-min) {
+      gap: 0.6rem;
+    }
+  }
+
+  &LabelCircleSlot {
+    width: 1.25rem;
+    flex-shrink: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    @media screen and (min-width: $tablet-min) {
+      width: 1.55rem;
+    }
+
+    @media screen and (min-width: $desktop-min) {
+      width: 1.925rem;
+    }
+  }
+
+  &LabelCircle {
+    box-sizing: border-box;
+    flex-shrink: 0;
+    border: 1px solid $font-color-bold;
+    border-radius: 50%;
+    background: transparent;
+
+    @media screen and (min-width: $tablet-min) {
+      border-width: 1.15px;
+    }
+
+    @media screen and (min-width: $desktop-min) {
+      border-width: 1.25px;
+    }
+  }
+
+  &LabelCircleSm {
+    width: 0.4rem;
+    height: 0.4rem;
+
+    @media screen and (min-width: $tablet-min) {
+      width: 0.5rem;
+      height: 0.5rem;
+    }
+
+    @media screen and (min-width: $desktop-min) {
+      width: 0.61rem;
+      height: 0.61rem;
+    }
+  }
+
+  &LabelCircleMd {
+    width: 0.62rem;
+    height: 0.62rem;
+
+    @media screen and (min-width: $tablet-min) {
+      width: 0.78rem;
+      height: 0.78rem;
+    }
+
+    @media screen and (min-width: $desktop-min) {
+      width: 0.96rem;
+      height: 0.96rem;
+    }
+  }
+
+  &LabelCircleLg {
+    width: 0.9rem;
+    height: 0.9rem;
+
+    @media screen and (min-width: $tablet-min) {
+      width: 1.15rem;
+      height: 1.15rem;
+    }
+
+    @media screen and (min-width: $desktop-min) {
+      width: 1.4rem;
+      height: 1.4rem;
+    }
+  }
+
+  &LabelCircleXl {
+    width: 1.2rem;
+    height: 1.2rem;
+
+    @media screen and (min-width: $tablet-min) {
+      width: 1.5rem;
+      height: 1.5rem;
+    }
+
+    @media screen and (min-width: $desktop-min) {
+      width: 1.84rem;
+      height: 1.84rem;
+    }
+  }
+
+  &LabelText {
+    font-family: var(--font-montserrat);
+    font-size: 0.58rem;
+    font-weight: 400;
+    line-height: 1.2;
+    color: $font-color-bold;
+    white-space: nowrap;
+
+    @media screen and (min-width: $tablet-min) {
+      font-size: 0.65rem;
+    }
+
+    @media screen and (min-width: $desktop-min) {
+      font-size: 0.735rem;
+    }
+  }
+
   &Chart {
     display: block;
     flex-shrink: 0;
@@ -154,7 +357,7 @@
 
   &DomainLabel {
     font-family: var(--font-montserrat);
-    font-size: clamp(0.62rem, 1.5vw, 0.85rem);
+    font-size: clamp(0.62rem, 1.5vw, 0.90rem);
     font-weight: 700;
     letter-spacing: 0.01em;
   }

--- a/app/aboutme/components/CapabilityMap/index.tsx
+++ b/app/aboutme/components/CapabilityMap/index.tsx
@@ -7,6 +7,7 @@ import type { CapabilityMapData } from "@/app/aboutme/data/capability-map-data";
 import { capabilityMapFallback } from "@/app/aboutme/data/capability-map-data";
 import { subscribeCapabilityMapData } from "@/app/aboutme/lib/capability-map.firestore";
 import { CapabilityMapChart } from "./CapabilityMapChart";
+import { CapabilityMapLabels } from "./CapabilityMapLabels";
 import { getCapabilityMapSizeStyles } from "./capability-map.size";
 import styles from "./capability-map.module.scss";
 
@@ -79,6 +80,10 @@ export function CapabilityMap() {
             ) : (
               <div className={styles.capabilityMapChartPlaceholder} aria-hidden />
             )}
+          </div>
+
+          <div className={styles.capabilityMapLabelsWrap}>
+            <CapabilityMapLabels />
           </div>
         </div>
       </div>

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -43,8 +43,10 @@ export default function Header({
   };
 
   const resumeHref = "/resume/AntonioEggermontResume-2024.pdf";
+  const stickyHeaderPaths = ["/", "/aboutme"];
   const useStickyHomeHeader =
-    pathname === "/" && position === defaultHeaderState.position;
+    stickyHeaderPaths.includes(pathname) &&
+    position === defaultHeaderState.position;
 
   const isOverlayPosition =
     !useStickyHomeHeader &&


### PR DESCRIPTION
### Summary

- Add an Expertise Level legend under the Capability Map (right-aligned), with responsive sizing for mobile/tablet/desktop
- Tune legend placement, typography, and spacing relative to the chart
- Keep the top navigation sticky on /aboutme, matching the landing page