### PR TITLE
Main landing page/layout improvements

### DIFF
--- a/app/home/BackgroundCard.tsx
+++ b/app/home/BackgroundCard.tsx
@@ -16,9 +16,10 @@ import CloseIcon from "@mui/icons-material/Close";
 
 import styles from "./background.module.scss";
 import type { BackgroundItem } from "@/app/home/data/background-data";
+import { buildPublicStorageUrl } from "@/lib/firebase/publicStorageUrl";
 
-const DIALOG_ICON_OPACITY = 0.80;
-const CARD_ICON_OPACITY = 0.80;
+const DIALOG_ICON_OPACITY = 1;
+const CARD_ICON_OPACITY = 1;
 
 type BackgroundCardProps = {
   info: BackgroundItem;
@@ -27,14 +28,21 @@ type BackgroundCardProps = {
 export default function BackgroundCard({ info }: BackgroundCardProps) {
   const [open, setOpen] = useState(false);
 
-  const { title, img, description } = info;
+  const {
+    title,
+    iconObjectPath,
+    iconWidth = 36,
+    iconHeight = 36,
+    summary,
+    description,
+  } = info;
+  const iconSrc = buildPublicStorageUrl(iconObjectPath);
 
   const handleClickOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
 
   return (
     <>
-      {/* Dialog with full description */}
       <Dialog
         fullWidth
         maxWidth="lg"
@@ -62,14 +70,14 @@ export default function BackgroundCard({ info }: BackgroundCardProps) {
           </Tooltip>
         </div>
 
-        {/* Header: icon + title */}
         <div className={styles.dialogHeader}>
           <div className={styles.dialogHeaderMain}>
             <div className={styles.dialogIcon}>
               <Image
-                src={img}
+                src={iconSrc}
                 alt={title}
                 fill
+                unoptimized
                 style={{ objectFit: "contain", opacity: DIALOG_ICON_OPACITY }}
               />
             </div>
@@ -96,7 +104,6 @@ export default function BackgroundCard({ info }: BackgroundCardProps) {
           </div>
         </div>
 
-        {/* Body: paragraphs */}
         <DialogContent dividers id="background-dialog-description">
           {description.map((paragraph, index) => (
             <DialogContentText
@@ -125,7 +132,6 @@ export default function BackgroundCard({ info }: BackgroundCardProps) {
         </DialogContent>
       </Dialog>
 
-      {/* Card */}
       <Card
         onClick={handleClickOpen}
         className={styles.fullHeightCard}
@@ -144,27 +150,42 @@ export default function BackgroundCard({ info }: BackgroundCardProps) {
         }}
         raised
       >
-        <CardActionArea sx={{ height: "100%" }}>
+        <CardActionArea
+          className={styles.cardActionArea}
+          sx={{
+            height: "100%",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "flex-start",
+            justifyContent: "flex-start",
+            padding: "24px",
+            boxSizing: "border-box",
+            gap: "16px",
+          }}
+        >
           <div className={styles.cardIconArea}>
-            <div className={styles.cardIcon}>
+            <div
+              className={styles.cardIcon}
+              style={{ width: iconWidth, height: iconHeight }}
+            >
               <Image
-                src={img}
+                src={iconSrc}
                 alt={title}
                 fill
+                unoptimized
                 style={{ objectFit: "contain", opacity: CARD_ICON_OPACITY }}
               />
             </div>
           </div>
 
-          {/* Title */}
-          <CardContent>
+          <CardContent className={styles.cardContent}>
             <div className={styles.backgroundTitle}>
               <span className={styles.backgroundTitleLabel}>{title}</span>
             </div>
+            <p className={styles.cardSummary}>{summary}</p>
           </CardContent>
         </CardActionArea>
       </Card>
     </>
   );
 }
-

--- a/app/home/BackgroundCard.tsx
+++ b/app/home/BackgroundCard.tsx
@@ -72,7 +72,10 @@ export default function BackgroundCard({ info }: BackgroundCardProps) {
 
         <div className={styles.dialogHeader}>
           <div className={styles.dialogHeaderMain}>
-            <div className={styles.dialogIcon}>
+            <div
+              className={styles.dialogIcon}
+              style={{ width: iconWidth, height: iconHeight }}
+            >
               <Image
                 src={iconSrc}
                 alt={title}
@@ -104,7 +107,10 @@ export default function BackgroundCard({ info }: BackgroundCardProps) {
           </div>
         </div>
 
-        <DialogContent dividers id="background-dialog-description">
+        <DialogContent
+          id="background-dialog-description"
+          className={styles.dialogContent}
+        >
           {description.map((paragraph, index) => (
             <DialogContentText
               key={index}
@@ -117,11 +123,9 @@ export default function BackgroundCard({ info }: BackgroundCardProps) {
                 },
                 fontWeight: 400,
                 fontFamily: "Poppins, sans-serif",
-                margin: {
-                  xs: "0.75rem 0.75rem",
-                  sm: "1rem 1.5rem",
-                  md: "1rem 2rem",
-                  lg: "1rem 2.5rem",
+                margin: 0,
+                "&:not(:last-of-type)": {
+                  mb: { xs: "0.75rem", sm: "1rem" },
                 },
                 color: "#011114",
               }}
@@ -138,6 +142,7 @@ export default function BackgroundCard({ info }: BackgroundCardProps) {
         sx={{
           cursor: "pointer",
           borderRadius: 3,
+          overflow: "hidden",
           boxShadow: "0 4px 18px rgba(0, 0, 0, 0.08)",
           backgroundColor: "#ffffff",
           transition:
@@ -145,7 +150,7 @@ export default function BackgroundCard({ info }: BackgroundCardProps) {
           "&:hover": {
             transform: "translateY(-6px)",
             boxShadow: "0 18px 45px rgba(0, 0, 0, 0.18)",
-            backgroundColor: "#f7fbff",
+            backgroundColor: "#efe9dc",
           },
         }}
         raised
@@ -161,6 +166,12 @@ export default function BackgroundCard({ info }: BackgroundCardProps) {
             padding: "24px",
             boxSizing: "border-box",
             gap: "16px",
+            borderRadius: "inherit",
+            overflow: "hidden",
+            // Keep hover color on the Card; don’t let MUI’s overlay square the corners
+            "& .MuiCardActionArea-focusHighlight": {
+              backgroundColor: "transparent",
+            },
           }}
         >
           <div className={styles.cardIconArea}>

--- a/app/home/LatestProjectCard.tsx
+++ b/app/home/LatestProjectCard.tsx
@@ -7,20 +7,31 @@ import CardContent from "@mui/material/CardContent";
 import CardMedia from "@mui/material/CardMedia";
 import CardActionArea from "@mui/material/CardActionArea";
 import Box from "@mui/material/Box";
+import Divider from "@mui/material/Divider";
 import Typography from "@mui/material/Typography";
+import NorthEastIcon from "@mui/icons-material/NorthEast";
 import type { StaticImageData } from "next/image";
 import { SELECTED_WORK_CARD } from "./selectedWorkCardLayout";
 
 export type LatestProjectProps = {
   title: string;
   thumbnailImg: StaticImageData;
-  description: string[];
+  role: string;
+  description: string;
+  outcome: string;
   href?: string;
 };
 
-function LatestProjectCard({ title, thumbnailImg, description, href }: LatestProjectProps) {
-  const { widthPx, heightPx, contentPaddingPx } = SELECTED_WORK_CARD;
-  const bleedX = contentPaddingPx * 2;
+function LatestProjectCard({
+  title,
+  thumbnailImg,
+  role,
+  description,
+  outcome,
+  href,
+}: LatestProjectProps) {
+  const { widthPx, heightPx, imageHeightPx, contentPaddingPx } =
+    SELECTED_WORK_CARD;
 
   return (
     <Card
@@ -28,7 +39,7 @@ function LatestProjectCard({ title, thumbnailImg, description, href }: LatestPro
         width: `${widthPx}px`,
         height: `${heightPx}px`,
         flexShrink: 0,
-        borderRadius: 1.5,
+        borderRadius: 3,
         boxShadow: "0 4px 14px rgba(0, 0, 0, 0.08)",
         transition: "transform 0.35s ease, box-shadow 0.35s ease, opacity 0.3s ease",
         overflow: "hidden",
@@ -54,8 +65,6 @@ function LatestProjectCard({ title, thumbnailImg, description, href }: LatestPro
           flexDirection: "column",
           alignItems: "stretch",
           boxSizing: "border-box",
-          padding: `${contentPaddingPx}px`,
-          paddingBottom: 0,
           ...(href ? {} : { cursor: "default" }),
         }}
       >
@@ -66,16 +75,11 @@ function LatestProjectCard({ title, thumbnailImg, description, href }: LatestPro
           alt={title}
           sx={{
             display: "block",
-            width: `calc(100% + ${bleedX}px)`,
-            maxWidth: `calc(100% + ${bleedX}px)`,
-            height: "auto",
+            width: "100%",
+            height: `${imageHeightPx}px`,
             flexShrink: 0,
-            marginTop: `-${contentPaddingPx}px`,
-            marginLeft: `-${contentPaddingPx}px`,
-            marginRight: `-${contentPaddingPx}px`,
-            marginBottom: `${contentPaddingPx}px`,
-            objectFit: "contain",
-            objectPosition: "top center",
+            objectFit: "cover",
+            objectPosition: "center",
             transition: "opacity 0.3s ease",
           }}
         />
@@ -88,8 +92,7 @@ function LatestProjectCard({ title, thumbnailImg, description, href }: LatestPro
             gap: 1,
             minHeight: 0,
             boxSizing: "border-box",
-            padding: 0,
-            paddingBottom: `${contentPaddingPx}px`,
+            padding: `${contentPaddingPx}px`,
             "&:last-child": {
               paddingBottom: `${contentPaddingPx}px`,
             },
@@ -99,41 +102,85 @@ function LatestProjectCard({ title, thumbnailImg, description, href }: LatestPro
             sx={{
               display: "flex",
               alignItems: "flex-start",
-              justifyContent: "center",
-              textAlign: "center",
+              justifyContent: "space-between",
+              gap: 1,
+              // Reserve two title lines so single-line titles don't shift the footer.
+              minHeight: "calc(1rem * 1.35 * 2)",
             }}
           >
             <Typography
               component="h3"
               sx={{
+                flex: 1,
                 fontSize: "1rem",
-                fontWeight: 500,
+                fontWeight: 600,
                 fontFamily: "Poppins, sans-serif",
                 color: "#011114",
+                lineHeight: 1.35,
+                textAlign: "left",
               }}
             >
               {title}
             </Typography>
+            <NorthEastIcon
+              aria-hidden
+              sx={{
+                fontSize: 18,
+                color: "#4a5560",
+                mt: "2px",
+                flexShrink: 0,
+              }}
+            />
           </Box>
 
-          <Box sx={{ textAlign: "left", flex: 1 }}>
-            {description.map((paragraph, idx) => (
-              <Typography
-                key={idx}
-                sx={{
-                  fontSize: "0.9rem",
-                  fontWeight: 400,
-                  fontFamily: "Poppins, sans-serif",
-                  color: "#011114",
-                  lineHeight: 1.6,
-                  "&:not(:last-of-type)": {
-                    mb: 1,
-                  },
-                }}
-              >
-                {paragraph}
-              </Typography>
-            ))}
+          <Typography
+            sx={{
+              fontSize: "0.8125rem",
+              fontWeight: 600,
+              fontFamily: "Poppins, sans-serif",
+              color: "#F59F0A",
+              lineHeight: 1.3,
+              textAlign: "left",
+            }}
+          >
+            {role}
+          </Typography>
+
+          <Typography
+            sx={{
+              fontSize: "0.875rem",
+              fontWeight: 400,
+              fontFamily: "Poppins, sans-serif",
+              color: "#5c6b73",
+              lineHeight: 1.5,
+              textAlign: "left",
+            }}
+          >
+            {description}
+          </Typography>
+
+          <Box
+            sx={{
+              mt: "auto",
+              display: "flex",
+              flexDirection: "column",
+              gap: 1,
+            }}
+          >
+            <Divider sx={{ borderColor: "rgba(1, 17, 20, 0.12)" }} />
+
+            <Typography
+              sx={{
+                fontSize: "0.875rem",
+                fontWeight: 500,
+                fontFamily: "Poppins, sans-serif",
+                color: "#011114",
+                lineHeight: 1.4,
+                textAlign: "left",
+              }}
+            >
+              {outcome}
+            </Typography>
           </Box>
         </CardContent>
       </CardActionArea>

--- a/app/home/background.module.scss
+++ b/app/home/background.module.scss
@@ -4,18 +4,42 @@
   max-width: 100%;
   display: flex;
   flex-direction: column;
+  box-sizing: border-box;
+}
+
+.cardActionArea {
+  /* Layout + 24px padding also set via MUI `sx` so they win over CardActionArea defaults */
+  height: 100%;
+  display: flex !important;
+  flex-direction: column !important;
+  align-items: flex-start !important;
+  justify-content: flex-start !important;
+  padding: 24px !important;
+  box-sizing: border-box !important;
+  gap: 16px;
 }
 
 .cardIconArea {
   display: flex;
-  justify-content: center;
-  padding-top: 0.65rem;
+  justify-content: flex-start;
+  align-items: flex-start;
+  padding: 0;
+  width: 100%;
 }
 
 .cardIcon {
   position: relative;
-  width: 72px;
-  height: 72px;
+  width: 36px;
+  height: 36px;
+  flex-shrink: 0;
+}
+
+.cardContent {
+  /* Kill MUI CardContent’s default 16px padding so the 24px card padding is the only inset */
+  padding: 0 !important;
+  margin: 0 !important;
+  width: 100%;
+  flex: 0 0 auto;
 }
 
 .dialogPaper {
@@ -81,41 +105,28 @@
   }
 }
 
-@media screen and #{$mobile} {
-  .backgroundTitle {
-    text-align: center;
-    .backgroundTitleLabel {
-      margin-bottom: 30px;
-      font-weight: 600;
-      font-size: 0.9rem;
-      color: #074C5F;
-      font-family: var(--font-montserrat);
-    }
+.backgroundTitle {
+  text-align: left;
+  width: 100%;
+
+  .backgroundTitleLabel {
+    display: block;
+    margin-bottom: 0;
+    font-family: var(--font-poppins);
+    font-size: 18px;
+    font-weight: 500;
+    color: #074c5f;
+    line-height: 1.3;
   }
 }
 
-@media screen and #{$tablet} {
-  .backgroundTitle {
-    text-align: center;
-    .backgroundTitleLabel {
-      margin-bottom: 30px;
-      font-weight: 600;
-      font-size: 1rem;
-      color: #074C5F;
-      font-family: var(--font-montserrat);
-    }
-  }
-}
-
-@media screen and #{$desktop-device} {
-  .backgroundTitle {
-    text-align: center;
-    .backgroundTitleLabel {
-      margin-bottom: 2rem;
-      font-weight: 600;
-      font-size: 1.1rem;
-      color: #074C5F;
-      font-family: var(--font-montserrat);
-    }
-  }
+.cardSummary {
+  margin: 0.5rem 0 0;
+  padding: 0;
+  text-align: left;
+  font-family: var(--font-poppins);
+  font-size: 16px;
+  font-weight: 300;
+  color: #074c5f;
+  line-height: 1.4;
 }

--- a/app/home/background.module.scss
+++ b/app/home/background.module.scss
@@ -1,45 +1,21 @@
 .fullHeightCard {
-  width: 152px;
-  height: 140px;
+  width: 280px;
+  height: 210px;
   max-width: 100%;
   display: flex;
   flex-direction: column;
-
-  @media screen and #{$tablet} {
-    width: 183px;
-    height: 168px;
-  }
-
-  @media screen and #{$desktop-device} {
-    width: 280px;
-    height: 210px;
-  }
 }
 
 .cardIconArea {
   display: flex;
   justify-content: center;
-  padding-top: 0.5rem;
-
-  @media screen and (min-width: $tablet-min) {
-    padding-top: 0.65rem;
-  }
+  padding-top: 0.65rem;
 }
 
 .cardIcon {
   position: relative;
-  width: 56px;
-  height: 56px;
-
-  @media screen and #{$tablet} {
-    width: 64px;
-    height: 64px;
-  }
-
-  @media screen and #{$desktop-device} {
-    width: 72px;
-    height: 72px;
-  }
+  width: 72px;
+  height: 72px;
 }
 
 .dialogPaper {

--- a/app/home/background.module.scss
+++ b/app/home/background.module.scss
@@ -5,6 +5,7 @@
   display: flex;
   flex-direction: column;
   box-sizing: border-box;
+  overflow: hidden;
 }
 
 .cardActionArea {
@@ -63,11 +64,11 @@
   padding: 2.75rem 16px 0;
 
   @media screen and (min-width: $tablet-min) {
-    padding: 2.75rem 1.5rem 0;
+    padding: 3rem 2.5rem 0;
   }
 
   @media screen and (min-width: $desktop-min) {
-    padding: 2.75rem 2rem 0;
+    padding: 3.25rem 3rem 0;
   }
 }
 
@@ -88,9 +89,22 @@
 
 .dialogIcon {
   position: relative;
-  width: 65px;
-  height: 65px;
+  width: 36px;
+  height: 36px;
   flex-shrink: 0;
+}
+
+.dialogContent {
+  /* Match header left/right; keep bottom consistent at each breakpoint */
+  padding: 16px !important;
+
+  @media screen and (min-width: $tablet-min) {
+    padding: 2.5rem !important;
+  }
+
+  @media screen and (min-width: $desktop-min) {
+    padding: 3rem !important;
+  }
 }
 
 .dialogTitle {

--- a/app/home/background.module.scss
+++ b/app/home/background.module.scss
@@ -1,34 +1,44 @@
 .fullHeightCard {
-  width: 168px;
-  height: 206px;
+  width: 152px;
+  height: 140px;
   max-width: 100%;
   display: flex;
   flex-direction: column;
 
-  @media screen and (min-width: $tablet-min) {
-    width: 212px;
-    height: 260px;
+  @media screen and #{$tablet} {
+    width: 183px;
+    height: 168px;
+  }
+
+  @media screen and #{$desktop-device} {
+    width: 280px;
+    height: 210px;
   }
 }
 
 .cardIconArea {
   display: flex;
   justify-content: center;
-  padding-top: 0.75rem;
+  padding-top: 0.5rem;
 
   @media screen and (min-width: $tablet-min) {
-    padding-top: 1rem;
+    padding-top: 0.65rem;
   }
 }
 
 .cardIcon {
   position: relative;
-  width: 95px;
-  height: 95px;
+  width: 56px;
+  height: 56px;
 
-  @media screen and (min-width: $tablet-min) {
-    width: 120px;
-    height: 120px;
+  @media screen and #{$tablet} {
+    width: 64px;
+    height: 64px;
+  }
+
+  @media screen and #{$desktop-device} {
+    width: 72px;
+    height: 72px;
   }
 }
 

--- a/app/home/components/WhatIDoCarousel.tsx
+++ b/app/home/components/WhatIDoCarousel.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import ArrowBackIosNewIcon from "@mui/icons-material/ArrowBackIosNew";
+import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
+
+import BackgroundCard from "@/app/home/BackgroundCard";
+import type { BackgroundItem } from "@/app/home/data/background-data";
+import { usePrefersReducedMotion } from "@/lib/hooks/usePrefersReducedMotion";
+
+import styles from "./what-i-do-carousel.module.scss";
+
+const SCROLL_EDGE_EPSILON = 8;
+
+type WhatIDoCarouselProps = {
+  items: BackgroundItem[];
+};
+
+function readScrollStepPx(track: HTMLDivElement): number {
+  const first = track.querySelector<HTMLElement>("[data-carousel-card]");
+  if (!first) return 304;
+  const w = first.getBoundingClientRect().width;
+  const marginEnd = Number.parseFloat(getComputedStyle(first).marginInlineEnd) || 0;
+  const cardStep = w + marginEnd;
+  const visibleCards = Math.max(1, Math.round(track.clientWidth / cardStep));
+  return cardStep * visibleCards;
+}
+
+/** True when first/last card extends past the visible track edges. */
+function cardsPeekOffscreen(track: HTMLDivElement): {
+  peeksLeft: boolean;
+  peeksRight: boolean;
+} {
+  const cards = track.querySelectorAll<HTMLElement>("[data-carousel-card]");
+  if (!cards.length) return { peeksLeft: false, peeksRight: false };
+
+  const trackRect = track.getBoundingClientRect();
+  const firstRect = cards[0].getBoundingClientRect();
+  const lastRect = cards[cards.length - 1].getBoundingClientRect();
+
+  return {
+    peeksLeft: firstRect.left < trackRect.left - SCROLL_EDGE_EPSILON,
+    peeksRight: lastRect.right > trackRect.right + SCROLL_EDGE_EPSILON,
+  };
+}
+
+function AnimatedCardShell({
+  children,
+  index,
+}: {
+  children: ReactNode;
+  index: number;
+}) {
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [inView, setInView] = useState(prefersReducedMotion);
+
+  useEffect(() => {
+    if (prefersReducedMotion) {
+      setInView(true);
+      return;
+    }
+
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setInView(true);
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      {
+        root: null,
+        threshold: 0.15,
+        rootMargin: "0px 0px -10% 0px",
+      },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [prefersReducedMotion]);
+
+  return (
+    <div
+      ref={ref}
+      data-carousel-card
+      className={`${styles.cardShell} ${inView ? styles.cardInView : ""}`}
+      style={{
+        transitionDelay:
+          inView && !prefersReducedMotion ? `${index * 90}ms` : "0ms",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function WhatIDoCarousel({ items }: WhatIDoCarouselProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollPrev, setCanScrollPrev] = useState(false);
+  const [canScrollNext, setCanScrollNext] = useState(false);
+  const [needsCarouselNav, setNeedsCarouselNav] = useState(false);
+
+  const updateScrollHints = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    const { peeksLeft, peeksRight } = cardsPeekOffscreen(el);
+    const overflow = peeksLeft || peeksRight;
+    const { scrollLeft, scrollWidth, clientWidth } = el;
+    const nextPrev =
+      peeksLeft || scrollLeft > SCROLL_EDGE_EPSILON;
+    const nextNext =
+      peeksRight ||
+      scrollLeft + clientWidth < scrollWidth - SCROLL_EDGE_EPSILON;
+
+    setNeedsCarouselNav((p) => (p === overflow ? p : overflow));
+    setCanScrollPrev((p) => (p === nextPrev ? p : nextPrev));
+    setCanScrollNext((p) => (p === nextNext ? p : nextNext));
+  }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollLeft = 0;
+    // Measure after layout — padding/spacers + card widths need a frame
+    const id = requestAnimationFrame(() => updateScrollHints());
+    return () => cancelAnimationFrame(id);
+  }, [items.length, updateScrollHints]);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    const onScroll = () => updateScrollHints();
+    el.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", updateScrollHints);
+
+    const resizeObserver = new ResizeObserver(() => updateScrollHints());
+    resizeObserver.observe(el);
+
+    return () => {
+      el.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", updateScrollHints);
+      resizeObserver.disconnect();
+    };
+  }, [items.length, updateScrollHints]);
+
+  const scrollByStep = (direction: 1 | -1) => {
+    const track = scrollRef.current;
+    if (!track) return;
+    track.scrollBy({ left: direction * readScrollStepPx(track), behavior: "smooth" });
+  };
+
+  if (!items.length) return null;
+
+  return (
+    <div
+      className={styles.carousel}
+      role="region"
+      aria-label="What I do capabilities"
+    >
+      <div ref={scrollRef} className={styles.track}>
+        {/* Spacers (not padding) align the first card and avoid false scroll overflow */}
+        <div className={styles.gutterSpacer} aria-hidden="true" />
+        {items.map((item, index) => (
+          <AnimatedCardShell key={item.title} index={index}>
+            <BackgroundCard info={item} />
+          </AnimatedCardShell>
+        ))}
+        <div className={styles.gutterSpacer} aria-hidden="true" />
+      </div>
+
+      {needsCarouselNav ? (
+        <div className={styles.nav}>
+          <button
+            type="button"
+            className={styles.navButton}
+            aria-label="Show previous capabilities"
+            disabled={!canScrollPrev}
+            onClick={() => {
+              if (canScrollPrev) scrollByStep(-1);
+            }}
+          >
+            <ArrowBackIosNewIcon sx={{ fontSize: 16 }} />
+          </button>
+          <button
+            type="button"
+            className={`${styles.navButton} ${styles.navButtonNext}`}
+            aria-label="Show more capabilities"
+            disabled={!canScrollNext}
+            onClick={() => {
+              if (canScrollNext) scrollByStep(1);
+            }}
+          >
+            <ArrowForwardIosIcon sx={{ fontSize: 16 }} />
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export default WhatIDoCarousel;

--- a/app/home/components/what-i-do-carousel.module.scss
+++ b/app/home/components/what-i-do-carousel.module.scss
@@ -24,7 +24,15 @@ $card-gap: 24px;
   -webkit-overflow-scrolling: touch;
   scrollbar-width: none;
   scroll-snap-type: x proximity;
-  padding-bottom: 0.25rem;
+  /*
+   * Hover uses translateY(-6px) + box-shadow 0 18px 45px.
+   * Scroll tracks clip overflow, so pad enough for lift + shadow,
+   * then pull layout back with negative margins.
+   */
+  padding-top: 14px;
+  padding-bottom: 56px;
+  margin-top: -14px;
+  margin-bottom: -16px;
   scroll-padding-inline: var(--what-i-do-gutter, #{home.$home-layout-margin-mobile});
 
   &::-webkit-scrollbar {
@@ -45,6 +53,8 @@ $card-gap: 24px;
   height: $card-height;
   scroll-snap-align: start;
   display: flex;
+  border-radius: 12px; /* match MUI borderRadius: 3 → 12px */
+  overflow: visible;
   opacity: 0;
   transform: translateY(24px);
   transition:
@@ -54,6 +64,12 @@ $card-gap: 24px;
   /* Gap between cards only — not between gutter spacers and cards */
   &:not(:nth-last-child(2)) {
     margin-inline-end: $card-gap;
+  }
+
+  /* Ensure the card (and its hover fill) keep rounded corners inside the shell */
+  :global(.MuiPaper-root) {
+    border-radius: 12px !important;
+    overflow: hidden;
   }
 }
 

--- a/app/home/components/what-i-do-carousel.module.scss
+++ b/app/home/components/what-i-do-carousel.module.scss
@@ -1,0 +1,123 @@
+@use '../home-layout' as home;
+
+$card-width: 280px;
+$card-height: 210px;
+$card-gap: 24px;
+
+.carousel {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.track {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  align-items: stretch;
+  gap: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+  scroll-behavior: smooth;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+  scroll-snap-type: x proximity;
+  padding-bottom: 0.25rem;
+  scroll-padding-inline: var(--what-i-do-gutter, #{home.$home-layout-margin-mobile});
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.gutterSpacer {
+  flex: 0 0 var(--what-i-do-gutter, #{home.$home-layout-margin-mobile});
+  width: var(--what-i-do-gutter, #{home.$home-layout-margin-mobile});
+  height: 1px;
+  pointer-events: none;
+}
+
+.cardShell {
+  flex: 0 0 auto;
+  width: $card-width;
+  height: $card-height;
+  scroll-snap-align: start;
+  display: flex;
+  opacity: 0;
+  transform: translateY(24px);
+  transition:
+    opacity 0.6s ease-out,
+    transform 0.6s ease-out;
+
+  /* Gap between cards only — not between gutter spacers and cards */
+  &:not(:nth-last-child(2)) {
+    margin-inline-end: $card-gap;
+  }
+}
+
+.cardInView {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.nav {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1.5rem;
+  box-sizing: border-box;
+  padding-inline: var(--what-i-do-gutter, #{home.$home-layout-margin-mobile});
+}
+
+.navButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  background-color: #f1f1f3;
+  color: #074c5f;
+  transition: background-color 0.2s ease;
+
+  &:hover:not(:disabled) {
+    background-color: #e8e8ec;
+  }
+
+  &:disabled {
+    cursor: default;
+    color: rgba(7, 76, 95, 0.28);
+  }
+}
+
+.navButtonNext {
+  background-color: #074c5f;
+  color: #ffffff;
+
+  &:hover:not(:disabled) {
+    background-color: #0a6280;
+  }
+
+  &:disabled {
+    background-color: #f1f1f3;
+    color: rgba(7, 76, 95, 0.28);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cardShell {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+
+  .track {
+    scroll-behavior: auto;
+  }
+}

--- a/app/home/contact-me.module.scss
+++ b/app/home/contact-me.module.scss
@@ -53,7 +53,7 @@
         max-width: 420px;
       }
 
-      @include fluid-type(16px, 22px, 32px);
+      @include home-fluid-type(16px, 22px, 32px);
       font-family: var(--font-figtree);
       color: $font-color-bold;
       line-height: 1.6;
@@ -109,7 +109,7 @@
           width: 100%;
           font-family: var(--font-poppins);
           font-weight: 500;
-          @include fluid-type(18px, 20px, 22px);
+          @include home-fluid-type(18px, 20px, 22px);
           color: #074C5F;
           padding-bottom: 1rem;
         }
@@ -129,7 +129,7 @@
           > span:not(.contactLinkedInLabel) {
             font-family: var(--font-figtree);
             font-weight: 500;
-            @include fluid-type(16px, 18px, 20px);
+            @include home-fluid-type(16px, 18px, 20px);
             color: #074C5F;
             padding-left: 1rem;
 

--- a/app/home/contact-me.module.scss
+++ b/app/home/contact-me.module.scss
@@ -8,10 +8,10 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: flex-start;
   position: relative;
   overflow: visible;
   padding-block: 2rem;
+  @include home.home-page-gutter;
 
   @media screen and (min-width: $tablet-min) {
     padding-block: 3rem;
@@ -20,160 +20,138 @@
   @media screen and (min-width: $desktop-min) {
     padding-block: 4rem;
   }
+}
 
-  .content {
-    @include home.home-page-gutter;
-    text-align: center;
+.ctaCard {
+  box-sizing: border-box;
+  width: 100%;
+  background-color: #1e3a4c;
+  border-radius: 24px;
+  padding: 2.5rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1.25rem;
+
+  @media screen and (min-width: $tablet-min) {
+    padding: 3.25rem 3rem;
+    gap: 1.5rem;
+  }
+
+  @media screen and (min-width: $desktop-min) {
+    padding: 4rem 4rem;
+  }
+}
+
+.heading {
+  margin: 0;
+  font-family: var(--font-poppins);
+  font-size: clamp(1.75rem, 3.5vw, 2.5rem);
+  font-weight: 600;
+  color: #ffffff;
+  line-height: 1.2;
+
+  :global(.Typewriter__cursor) {
+    display: inline-block;
+    margin-left: 0.08em;
+    font-size: 1em;
+    color: #ffffff;
+    animation: twBlink 1s steps(2, start) infinite;
+  }
+}
+
+.summary {
+  margin: 0;
+  max-width: 36rem;
+  font-family: var(--font-figtree);
+  @include home-fluid-type(15px, 17px, 18px);
+  color: rgba(255, 255, 255, 0.82);
+  line-height: 1.6;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 0.875rem;
+  margin-top: 0.75rem;
+  width: 100%;
+}
+
+.primaryButton,
+.secondaryButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  min-height: 48px;
+  padding: 0.75rem 1.35rem;
+  border-radius: 12px;
+  font-family: var(--font-poppins);
+  font-size: 0.95rem;
+  font-weight: 500;
+  text-decoration: none;
+  cursor: pointer;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease,
+    background-color 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.primaryButton {
+  border: none;
+  background-color: #f59f0a;
+  color: #011114;
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 24px rgba(245, 159, 10, 0.35);
+  }
+}
+
+.secondaryButton {
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  background-color: transparent;
+  color: #ffffff;
+
+  &:hover {
+    border-color: rgba(255, 255, 255, 0.8);
+    background-color: rgba(255, 255, 255, 0.06);
+    transform: translateY(-2px);
+  }
+}
+
+.buttonIcon {
+  font-size: 1.15rem !important;
+}
+
+.buttonIconEnd {
+  font-size: 1rem !important;
+  margin-left: 0.15rem;
+}
+
+@keyframes twBlink {
+  0%,
+  49% {
+    opacity: 1;
+  }
+  50%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@media screen and #{$mobile} {
+  .actions {
+    flex-direction: column;
+  }
+
+  .primaryButton,
+  .secondaryButton {
     width: 100%;
-    padding-bottom: 2rem;
-  }
-
-  .heading {
-    font-family: var(--font-poppins);
-    font-size: clamp(1.8rem, 4vw, 2.2rem);
-    font-weight: 600;
-    color: #074C5F;
-    margin-bottom: 1.5rem;
-    padding-bottom: 1vh;
-    text-align: left;
-
-    @media screen and #{$mobile} {
-      text-align: center;
-    }
-  }
-
-  .summarySection {
-    width: 100%;
-    margin: 0 auto 2.5rem;
-    display: flex;
-    justify-content: center;
-
-    .summarySectionText {
-      @media screen and #{$mobile} {
-        max-width: 420px;
-      }
-
-      @include home-fluid-type(16px, 22px, 32px);
-      font-family: var(--font-figtree);
-      color: $font-color-bold;
-      line-height: 1.6;
-      opacity: 0.9;
-      text-align: left;
-    }
-  }
-
-  .contactFormContainer {
-    display: flex;
-
-    @media screen and #{$desktop-device, $tablet} {
-      flex-direction: row;
-      justify-content: center;
-      align-items: flex-start;
-      margin-top: 5vh;
-      gap: 5rem;
-    }
-
-    @media screen and #{$mobile} {
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      padding-top: 2vh;
-    }
-
-    .contacMeContainer {
-        display: flex;
-        @media screen and #{$desktop-device, $tablet} {
-          width: 35%;
-          flex-direction: column;
-          align-items: flex-start;
-          align-content: center;
-          justify-content: center;
-          gap: 1rem;
-        }
-        
-        @media screen and #{$mobile} {
-          padding-top: 2rem;
-          flex-direction: column;
-          align-items: center;
-          align-content: center;
-          justify-content: center;
-          gap: 0.75rem;
-          width: 100%;
-          max-width: 360px;
-          margin-left: auto;
-          margin-right: auto;
-          align-self: center;
-        }
-
-        .contactMeSectionTitle {
-          width: 100%;
-          font-family: var(--font-poppins);
-          font-weight: 500;
-          @include home-fluid-type(18px, 20px, 22px);
-          color: #074C5F;
-          padding-bottom: 1rem;
-        }
-       
-        .contactRow {
-          display: flex;
-          align-items: center;
-          justify-content: center;
-
-          @media screen and #{$mobile} {
-            flex-direction: row;
-            justify-content: center;
-            gap: 0.75rem;
-            width: 100%;
-          }
-
-          > span:not(.contactLinkedInLabel) {
-            font-family: var(--font-figtree);
-            font-weight: 500;
-            @include home-fluid-type(16px, 18px, 20px);
-            color: #074C5F;
-            padding-left: 1rem;
-
-            @media screen and #{$mobile} {
-              padding-left: 0;
-              text-align: left;
-            }
-          }
-        }
-
-        .contactLinkedInRow {
-          gap: 0.6rem;
-          text-align: initial;
-        }
-
-        .contactLinkedInLabel {
-          font-family: var(--font-poppins);
-          font-size: 1rem;
-          font-weight: 500;
-          color: $font-color-bold;
-          cursor: pointer;
-        }
-    }
-  }
-}
-
-.floatLayer {
-  @include home.home-float-layer-bleed;
-}
-
-.floatImg {
-  position: absolute;
-  opacity: 1;
-  animation: slowFloat 12s ease-in-out infinite alternate;
-  filter: drop-shadow(0 2px 4px rgba(0,0,0,0.08));
-}
-
-@keyframes slowFloat {
-  0%   { transform: translate(-10px, 240px) scale(0.5); }
-  100% { transform: translate(10px, -28px) scale(1.06); }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .floatImg {
-    animation: none !important;
+    max-width: 280px;
   }
 }

--- a/app/home/contact-me.tsx
+++ b/app/home/contact-me.tsx
@@ -11,7 +11,7 @@ import QrFloatingCard from "@/components/QrFloatingCard/QrFloatingCard";
 import { LinkedInProfileButton } from "@/components/LinkedInProfileButton/LinkedInProfileButton";
 import { SectionTypewriterHeading } from "./components/SectionTypewriterHeading";
 
-const FLOAT_COUNT = 24;
+const FLOAT_COUNT = 6;
 
 type FloaterConfig = {
   img: any;

--- a/app/home/contact-me.tsx
+++ b/app/home/contact-me.tsx
@@ -1,199 +1,94 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
+import React, { useState } from "react";
+import Dialog from "@mui/material/Dialog";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import IconButton from "@mui/material/IconButton";
+import CloseIcon from "@mui/icons-material/Close";
+import MailOutlineIcon from "@mui/icons-material/MailOutline";
+import NorthEastIcon from "@mui/icons-material/NorthEast";
+import LinkedInIcon from "@mui/icons-material/LinkedIn";
+
 import styles from "./contact-me.module.scss";
-import Image from "next/image";
-import { backgroundFloatImages } from "./background-float-images";
-import PhoneIphoneIcon from '@mui/icons-material/PhoneIphone';
-import AlternateEmailIcon from '@mui/icons-material/AlternateEmail';
-import emailjs from '@emailjs/browser';
-import QrFloatingCard from "@/components/QrFloatingCard/QrFloatingCard";
-import { LinkedInProfileButton } from "@/components/LinkedInProfileButton/LinkedInProfileButton";
+import SendMessage from "@/components/SendMessage/SendMessage";
 import { SectionTypewriterHeading } from "./components/SectionTypewriterHeading";
 
-const FLOAT_COUNT = 6;
-
-type FloaterConfig = {
-  img: any;
-  top: string;
-  left: string;
-  size: string;
-  delay: string;
-  duration: string;
-};
+const LINKEDIN_URL =
+  "https://www.linkedin.com/in/antonio-aranda-eggermont-23aa7b8/";
 
 function ContactMe() {
-  const [floaters, setFloaters] = useState<FloaterConfig[]>([]);
-  const form = useRef<HTMLFormElement | null>(null);
-  const [name, setName] = useState("");
-  const [email, setEmail] = useState("");
-  const [message, setMessage] = useState("");
-  const [emailError, setEmailError] = useState(false);
-
-  const [isSending, setIsSending] = useState(false);
-  const [toast, setToast] = useState<{
-    message: string;
-    type: "success" | "error";
-  } | null>(null);
-
-    const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
-      event.preventDefault();
-      if (isSending) return; // guard for double-clicks
-
-      if (!form.current) return;
-
-      try {
-        setIsSending(true);
-        setToast(null);
-
-        await emailjs.sendForm(
-          "service_9vnb61i",
-          "template_4jckt0n",
-          form.current,
-          { publicKey: "vF8vNTkUpDVRI5ITP" }
-        );
-
-        setToast({
-          message: "Thanks! Your message was sent successfully.",
-          type: "success",
-        });
-
-        // reset form + local state
-        form.current.reset();
-        setName("");
-        setEmail("");
-        setMessage("");
-      } catch (error: any) {
-        console.error("FAILED…", error?.text || error);
-        setToast({
-          message:
-            "Oops, something went wrong. Please try again in a moment.",
-          type: "error",
-        });
-      } finally {
-        setIsSending(false);
-      }
-    };
-
-
-  useEffect(() => {
-    // This runs ONLY in the browser, after hydration ✅
-    const generated: FloaterConfig[] = Array.from({ length: FLOAT_COUNT }).map(
-      () => {
-        const img =
-          backgroundFloatImages[
-            Math.floor(Math.random() * backgroundFloatImages.length)
-          ];
-
-        return {
-          img,
-          top: `${Math.random() * 90}%`,
-          left: `${Math.random() * 90}%`,
-          size: `${40 + Math.random() * 120}px`, // 40–160px
-          delay: `${Math.random() * 5}s`,
-          duration: `${10 + Math.random() * 10}s`,
-        };
-      }
-    );
-
-    setFloaters(generated);
-  }, []);
-
-
-  useEffect(() => {
-    if (!toast) return;
-
-    const timer = setTimeout(() => {
-      setToast(null);
-    }, 4000);
-
-    return () => clearTimeout(timer);
-  }, [toast]);
-
-
-  const handleLinkedIn = () => {
-    window.location.href = 'https://www.linkedin.com/in/antonio-aranda-eggermont-23aa7b8/';
-  };
-
-  const mainContent = (
-    <div className={styles.content}>
-      <SectionTypewriterHeading text="Get in Touch" className={styles.heading} />
-      <div className={styles.summarySection}>
-        <span className={styles.summarySectionText}>
-          I&apos;m open to full-time roles, consulting, and partnerships—especially
-          in product design, frontend, and AI-driven experiences.
-        </span>
-      </div>
-
-      <div className={styles.contactFormContainer}>
-        <QrFloatingCard src="/images/qr/AAEQRImage.png" title="Scan me" />
-        <div className={styles.contacMeContainer}>
-          <div className={styles.contactRow}>
-            <PhoneIphoneIcon sx={{ color: "#02232c" }} style={{ fontSize: 40 }} />
-            <span> USA: +206 556 8918</span>
-          </div>
-          <div className={styles.contactRow}>
-            <PhoneIphoneIcon sx={{ color: "#02232c" }} style={{ fontSize: 40 }} />
-            <span> Mexico: +52 55 36 71 57 12</span>
-          </div>
-          <div className={styles.contactRow}>
-            <AlternateEmailIcon sx={{ color: "#02232c" }} style={{ fontSize: 40 }} />
-            <span> aaeggermont@outlook.com</span>
-          </div>
-          <div className={`${styles.contactRow} ${styles.contactLinkedInRow}`}>
-            <LinkedInProfileButton onClick={handleLinkedIn} />
-            <span
-              className={styles.contactLinkedInLabel}
-              onClick={handleLinkedIn}
-            >
-              LinkedIn
-            </span>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
+  const [isFormOpen, setIsFormOpen] = useState(false);
 
   return (
     <section className={styles.contactMeSection} id="contact-me">
-       {/* Decorative floating images – render only after we have client-side config */}
-      <div className={styles.floatLayer}>
-        {floaters.map((f, i) => (
-          <Image
-            key={`float-${i}-${f.top}-${f.left}`}
-            src={f.img}
-            alt=""
-            aria-hidden="true"
-            className={styles.floatImg}
-            width={150}
-            height={150}
-            style={{
-              top: f.top,
-              left: f.left,
-              width: f.size,
-              height: "auto",
-              animationDelay: f.delay,
-              animationDuration: f.duration,
-            }}
-          />
-        ))}
+      <div className={styles.ctaCard}>
+        <SectionTypewriterHeading
+          text="Let's build something"
+          className={styles.heading}
+        />
+        <p className={styles.summary}>
+          Have a project in mind, or just want to say hello? I&apos;m always
+          open to talking through ideas and opportunities.
+        </p>
+
+        <div className={styles.actions}>
+          <button
+            type="button"
+            className={styles.primaryButton}
+            onClick={() => setIsFormOpen(true)}
+          >
+            <MailOutlineIcon className={styles.buttonIcon} aria-hidden />
+            <span>Get in touch</span>
+            <NorthEastIcon className={styles.buttonIconEnd} aria-hidden />
+          </button>
+
+          <a
+            className={styles.secondaryButton}
+            href={LINKEDIN_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <LinkedInIcon className={styles.buttonIcon} aria-hidden />
+            <span>LinkedIn</span>
+          </a>
+        </div>
       </div>
 
-      {mainContent}
-  
-      {toast && (
-        <div
-          className={`${styles.toast} ${
-            toast.type === "success"
-              ? styles.toastSuccess
-              : styles.toastError
-          } ${styles.toastVisible}`}
-          role="status"
-          aria-live="polite"
+      <Dialog
+        open={isFormOpen}
+        onClose={() => setIsFormOpen(false)}
+        fullWidth
+        maxWidth="sm"
+        aria-labelledby="contact-form-title"
+        PaperProps={{
+          sx: {
+            borderRadius: 3,
+            overflow: "hidden",
+          },
+        }}
+      >
+        <DialogTitle
+          id="contact-form-title"
+          sx={{
+            fontFamily: "Poppins, sans-serif",
+            fontWeight: 600,
+            pr: 6,
+          }}
         >
-          {toast.message}
-        </div>
-      )}
+          Get in touch
+          <IconButton
+            aria-label="Close contact form"
+            onClick={() => setIsFormOpen(false)}
+            sx={{ position: "absolute", right: 8, top: 8 }}
+          >
+            <CloseIcon />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent dividers>
+          <SendMessage compact />
+        </DialogContent>
+      </Dialog>
     </section>
   );
 }

--- a/app/home/data/background-data.ts
+++ b/app/home/data/background-data.ts
@@ -50,8 +50,7 @@ export const backgroundItems: BackgroundItem[] = [
     summary:
       "Transforming complex data into actionable insights and intuitive visual experiences.",
     description: [
-      "I connect data, user experience, and application layers so that systems work together seamlessly and users get a unified view of the product or service. I focus on making frontends, backends, and data reliable and scalable as they grow.",
-      "I work with RESTful APIs, event-driven architecture and message queues for real-time and two-way communication, and cloud integrations—including AWS, GCP, and Snowflake—so that applications stay consistent and performant end to end.",
+      "I design and build enterprise data-driven applications, including analytics dashboards, interactive data grids, data ingestion workflows, and decision-support tools. My work centers on making complex enterprise systems easier to understand through intuitive data visualization and user-centered interfaces that support confident decision-making.",
     ],
   },
 ];

--- a/app/home/data/background-data.ts
+++ b/app/home/data/background-data.ts
@@ -1,44 +1,54 @@
-import type { ImageProps } from "next/image";
-
-import UXUIDesignIcon from "../images/UXUIDesignIcon.svg";
-import HumanCenteredDesignIcon from "../images/HumanCenteredDesignIcon.svg";
-import FrontEndDevelopmentIcon from "../images/FullStrackDevelopmentIcon.svg";
-import SystemsArchitectureIcon from "../images/SystemsArchitectureIcon.svg";
-
 export type BackgroundItem = {
   title: string;
-  img: ImageProps["src"];
+  /** Firebase Storage object path under the public `site/` prefix. */
+  iconObjectPath: string;
+  /** Card icon display size — defaults to 36×36. */
+  iconWidth?: number;
+  iconHeight?: number;
+  /** One-line blurb shown on the card under the title. */
+  summary: string;
+  /** Longer copy shown in the card dialog. */
   description: string[];
 };
 
 export const backgroundItems: BackgroundItem[] = [
   {
-    title: "UX/UI Design & Engineering",
-    img: UXUIDesignIcon,
+    title: "UX Engineering",
+    iconObjectPath: "site/UXEngineringCardIcon.png",
+    iconWidth: 44,
+    iconHeight: 36,
+    summary:
+      "Bridging design and engineering to build intuitive digital experiences.",
     description: [
       "I bridge design and engineering across the full product lifecycle—from research and concept to implementation. My combination of design craft and software engineering helps teams ship experiences that are both usable and technically sound, and I work as a connector between design, product, and engineering.",
       "I focus on understanding users and translating that into clear structure and interaction: information architecture, layouts, wireframes at multiple breakpoints, and functional prototypes. I’ve applied this in product design, web and mobile interfaces, and in high-traffic, guest-facing experiences.",
     ],
   },
   {
-    title: "Human Centered Design",
-    img: HumanCenteredDesignIcon,
+    title: "Human-Centered Design",
+    iconObjectPath: "site/HumanCenteredDesignCardIcon.png",
+    summary:
+      "Designing products around people, workflows, and business goals.",
     description: [
       "I use human-centered design as a framework to keep products and services usable and aligned with real user needs. In practice, that means starting from the user when building or improving a product, iterating in design and development, and building empathy and collaboration across design, engineering, and stakeholders.",
       "I draw on research methods such as contextual inquiry, co-design, participatory design, rapid ethnography, personas, and storyboarding, and I apply Design Thinking and human–computer interaction (HCI) to prototype and test solutions with users and stakeholders.",
     ],
   },
   {
-    title: "Frontend Development",
-    img: FrontEndDevelopmentIcon,
+    title: "Software Development",
+    iconObjectPath: "site/SoftwareDevelopmentCardIcon.png",
+    summary:
+      "Building modern, scalable, and interactive enterprise applications.",
     description: [
       "I turn design vision into production-ready frontends for web and mobile, with a focus on performance and maintainable code. I specialize in AI/ML-driven interactive interfaces that connect users to intelligent backend services.",
       "I work with frameworks such as React, Angular, Django, and iOS/Swift, and languages including TypeScript, JavaScript, Python, HTML, and CSS (with preprocessors). I've delivered frontends for content and revenue management systems, web publishing, and applications that integrate with AI/ML backends for automation and recommendations.",
     ],
   },
   {
-    title: "Systems Integration",
-    img: SystemsArchitectureIcon,
+    title: "Data & Visualization",
+    iconObjectPath: "site/DatVizCardIcon.png",
+    summary:
+      "Transforming complex data into actionable insights and intuitive visual experiences.",
     description: [
       "I connect data, user experience, and application layers so that systems work together seamlessly and users get a unified view of the product or service. I focus on making frontends, backends, and data reliable and scalable as they grow.",
       "I work with RESTful APIs, event-driven architecture and message queues for real-time and two-way communication, and cloud integrations—including AWS, GCP, and Snowflake—so that applications stay consistent and performant end to end.",

--- a/app/home/data/latestprojects-data.ts
+++ b/app/home/data/latestprojects-data.ts
@@ -8,7 +8,12 @@ import R3XAutomaticSeaterThumb from "../images/R3-XAutomaticSeater-thumb.png";
 export type LatestProjectItem = {
   title: string;
   img: StaticImageData;
-  description: string[];
+  /** Role line shown under the title (orange). */
+  role: string;
+  /** Short card body copy. */
+  description: string;
+  /** Bold outcome line at the bottom of the card. */
+  outcome: string;
   /** Optional route for Selected Work cards that already have a project page. */
   href?: string;
 };
@@ -17,23 +22,28 @@ export const latestProjectsItems: LatestProjectItem[] = [
   {
     title: "Disney AR Magic Tours",
     img: ARMagicToursThumb,
-    description: [
-      "Enhanced park experiences by transforming the environment into an interactive AR-driven attraction",
-    ],
+    role: "UX Engineer",
+    description:
+      "Transformed park environments into interactive AR-driven guest attractions.",
+    outcome: "Guest experiences reimagined",
+    href: "/work/ar-story-teller",
   },
   {
     title: "Disney Cruise Line Revenue Management",
     img: DCLImageThumb,
-    description: [
-      "Led front-end redesign of dashboards, data grids, and ingestion workflows for pricing and inventory insights."
-    ],
+    role: "Frontend Lead",
+    description:
+      "Redesigned dashboards and ingestion workflows for pricing & inventory insights.",
+    outcome: "Revenue systems modernized",
     href: "/work/dcl-revenue-management",
   },
   {
     title: "R-3X – Automatic Seating Assignments",
     img: R3XAutomaticSeaterThumb,
-    description: [
-      "Led development of a real-time mobile solution to optimize guest seating throughput at rides and attractions."
-    ],
+    role: "Frontend Lead",
+    description:
+      "Built a real-time mobile solution to optimize guest seating at rides and attractions.",
+    outcome: "Seating throughput optimized",
+    href: "/work/automatic-seater-assignments",
   },
 ];

--- a/app/home/home-page.module.scss
+++ b/app/home/home-page.module.scss
@@ -1,7 +1,11 @@
 /* app/home/home-page.module.scss */
+@use './home-layout' as home;
 
 .homePage {
   width: 100%;
+  max-width: home.$home-layout-max-width-desktop; /* 1260px */
+  margin-left: auto;
+  margin-right: auto;
   background-color: var(--page-canvas);
   display: flex;
   flex-direction: column;

--- a/app/home/home-page.module.scss
+++ b/app/home/home-page.module.scss
@@ -9,17 +9,17 @@
   background-color: var(--page-canvas);
   display: flex;
   flex-direction: column;
-  gap: 3rem;
+  gap: 1.5rem;
   /* Approximate global header height for hero min-height and anchor scroll offset */
   --header-height: 80px;
 
   @media screen and (min-width: $tablet-min) {
-    gap: 5rem;
+    gap: 2rem;
     --header-height: 72px;
   }
 
   @media screen and (min-width: $desktop-min) {
-    gap: 8rem;
+    gap: 2.5rem;
     --header-height: 64px;
   }
 }

--- a/app/home/latest-projects.module.scss
+++ b/app/home/latest-projects.module.scss
@@ -61,15 +61,15 @@
       display: grid;
       grid-template-columns: repeat(
         3,
-        var(--selected-work-card-width, 294px)
+        var(--selected-work-card-width, 300px)
       );
-      gap: 2rem;
+      gap: 16px;
       justify-content: center;
       align-items: center;
       width: min(
         100%,
         calc(
-          var(--selected-work-card-width, 294px) * 3 + 2rem * 2
+          var(--selected-work-card-width, 300px) * 3 + 16px * 2
         )
       );
       margin-inline: auto;
@@ -78,7 +78,7 @@
 
   .projectsGridItem {
     display: flex;
-    width: var(--selected-work-card-width, 294px);
+    width: var(--selected-work-card-width, 300px);
     min-width: 0;
     justify-content: center;
     transform: scale(var(--selected-work-carousel-inactive-scale, 0.94));
@@ -127,7 +127,7 @@
 
     :global(.swiper-slide) {
       display: flex;
-      width: var(--selected-work-card-width, 294px);
+      width: var(--selected-work-card-width, 300px);
       box-sizing: border-box;
       justify-content: center;
       height: auto;

--- a/app/home/latest-projects.module.scss
+++ b/app/home/latest-projects.module.scss
@@ -45,7 +45,7 @@
     justify-content: center;
   
     .summarySectionText {
-      @include fluid-type(16px, 22px, 32px);
+      @include home-fluid-type(16px, 22px, 32px);
       font-family: var(--font-figtree);
       color: $font-color-bold;
       line-height: 1.6;

--- a/app/home/latest-projects.module.scss
+++ b/app/home/latest-projects.module.scss
@@ -155,6 +155,48 @@
     transform: scale(var(--selected-work-carousel-active-scale, 1));
     opacity: 1;
   }
+
+  .viewAllWorkContainer {
+    display: flex;
+    justify-content: center;
+    margin-top: 1.5rem;
+  }
+
+  .viewAllWorkButton {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+    min-height: 44px;
+    padding: 0.7rem 1.25rem;
+    border-radius: 8px;
+    background-color: #1e3a4c;
+    color: #ffffff;
+    font-family: var(--font-poppins);
+    font-size: 0.875rem;
+    font-weight: 500;
+    line-height: 1;
+    text-decoration: none;
+    transition:
+      transform 0.2s ease,
+      background-color 0.2s ease,
+      box-shadow 0.2s ease;
+
+    &:hover {
+      transform: translateY(-2px);
+      background-color: #074c5f;
+      box-shadow: 0 8px 18px rgba(7, 76, 95, 0.2);
+    }
+
+    &:focus-visible {
+      outline: 3px solid rgba(245, 159, 10, 0.55);
+      outline-offset: 3px;
+    }
+  }
+
+  .viewAllWorkIcon {
+    font-size: 1rem;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/app/home/latest-projects.tsx
+++ b/app/home/latest-projects.tsx
@@ -4,6 +4,8 @@
 import React, { useEffect, useState } from "react";
 import styles from "./latest-projects.module.scss";
 import Image from "next/image";
+import Link from "next/link";
+import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
 
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Pagination } from "swiper/modules";
@@ -152,6 +154,13 @@ function LatestProjects() {
             </SwiperSlide>
           ))}
         </Swiper>
+
+        <div className={styles.viewAllWorkContainer}>
+          <Link href="/mywork" className={styles.viewAllWorkButton}>
+            <span>View all work</span>
+            <ArrowForwardIcon aria-hidden className={styles.viewAllWorkIcon} />
+          </Link>
+        </div>
       </div>
     </section>
   );

--- a/app/home/latest-projects.tsx
+++ b/app/home/latest-projects.tsx
@@ -18,7 +18,7 @@ import { latestProjectsItems } from "./data/latestprojects-data";
 import { SectionTypewriterHeading } from "./components/SectionTypewriterHeading";
 import { selectedWorkLayoutStyle } from "./selectedWorkCardLayout";
 
-const FLOAT_COUNT = 14;
+const FLOAT_COUNT = 6;
 
 type FloaterConfig = {
   img: any;
@@ -105,7 +105,9 @@ function LatestProjects() {
             <div key={item.title} className={styles.projectsGridItem}>
               <LatestProjectCard
                 title={item.title}
+                role={item.role}
                 description={item.description}
+                outcome={item.outcome}
                 thumbnailImg={item.img}
                 href={item.href}
               />
@@ -130,7 +132,7 @@ function LatestProjects() {
             },
             768: {
               slidesPerView: "auto",
-              spaceBetween: 24,
+              spaceBetween: 16,
               centeredSlides: false,
             },
           }}
@@ -140,7 +142,9 @@ function LatestProjects() {
               <div className={styles.carouselCardShell}>
                 <LatestProjectCard
                   title={item.title}
+                  role={item.role}
                   description={item.description}
+                  outcome={item.outcome}
                   thumbnailImg={item.img}
                   href={item.href}
                 />

--- a/app/home/main-banner.module.scss
+++ b/app/home/main-banner.module.scss
@@ -131,6 +131,12 @@
     padding: 2.5rem 0;
     z-index: 2;
 
+    @media screen and (min-width: 1258px) {
+      /* Prefer headline width, but keep a usable portrait size */
+      min-width: min(100%, 36rem);
+      flex: 1 1 auto;
+    }
+
     @media screen and #{$mobile} {
       align-items: center;
       flex: 0 0 auto;
@@ -152,6 +158,10 @@
     filter: drop-shadow(0 22px 48px rgba(15, 23, 42, 0.22))
       drop-shadow(0 8px 16px rgba(15, 23, 42, 0.12));
 
+    @media screen and (min-width: 1258px) {
+      flex: 0 0 auto;
+      width: clamp(240px, 34%, 420px);
+    }
     @media screen and #{$tablet} {
       width: clamp(220px, 40%, 420px);
     }
@@ -224,7 +234,7 @@
     }
 
     @media screen and #{$desktop-device} {
-      font-size: 32px;
+      font-size: 28px;
     }
 
     @media screen and #{$mobile} {
@@ -262,7 +272,42 @@
     @media screen and #{$desktop-device} {
       min-width: 0;
       opacity: 0.93;
-      font-size: 40px;
+      font-size: 35px;
+    }
+
+    /*
+     * ≥1258px: exactly two lines —
+     *   UX Engineer · Full-stack applications ·
+     *   AI-powered experiences
+     */
+    @media screen and (min-width: 1258px) {
+      width: max-content;
+      max-width: 100%;
+    }
+
+    .titleFirstLine {
+      @media screen and (min-width: 1258px) {
+        display: inline-block;
+        white-space: nowrap;
+      }
+    }
+
+    .titleBreak {
+      display: none;
+
+      @media screen and (min-width: 1258px) {
+        display: block;
+        height: 0;
+        width: 100%;
+        overflow: hidden;
+      }
+    }
+
+    .titleSecondLine {
+      @media screen and (min-width: 1258px) {
+        display: inline-block;
+        white-space: nowrap;
+      }
     }
   }
 

--- a/app/home/main-banner.module.scss
+++ b/app/home/main-banner.module.scss
@@ -104,8 +104,9 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  justify-content: center;
-  gap: clamp(1.5rem, 5vw, 4rem);
+  /* Fill the 1100px usable band: text left, portrait right — no dead side space */
+  justify-content: space-between;
+  gap: clamp(1.25rem, 2vw, 2rem);
 
   @media screen and #{$mobile} {
     flex-direction: column-reverse;
@@ -122,52 +123,48 @@
     flex-direction: column;
     align-items: flex-start;
     justify-content: center;
-    /* Narrower column so the portrait can carry more visual weight beside the headline */
-    width: min(36rem, 34vw);
-    padding: 4rem 0;
+    /* Grow into remaining space beside the portrait within the 1100px band */
+    flex: 1 1 0;
+    min-width: 0;
+    width: auto;
+    max-width: none;
+    padding: 2.5rem 0;
     z-index: 2;
-
-    @media screen and #{$tablet} {
-      width: min(38rem, 46vw);
-    }
-
-    @media screen and #{$desktop-device} {
-      width: min(36rem, 34vw);
-    }
 
     @media screen and #{$mobile} {
       align-items: center;
+      flex: 0 0 auto;
       width: 100%;
       max-width: 32rem;
       padding: 0;
-      flex: 0 0 auto;
     }
   }
 
   .bannerPhoto {
     position: relative;
-    /* Larger clamp vs text column — portrait reads as co-equal hero element (~10% down from prior max) */
-    width: clamp(270px, 37.8vw, 702px);
+    /* Sized vs the content band (%), not viewport, so it sits flush on the right */
+    flex: 0 0 auto;
+    width: clamp(230px, 38%, 460px);
     aspect-ratio: 3 / 4;
     height: auto;
-    max-height: min(84.6vh, 810px);
+    max-height: min(71.9vh, 689px);
     z-index: 2;
     filter: drop-shadow(0 22px 48px rgba(15, 23, 42, 0.22))
       drop-shadow(0 8px 16px rgba(15, 23, 42, 0.12));
 
     @media screen and #{$tablet} {
-      width: clamp(270px, 43.2vw, 702px);
+      width: clamp(220px, 40%, 420px);
     }
 
     @media screen and #{$mobile} {
       /* ~10% larger than prior mobile cap; shifted up so the 3 intro lines stay in view */
       height: clamp(
-        207px,
+        176px,
         calc(100dvh - var(--header-height, 80px) - 7.5rem),
-        330px
+        281px
       );
       width: auto;
-      max-width: min(86vw, 289px);
+      max-width: min(73vw, 246px);
       aspect-ratio: 3 / 4;
       flex: 0 0 auto;
       /* ~10% of portrait height — margin avoids fighting GSAP transform on this node */
@@ -176,8 +173,8 @@
 
       /* Wide mobile / large-phone edge (e.g. 767px): portrait was undersized vs full-width copy */
       @media (min-width: 600px) {
-        height: clamp(300px, 56vh, 480px);
-        max-width: min(58vw, 440px);
+        height: clamp(255px, 47.6vh, 408px);
+        max-width: min(49.3vw, 374px);
         margin: -1.25rem 0 0;
       }
     }
@@ -216,26 +213,35 @@
 
   .helloText {
     font-family: var(--font-poppins);
-    @include fluid-type(18px, 22px, 34px);
+    font-size: 22px; /* mobile */
     font-weight: 500;
+    color: #F59F0A;
     margin-bottom: 1rem;
+    white-space: nowrap;
+
+    @media screen and #{$tablet} {
+      font-size: 26px;
+    }
+
+    @media screen and #{$desktop-device} {
+      font-size: 32px;
+    }
 
     @media screen and #{$mobile} {
       padding: 0 1rem;
       margin-bottom: 0.35rem;
-      font-size: clamp(1rem, 4.2vw, 1.125rem);
       line-height: 1.25;
     }
 
     span {
-      color: $font-color-bold;
-      font-weight: 800;
+      color: inherit;
+      font-weight: 500;
     }
   }
 
   .backgroundText {
-    @include fluid-type(24px, 30px, 45px);
-    max-width: 48rem;
+    @include home-fluid-type(24px, 30px, 45px);
+    max-width: 100%;
     font-family: var(--font-poppins);
     font-weight: 600;
     color: $font-color-bold;
@@ -250,20 +256,19 @@
     }
 
     @media screen and #{$tablet} {
-      max-width: min(700px, 100%);
       min-width: 0;
     }
 
     @media screen and #{$desktop-device} {
-      max-width: min(700px, 100%);
       min-width: 0;
       opacity: 0.93;
+      font-size: 40px;
     }
   }
 
   .description {
-    @include fluid-type(16px, 22px, 34px);
-    max-width: 48rem;
+    @include home-fluid-type(16px, 22px, 34px);
+    max-width: 100%;
     font-family: var(--font-figtree);
     color: $font-color-bold;
     line-height: 1.5;

--- a/app/home/main-banner.tsx
+++ b/app/home/main-banner.tsx
@@ -17,7 +17,7 @@ function TypewriterComponent() {
   const prefersReducedMotion = usePrefersReducedMotion();
 
   if (prefersReducedMotion) {
-    return <>Hello, my name is Antonio</>;
+    return <>Antonio Aranda Eggermont</>;
   }
 
   return (
@@ -28,7 +28,7 @@ function TypewriterComponent() {
         deleteSpeed: 50,
       }}
       onInit={(typewriter) => {
-        typewriter.typeString("Hello, my name is Antonio").pauseFor(2500).start();
+        typewriter.typeString("Antonio Aranda Eggermont").pauseFor(2500).start();
       }}
     />
   );

--- a/app/home/main-banner.tsx
+++ b/app/home/main-banner.tsx
@@ -13,6 +13,19 @@ import { backgroundFloatImages } from "./background-float-images";
 import type { MainBannerData } from "./data/main-banner-data";
 import { usePrefersReducedMotion } from "@/lib/hooks/usePrefersReducedMotion";
 
+function splitBannerTitle(title: string): { lead: string; rest: string } | null {
+  const sep = " · ";
+  const parts = title.split(sep);
+  if (parts.length < 3) return null;
+  // Match desired wrap beyond 1258px:
+  //   UX Engineer · Full-stack applications ·
+  //   AI-powered experiences
+  return {
+    lead: `${parts[0]}${sep}${parts[1]}${sep}`,
+    rest: parts.slice(2).join(sep),
+  };
+}
+
 function TypewriterComponent() {
   const prefersReducedMotion = usePrefersReducedMotion();
 
@@ -136,6 +149,8 @@ function MainBanner({ banner }: MainBannerProps) {
     );
   };
 
+  const titleSplit = splitBannerTitle(banner.title);
+
   return (
     <section className={styles.mainBanner}>
       {/* Full-bleed behind orb + copy + portrait (see .floatLayer z-index) */}
@@ -173,7 +188,17 @@ function MainBanner({ banner }: MainBannerProps) {
           <TypewriterComponent key={`hero-${typewriterKey}`} />
         </h1>
 
-        <h2 className={styles.backgroundText}>{banner.title}</h2>
+        <h2 className={styles.backgroundText}>
+          {titleSplit ? (
+            <>
+              <span className={styles.titleFirstLine}>{titleSplit.lead}</span>
+              <span className={styles.titleBreak} aria-hidden="true" />
+              <span className={styles.titleSecondLine}>{titleSplit.rest}</span>
+            </>
+          ) : (
+            banner.title
+          )}
+        </h2>
 
         <p className={styles.description}>{banner.description}</p>
 

--- a/app/home/main-banner.tsx
+++ b/app/home/main-banner.tsx
@@ -56,7 +56,7 @@ type FloaterConfig = {
   duration: string;
 };
 
-const FLOAT_COUNT = 14;
+const FLOAT_COUNT = 6;
 
 type MainBannerProps = {
   banner: MainBannerData;

--- a/app/home/my-background.module.scss
+++ b/app/home/my-background.module.scss
@@ -11,17 +11,28 @@
   margin-right: calc(50% - 50vw);
   background-color: #f9f7f2;
   display: flex;
-  align-items: flex-start;
+  flex-direction: column;
+  align-items: stretch;
   overflow-x: clip;
   overflow-y: visible;
   padding-block: 2rem;
+  /* Gutter aligns carousel first card with heading (mirrors Guest Needs) */
+  --what-i-do-gutter: #{home.$home-layout-margin-mobile};
 
   @media screen and (min-width: $tablet-min) {
     padding-block: 3rem;
+    --what-i-do-gutter: calc(
+      (100vw - min(100vw, #{home.$home-layout-max-width-tablet})) / 2 +
+        #{home.$home-layout-margin-tablet}
+    );
   }
 
   @media screen and (min-width: $desktop-min) {
     padding-block: 4rem;
+    --what-i-do-gutter: calc(
+      (100vw - min(100vw, #{home.$home-layout-max-width-desktop})) / 2 +
+        #{home.$home-layout-margin-desktop}
+    );
   }
 }
 
@@ -29,7 +40,6 @@
   @include home.home-page-gutter;
   text-align: center;
   width: 100%;
-  padding-bottom: 2rem;
 }
 
 .heading {
@@ -46,113 +56,6 @@
   }
 }
 
-
-.placeholder {
-  @include home-fluid-type(16px, 18px, 20px);
-  font-family: var(--font-figtree);
-  color: $font-color-bold;
-  opacity: 0.75;
-}
-
-.backgroundsContainer {
-    display: flex;
-    flex-direction: row;
-    width: 100%;
-    gap: 5%;
-}
-
-$what-i-do-card-width-mobile: 152px;
-$what-i-do-card-height-mobile: 140px;
-$what-i-do-card-width-tablet: 183px;
-$what-i-do-card-height-tablet: 168px;
-$what-i-do-card-width: 280px;
-$what-i-do-card-height: 210px;
-$what-i-do-gap-mobile: 48px;
-$what-i-do-gap-tablet: 82px;
-$what-i-do-gap-desktop: 24px;
-
-.cardsGrid {
-  display: grid;
-  width: min(100%, $what-i-do-card-width-mobile);
-  margin-inline: auto;
-  justify-content: center;
-  justify-items: center;
-  gap: $what-i-do-gap-mobile;
-  grid-template-columns: minmax(0, $what-i-do-card-width-mobile);
-
-  /* Wide mobile — 2×2 */
-  @media screen and (min-width: 600px) and (max-width: $mobile-max) {
-    gap: $what-i-do-gap-mobile;
-    grid-template-columns: repeat(2, minmax(0, $what-i-do-card-width-mobile));
-    width: min(
-      100%,
-      calc(#{$what-i-do-card-width-mobile} * 2 + #{$what-i-do-gap-mobile})
-    );
-  }
-
-  /* Tablet — 2×2 */
-  @media screen and #{$tablet} {
-    gap: $what-i-do-gap-tablet;
-    grid-template-columns: repeat(2, minmax(0, $what-i-do-card-width-tablet));
-    width: min(
-      100%,
-      calc(#{$what-i-do-card-width-tablet} * 2 + #{$what-i-do-gap-tablet})
-    );
-  }
-
-  /* Desktop — 1×4 row, 280×210 cards */
-  @media screen and #{$desktop-device} {
-    gap: $what-i-do-gap-desktop;
-    grid-template-columns: repeat(4, $what-i-do-card-width);
-    width: min(
-      100%,
-      calc(
-        #{$what-i-do-card-width} * 4 + #{$what-i-do-gap-desktop} * 3
-      )
-    );
-    justify-content: space-between;
-  }
-}
-
-.cardWrapper {
-  width: $what-i-do-card-width-mobile;
-  max-width: 100%;
-
-  @media screen and #{$tablet} {
-    width: $what-i-do-card-width-tablet;
-  }
-
-  @media screen and #{$desktop-device} {
-    width: $what-i-do-card-width;
-  }
-  opacity: 0;
-  transform: translateY(24px);
-  transition:
-  opacity 0.6s ease-out,
-  transform 0.6s ease-out;
-}
-
-.cardInView {
-  opacity: 1;
-  transform: translateY(0);
-}
-
-.floatLayer {
-  @include home.home-float-layer-bleed;
-}
-
-.floatImg {
-  position: absolute;
-  opacity: 1;
-  animation: slowFloat 12s ease-in-out infinite alternate;
-  filter: drop-shadow(0 2px 4px rgba(0,0,0,0.08));
-}
-
-@keyframes slowFloat {
-  0%   { transform: translate(-10px, 240px) scale(0.5); }
-  100% { transform: translate(10px, -28px) scale(1.06); }
-}
-
 .summarySection {
   width: 100%;
   margin: 0 auto 2.5rem;
@@ -166,10 +69,41 @@ $what-i-do-gap-desktop: 24px;
     line-height: 1.6;
     opacity: 0.9;
     text-align: left;
+
+    @media screen and #{$mobile} {
+      text-align: center;
+    }
   }
 }
 
-/* Style the built-in cursor */
+.carouselStrip {
+  width: 100%;
+  box-sizing: border-box;
+  position: relative;
+  z-index: 2;
+  padding-bottom: 2rem;
+}
+
+.floatLayer {
+  @include home.home-float-layer-bleed;
+}
+
+.floatImg {
+  position: absolute;
+  opacity: 1;
+  animation: slowFloat 12s ease-in-out infinite alternate;
+  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.08));
+}
+
+@keyframes slowFloat {
+  0% {
+    transform: translate(-10px, 240px) scale(0.5);
+  }
+  100% {
+    transform: translate(10px, -28px) scale(1.06);
+  }
+}
+
 :global(.Typewriter__cursor) {
   display: inline-block;
   margin-left: 0.08em;
@@ -179,19 +113,19 @@ $what-i-do-gap-desktop: 24px;
 }
 
 @keyframes twBlink {
-  0%, 49%   { opacity: 1; }
-  50%, 100% { opacity: 0; }
+  0%,
+  49% {
+    opacity: 1;
+  }
+  50%,
+  100% {
+    opacity: 0;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .floatImg {
     animation: none !important;
-  }
-
-  .cardWrapper {
-    opacity: 1;
-    transform: none;
-    transition: none;
   }
 
   :global(.Typewriter__cursor) {

--- a/app/home/my-background.module.scss
+++ b/app/home/my-background.module.scss
@@ -42,7 +42,7 @@
 
 
 .placeholder {
-  @include fluid-type(16px, 18px, 20px);
+  @include home-fluid-type(16px, 18px, 20px);
   font-family: var(--font-figtree);
   color: $font-color-bold;
   opacity: 0.75;
@@ -146,7 +146,7 @@ $what-i-do-gap-desktop: 32px;
   display: flex;
   justify-content: center;  // center the text block horizontally
   .summarySectionText {
-    @include fluid-type(16px, 22px, 32px);
+    @include home-fluid-type(16px, 22px, 32px);
     font-family: var(--font-figtree);
     color: $font-color-bold;
     line-height: 1.6;

--- a/app/home/my-background.module.scss
+++ b/app/home/my-background.module.scss
@@ -2,12 +2,18 @@
 @use './home-layout' as home;
 
 .myBackgroundSection {
-  width: 100%;
-  background-color: var(--page-canvas);
+  /* Full-bleed cream band — breaks out of the 1260px home shell */
+  position: relative;
+  box-sizing: border-box;
+  width: 100vw;
+  max-width: none;
+  margin-left: calc(50% - 50vw);
+  margin-right: calc(50% - 50vw);
+  background-color: #f9f7f2;
   display: flex;
   align-items: flex-start;
-  overflow: visible;
-  position: relative;
+  overflow-x: clip;
+  overflow-y: visible;
   padding-block: 2rem;
 
   @media screen and (min-width: $tablet-min) {
@@ -31,8 +37,8 @@
   font-size: clamp(1.8rem, 4vw, 2.2rem);
   font-weight: 600;
   color: #074C5F;
-  margin-bottom: 2rem;
-  padding-bottom: 2vh;
+  margin-bottom: 0.5rem;
+  padding-bottom: 0;
   text-align: left;
 
   @media screen and #{$mobile} {
@@ -55,13 +61,15 @@
     gap: 5%;
 }
 
-$what-i-do-card-width-mobile: 168px;
-$what-i-do-card-height-mobile: 206px;
-$what-i-do-card-width: 212px;
-$what-i-do-card-height: 260px;
-$what-i-do-gap-mobile: 24px;
-$what-i-do-gap-tablet: 24px;
-$what-i-do-gap-desktop: 32px;
+$what-i-do-card-width-mobile: 152px;
+$what-i-do-card-height-mobile: 140px;
+$what-i-do-card-width-tablet: 183px;
+$what-i-do-card-height-tablet: 168px;
+$what-i-do-card-width: 280px;
+$what-i-do-card-height: 210px;
+$what-i-do-gap-mobile: 48px;
+$what-i-do-gap-tablet: 82px;
+$what-i-do-gap-desktop: 24px;
 
 .cardsGrid {
   display: grid;
@@ -72,7 +80,7 @@ $what-i-do-gap-desktop: 32px;
   gap: $what-i-do-gap-mobile;
   grid-template-columns: minmax(0, $what-i-do-card-width-mobile);
 
-  /* Wide mobile — 2×2 with phone card size (168×206) */
+  /* Wide mobile — 2×2 */
   @media screen and (min-width: 600px) and (max-width: $mobile-max) {
     gap: $what-i-do-gap-mobile;
     grid-template-columns: repeat(2, minmax(0, $what-i-do-card-width-mobile));
@@ -82,26 +90,27 @@ $what-i-do-gap-desktop: 32px;
     );
   }
 
-  /* Tablet — 2×2, 24px gap (proportional to desktop 32px) */
+  /* Tablet — 2×2 */
   @media screen and #{$tablet} {
     gap: $what-i-do-gap-tablet;
-    grid-template-columns: repeat(2, minmax(0, $what-i-do-card-width));
+    grid-template-columns: repeat(2, minmax(0, $what-i-do-card-width-tablet));
     width: min(
       100%,
-      calc(#{$what-i-do-card-width} * 2 + #{$what-i-do-gap-tablet})
+      calc(#{$what-i-do-card-width-tablet} * 2 + #{$what-i-do-gap-tablet})
     );
   }
 
-  /* Desktop — 1×4 row, 32px gap */
+  /* Desktop — 1×4 row, 280×210 cards */
   @media screen and #{$desktop-device} {
     gap: $what-i-do-gap-desktop;
-    grid-template-columns: repeat(4, minmax(0, $what-i-do-card-width));
+    grid-template-columns: repeat(4, $what-i-do-card-width);
     width: min(
       100%,
       calc(
         #{$what-i-do-card-width} * 4 + #{$what-i-do-gap-desktop} * 3
       )
     );
+    justify-content: space-between;
   }
 }
 
@@ -109,7 +118,11 @@ $what-i-do-gap-desktop: 32px;
   width: $what-i-do-card-width-mobile;
   max-width: 100%;
 
-  @media screen and (min-width: $tablet-min) {
+  @media screen and #{$tablet} {
+    width: $what-i-do-card-width-tablet;
+  }
+
+  @media screen and #{$desktop-device} {
     width: $what-i-do-card-width;
   }
   opacity: 0;
@@ -144,7 +157,8 @@ $what-i-do-gap-desktop: 32px;
   width: 100%;
   margin: 0 auto 2.5rem;
   display: flex;
-  justify-content: center;  // center the text block horizontally
+  justify-content: flex-start;
+
   .summarySectionText {
     @include home-fluid-type(16px, 22px, 32px);
     font-family: var(--font-figtree);

--- a/app/home/my-background.tsx
+++ b/app/home/my-background.tsx
@@ -135,13 +135,8 @@ export default function MyBackground() {
 
         <div className={styles.summarySection}>
           <p className={styles.summarySectionText}>
-            I transform user insights into meaningful, well-crafted digital
-            experiences that balance clarity, creativity, and usability. By
-            combining UX design, frontend engineering, AI-driven application
-            development, and system integration, I build seamless, intelligent
-            products that feel intuitive and human from end to end. I've applied
-            this across theme parks, revenue systems, and operational tools at
-            scale.
+            A blend of design, engineering, and systems thinking — applied end to
+            end.
           </p>
         </div>
 

--- a/app/home/my-background.tsx
+++ b/app/home/my-background.tsx
@@ -9,7 +9,7 @@ import { backgroundFloatImages } from "./background-float-images";
 import { SectionTypewriterHeading } from "./components/SectionTypewriterHeading";
 import { WhatIDoCarousel } from "./components/WhatIDoCarousel";
 
-const FLOAT_COUNT = 14;
+const FLOAT_COUNT = 6;
 
 type FloaterConfig = {
   img: any;

--- a/app/home/my-background.tsx
+++ b/app/home/my-background.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
+import Image from "next/image";
+
 import styles from "./my-background.module.scss";
 import backgroundItems from "@/app/home/data/background-data";
-import BackgroundCard from "@/app/home/BackgroundCard";
-import Image from "next/image";
 import { backgroundFloatImages } from "./background-float-images";
 import { SectionTypewriterHeading } from "./components/SectionTypewriterHeading";
-import { usePrefersReducedMotion } from "@/lib/hooks/usePrefersReducedMotion";
+import { WhatIDoCarousel } from "./components/WhatIDoCarousel";
 
 const FLOAT_COUNT = 14;
 
@@ -20,65 +20,10 @@ type FloaterConfig = {
   duration: string;
 };
 
-function AnimatedCardWrapper({
-  children,
-  index,
-}: {
-  children: React.ReactNode;
-  index: number;
-}) {
-  const prefersReducedMotion = usePrefersReducedMotion();
-  const ref = useRef<HTMLDivElement | null>(null);
-  const [inView, setInView] = useState(prefersReducedMotion);
-
-  useEffect(() => {
-    if (prefersReducedMotion) {
-      setInView(true);
-      return;
-    }
-
-    const el = ref.current;
-    if (!el) return;
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            setInView(true);
-            observer.unobserve(entry.target);
-          }
-        });
-      },
-      {
-        root: null,
-        threshold: 0.15,
-        rootMargin: "0px 0px -10% 0px",
-      }
-    );
-
-    observer.observe(el);
-
-    return () => observer.disconnect();
-  }, [prefersReducedMotion]);
-
-  return (
-    <div
-      ref={ref}
-      className={`${styles.cardWrapper} ${inView ? styles.cardInView : ""}`}
-      style={{
-        transitionDelay: inView && !prefersReducedMotion ? `${index * 90}ms` : "0ms",
-      }}
-    >
-      {children}
-    </div>
-  );
-}
-
 export default function MyBackground() {
   const [floaters, setFloaters] = useState<FloaterConfig[]>([]);
 
   useEffect(() => {
-    // This runs ONLY in the browser, after hydration ✅
     const generated: FloaterConfig[] = Array.from({ length: FLOAT_COUNT }).map(
       () => {
         const img =
@@ -90,11 +35,11 @@ export default function MyBackground() {
           img,
           top: `${Math.random() * 90}%`,
           left: `${Math.random() * 90}%`,
-          size: `${40 + Math.random() * 120}px`, // 40–160px
+          size: `${40 + Math.random() * 120}px`,
           delay: `${Math.random() * 5}s`,
           duration: `${10 + Math.random() * 10}s`,
         };
-      }
+      },
     );
 
     setFloaters(generated);
@@ -102,7 +47,6 @@ export default function MyBackground() {
 
   return (
     <section className={styles.myBackgroundSection} id="my-background">
-      {/* Decorative floating images – render only after we have client-side config */}
       <div className={styles.floatLayer}>
         {floaters.map((f, i) => (
           <Image
@@ -126,7 +70,6 @@ export default function MyBackground() {
       </div>
 
       <div className={styles.content}>
-
         <SectionTypewriterHeading
           as="div"
           text="What I do"
@@ -139,15 +82,10 @@ export default function MyBackground() {
             end.
           </p>
         </div>
+      </div>
 
-        <div className={styles.cardsGrid}>
-          {backgroundItems.map((item, index) => (
-            <AnimatedCardWrapper key={item.title} index={index}>
-              <BackgroundCard info={item} />
-            </AnimatedCardWrapper>
-          ))}
-        </div>
-       
+      <div className={styles.carouselStrip}>
+        <WhatIDoCarousel items={backgroundItems} />
       </div>
     </section>
   );

--- a/app/home/selectedWorkCardLayout.ts
+++ b/app/home/selectedWorkCardLayout.ts
@@ -2,8 +2,10 @@ import type { CSSProperties } from "react";
 
 /** Selected Work project cards — single source of truth for dimensions. */
 export const SELECTED_WORK_CARD = {
-  widthPx: 294,
+  widthPx: 300,
   heightPx: 390,
+  /** Hero image height — leave enough band for title / role / summary / outcome. */
+  imageHeightPx: 185,
   contentPaddingPx: 20,
 } as const;
 

--- a/components/SendMessage/SendMessage.tsx
+++ b/components/SendMessage/SendMessage.tsx
@@ -1,26 +1,29 @@
-
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
-import styles from "./send-message.module.scss"
-import TextField from '@mui/material/TextField';
-import emailjs from '@emailjs/browser';
+import React, { useRef, useState } from "react";
+import styles from "./send-message.module.scss";
+import TextField from "@mui/material/TextField";
+import emailjs from "@emailjs/browser";
 
-export default function SendMessage() {
+type SendMessageProps = {
+  /** Compact layout for modal / embedded use (no full-page chrome). */
+  compact?: boolean;
+};
+
+export default function SendMessage({ compact = false }: SendMessageProps) {
   const form = useRef<HTMLFormElement | null>(null);
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [message, setMessage] = useState("");
-  const [emailError, setEmailError] = useState(false);
   const [isSending, setIsSending] = useState(false);
   const [toast, setToast] = useState<{
     message: string;
     type: "success" | "error";
   } | null>(null);
-    
+
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (isSending) return; // guard for double-clicks
+    if (isSending) return;
 
     if (!form.current) return;
 
@@ -32,7 +35,7 @@ export default function SendMessage() {
         "service_9vnb61i",
         "template_4jckt0n",
         form.current,
-        { publicKey: "vF8vNTkUpDVRI5ITP" }
+        { publicKey: "vF8vNTkUpDVRI5ITP" },
       );
 
       setToast({
@@ -40,16 +43,14 @@ export default function SendMessage() {
         type: "success",
       });
 
-      // reset form + local state
       form.current.reset();
       setName("");
       setEmail("");
       setMessage("");
-    } catch (error: any) {
-      console.error("FAILED…", error?.text || error);
+    } catch (error: unknown) {
+      console.error("FAILED…", error);
       setToast({
-        message:
-          "Oops, something went wrong. Please try again in a moment.",
+        message: "Oops, something went wrong. Please try again in a moment.",
         type: "error",
       });
     } finally {
@@ -57,75 +58,77 @@ export default function SendMessage() {
     }
   };
 
-
   return (
-    <div className={styles.contactMeSection}>
+    <div
+      className={`${styles.contactMeSection} ${compact ? styles.compact : ""}`}
+    >
       <div className={styles.content}>
-        {/* Contact Form */}
         <div className={styles.contactFormContainer}>
-          <span> Send me a Message </span>
+          {!compact && <span> Send me a Message </span>}
           <form ref={form} onSubmit={handleSubmit}>
             <div className={styles.formFields}>
               <TextField
                 sx={{
-                    width: { xs: "300px", sm: "300px", md: "300px", lg: "350px" },
+                  width: { xs: "100%", sm: "300px", md: "300px", lg: "350px" },
+                  maxWidth: "100%",
                 }}
                 required
                 type="text"
                 name="from_name"
                 label="Your name"
                 variant="filled"
-                onChange={e => setName(e.target.value)}
+                value={name}
+                onChange={(e) => setName(e.target.value)}
               />
-            
+
               <TextField
                 required
                 sx={{
-                    width: { xs: "300px", sm: "300px", md: "300px", lg: "350px" },
+                  width: { xs: "100%", sm: "300px", md: "300px", lg: "350px" },
+                  maxWidth: "100%",
                 }}
-                id="outlined-required"
+                id="contact-email"
                 label="Your email"
                 type="email"
                 name="user_email"
-                defaultValue=""
                 variant="filled"
-                onChange={e => setEmail(e.target.value)}
-                  />
-        
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+              />
+
               <TextField
                 required
                 multiline
                 rows={4}
                 sx={{
-                      width: { xs: "300px", sm: "300px", md: "300px", lg: "350px" },
+                  width: { xs: "100%", sm: "300px", md: "300px", lg: "350px" },
+                  maxWidth: "100%",
                 }}
-                id="outlined-required"
+                id="contact-message"
                 label="Your message"
                 name="message"
-                defaultValue=""
                 variant="filled"
-                onChange={e => setMessage(e.target.value)}
+                value={message}
+                onChange={(e) => setMessage(e.target.value)}
               />
             </div>
             <div className={styles.formActions}>
               <button
                 type="submit"
-                  disabled={isSending}
+                disabled={isSending}
                 className={styles.submitButton}
               >
-
-              {isSending && (
-                <span className={styles.spinner} aria-hidden="true" />
-              )}
-
+                {isSending && (
+                  <span className={styles.spinner} aria-hidden="true" />
+                )}
                 <span className={styles.submitLabel}>
                   {isSending ? "Sending…" : "Send message"}
                 </span>
               </button>
             </div>
           </form>
+        </div>
       </div>
-    </div>
       {toast && (
         <div
           className={`${styles.toast} ${

--- a/components/SendMessage/send-message.module.scss
+++ b/components/SendMessage/send-message.module.scss
@@ -7,6 +7,29 @@
   position: relative;
   overflow: visible;
 
+  &.compact {
+    min-height: 0;
+    align-items: stretch;
+
+    .content {
+      padding-bottom: 0;
+    }
+
+    .contactFormContainer {
+      margin-top: 0;
+      width: 100%;
+      align-items: stretch;
+    }
+
+    .formFields {
+      width: 100%;
+    }
+
+    .formActions {
+      justify-content: flex-start;
+    }
+  }
+
   .content {
     text-align: center;
     width: 100%;

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "seed:project-2": "tsx scripts/seed-project-2.ts",
     "seed:automatic-seater": "tsx scripts/seed-automatic-seater-assignments.ts",
     "create:access-code": "tsx scripts/create-project-access-code.ts",
-    "seed:main-banner": "tsx scripts/seed-main-banner.ts",
-    "seed:what-i-do": "tsx scripts/seed-what-i-do.ts",
+    "seed:main-page": "tsx scripts/seed-main-page.ts",
+    "seed:main-banner": "tsx scripts/seed-main-page.ts",
     "seed:capability-map": "tsx scripts/seed-capability-map.ts",
     "seed:about-intro": "tsx scripts/seed-about-intro.ts",
     "seed:experience-training": "tsx scripts/seed-experience-training.ts"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "seed:automatic-seater": "tsx scripts/seed-automatic-seater-assignments.ts",
     "create:access-code": "tsx scripts/create-project-access-code.ts",
     "seed:main-banner": "tsx scripts/seed-main-banner.ts",
+    "seed:what-i-do": "tsx scripts/seed-what-i-do.ts",
     "seed:capability-map": "tsx scripts/seed-capability-map.ts",
     "seed:about-intro": "tsx scripts/seed-about-intro.ts",
     "seed:experience-training": "tsx scripts/seed-experience-training.ts"

--- a/styles/mixins.scss
+++ b/styles/mixins.scss
@@ -58,3 +58,45 @@
   width: clamp($minWidth, 16vw, $maxWidth);
   height: clamp($minHeight, 26vw, $maxHeight);
 }
+
+/**
+ * Landing-page fluid type — same curve as `fluid-type`, but `100vw` is capped at the
+ * 1260px home shell so type does not keep growing on wider viewports.
+ */
+@mixin home-fluid-type($mobile-size, $desktop-size, $large-size: null) {
+  // Keep in sync with `$home-layout-max-width-desktop` in `app/home/home-layout.scss`.
+  $home-shell-max: 1260px;
+
+  font-size: $mobile-size;
+
+  @media screen and (min-width: $mobile-min) and (max-width: #{$desktop-min - 1px}) {
+    font-size: clamp(
+      $mobile-size,
+      calc(
+        #{$mobile-size} + (#{$desktop-size} - #{$mobile-size}) *
+        ((100vw - #{$mobile-min}) / (#{$desktop-min} - #{$mobile-min}))
+      ),
+      $desktop-size
+    );
+  }
+
+  @if $large-size != null {
+    @media screen and (min-width: $desktop-min) {
+      font-size: clamp(
+        $desktop-size,
+        calc(
+          #{$desktop-size} + (#{$large-size} - #{$desktop-size}) *
+          (
+            (min(100vw, #{$home-shell-max}) - #{$desktop-min}) /
+            (#{$desktop-max} - #{$desktop-min})
+          )
+        ),
+        $large-size
+      );
+    }
+  } @else {
+    @media screen and (min-width: $desktop-min) {
+      font-size: $desktop-size;
+    }
+  }
+}


### PR DESCRIPTION
### Summary

Landing-page layout and content improvements across hero, What I do, Selected Work, and Get in Touch.

**Hero**

- Typewriter name and headline refinements (including 2-line break on wide screens)
- Portrait/text spacing and fluid type tweaks
- Home shell max-width centered at 1260px

**What I do**

- Full-bleed cream band (#f9f7f2)
- New WhatIDoCarousel (horizontal scroll, snap, edge peek, prev/next when needed)
- Fixed 280×210 cards with Storage icons, left-aligned titles, summaries
- Dialogs: same icon sizes as cards, unified paddings, no title/body divider
- Updated Data & Visualization dialog copy
- Hover: cream #efe9dc, rounded corners preserved, shadows no longer clipped
- Floating particles set to 6

**Selected Work**

- Cards redesigned: image, title + arrow, orange role, short description, divider, outcome
- 300px width, 12px radius, 16px gaps
- Footer alignment via pinned outcome + title min-height
- Links for all three projects (AR Story Teller, DCL, R-3X)
- Centered View all work → button to /mywork

**Get in Touch**

- Replaced phones/QR/form layout with a contained navy CTA card
- Typewriter headline: “Let's build something”
- Get in touch opens EmailJS form in a modal; LinkedIn as outlined button
- No particles in this section

**Spacing & tooling**

- Reduced home section gaps (desktop was very large between What I do and Selected Work)
- Unified seed:main-page for main_page (main_banner, what_i_do, selected_work, get_in_touch)
- SendMessage supports a compact modal mode
