### PR TITLE
About me/layout page improvements

### DIFF
--- a/app/aboutme/aboutme.module.scss
+++ b/app/aboutme/aboutme.module.scss
@@ -14,15 +14,17 @@
     align-items: center;
     // Major section rhythm — matches home page (3rem / 5rem / 8rem ≈ 48 / 80 / 128px).
     gap: 3rem;
-    margin-top: 1rem;
+    // Extra headroom under the sticky header before "Hello, I'm Antonio".
+    margin-top: 2.5rem;
 
     @media screen and (min-width: $tablet-min) {
       gap: 5rem;
-      margin-top: 2rem;
+      margin-top: 3.5rem;
     }
 
     @media screen and (min-width: $desktop-min) {
       gap: 8rem;
+      margin-top: 4.5rem;
       padding-bottom: 1rem;
     }
   }

--- a/app/aboutme/components/AboutMeIntro/aboutme_intro.module.scss
+++ b/app/aboutme/components/AboutMeIntro/aboutme_intro.module.scss
@@ -25,9 +25,24 @@
       }
     }
 
+    &Eyebrow {
+      margin: 0 0 0.55rem;
+      font-family: var(--font-poppins);
+      font-size: 0.75rem; /* ~12px — matches mockup PROFILE label */
+      font-weight: 600;
+      letter-spacing: 0.1em;
+      line-height: 1.2;
+      text-transform: uppercase;
+      color: #f59f0a;
+
+      @media #{$xs}, #{$sm} {
+        text-align: center;
+      }
+    }
+
     &Title {
       font-family: var(--font-montserrat);
-      @include fluid-type(20px, 26px, 26px);
+      font-size: clamp(1.8rem, 4vw, 2.2rem);
       font-weight: bold;
       color: $font-color-bold;
       margin-bottom: 1rem;
@@ -45,6 +60,40 @@
         @include fluid-type(16px, 20px, 24px);
         font-weight: 500;
       }
+    }
+
+    &BiographyLink {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      margin-top: 1.25rem;
+      color: #f59f0a;
+      font-family: var(--font-poppins);
+      font-size: 0.95rem;
+      font-weight: 500;
+      line-height: 1.2;
+      text-decoration: none;
+      transition: color 0.2s ease, gap 0.2s ease;
+
+      &:hover {
+        color: #d97706;
+        gap: 0.55rem;
+      }
+
+      &:focus-visible {
+        outline: 2px solid rgba(245, 159, 10, 0.55);
+        outline-offset: 4px;
+        border-radius: 2px;
+      }
+
+      @media #{$xs}, #{$sm} {
+        justify-content: center;
+        width: 100%;
+      }
+    }
+
+    &BiographyIcon {
+      font-size: 1rem !important;
     }
 
     &Img {

--- a/app/aboutme/components/AboutMeIntro/index.tsx
+++ b/app/aboutme/components/AboutMeIntro/index.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-import { useEffect, useState } from 'react';
-import Typewriter from 'typewriter-effect';
+import { useEffect, useState } from 'react'
+import Typewriter from 'typewriter-effect'
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
 import styles from './aboutme_intro.module.scss'
-import { aboutIntroFallback, type AboutIntroData } from '../../data/about-intro-data';
-import { subscribeAboutIntroData } from '../../lib/about-intro.firestore';
-import { AboutMeMobileImg } from './AboutMeIntroMobileImg';
-import { AboutMeDesktopTabletImg } from './AboutMeIntroDesktopTabletImg';
+import { aboutIntroFallback, type AboutIntroData } from '../../data/about-intro-data'
+import { subscribeAboutIntroData } from '../../lib/about-intro.firestore'
+import { AboutMeMobileImg } from './AboutMeIntroMobileImg'
+import { AboutMeDesktopTabletImg } from './AboutMeIntroDesktopTabletImg'
 
 function TypewriterComponent({ title }: { title: string }) {
   return (
@@ -32,6 +33,7 @@ export function AboutMeIntro() {
     <div className={styles.aboutmeIntro}>
       <div className={styles.aboutmeIntroContainer}>
         <div className={styles.aboutmeIntroInfo}>
+          <p className={styles.aboutmeIntroEyebrow}>Profile</p>
           <h1 className={styles.aboutmeIntroTitle}>
             <TypewriterComponent title={intro.pageTitle} />
           </h1>
@@ -47,6 +49,16 @@ export function AboutMeIntro() {
               >{ paragraph }</p>
             )}
           </div>
+          <a
+            href="#about-me-more"
+            className={styles.aboutmeIntroBiographyLink}
+          >
+            <span>Read full biography</span>
+            <ArrowForwardIcon
+              aria-hidden
+              className={styles.aboutmeIntroBiographyIcon}
+            />
+          </a>
         </div>
         <AboutMeDesktopTabletImg />
       </div>

--- a/app/aboutme/components/AboutMeMore/AboutMeMoreCard/index.tsx
+++ b/app/aboutme/components/AboutMeMore/AboutMeMoreCard/index.tsx
@@ -30,6 +30,8 @@ const TypeCardImg: Record<AboutMeMoreCardType, StaticImageData> = {
 export type AboutMeMoreCardProps = {
   type: null | AboutMeMoreCardType;
   title: string;
+  /** Optional one-line blurb under the title. */
+  description?: string;
   selected: boolean;
   onClick: (type: AboutMeMoreCardType | null) => void;
 };
@@ -37,6 +39,7 @@ export type AboutMeMoreCardProps = {
 export function AboutMeMoreCard({
   type = null,
   title = "",
+  description,
   selected = false,
   onClick,
 }: AboutMeMoreCardProps) {
@@ -52,8 +55,11 @@ export function AboutMeMoreCard({
         backgroundColor: "#ffffff",
         transition:
           "transform 0.22s ease, box-shadow 0.22s ease, background-color 0.22s ease, opacity 0.22s ease",
-        width: { xs: 120, sm: 142, md: 155, lg: 155, xl: 155 },
-        height: { xs: 166, sm: 196, md: 214, lg: 214, xl: 214 },
+        width: 280,
+        height: 210,
+        maxWidth: "100%",
+        flexShrink: 0,
+        overflow: "hidden",
 
         // selected state (subtle but clear)
         outline: selected ? "2px solid rgba(7, 76, 95, 0.55)" : "1px solid rgba(0,0,0,0.06)",
@@ -75,22 +81,24 @@ export function AboutMeMoreCard({
           height: "100%",
           display: "flex",
           flexDirection: "column",
-          alignItems: "center",
+          alignItems: "flex-start",
           justifyContent: "flex-start",
-          py: { xs: 1.25, md: 2 },
+          padding: "24px",
+          boxSizing: "border-box",
+          gap: "16px",
+          borderRadius: "inherit",
+          overflow: "hidden",
+          "& .MuiCardActionArea-focusHighlight": {
+            backgroundColor: "transparent",
+          },
         }}
       >
         {/* Image */}
         <Box
           sx={{
             position: "relative",
-            width: "70%",            
-            maxWidth: { xs: 90, md: 150 },
-            minWidth: { xs: 20, md: 110 },
-
-            aspectRatio: "1 / 1",
-
-            mt: { xs: 0.5, md: 0.5 },
+            width: 37,
+            height: 37,
             flexShrink: 0,
           }}
         >
@@ -100,24 +108,24 @@ export function AboutMeMoreCard({
               alt={type ?? "about-me"}
               fill
               style={{ objectFit: "contain" }}
-              sizes="(max-width: 600px) 90px, 150px"
+              sizes="37px"
             />
           ) : null}
         </Box>
 
-
-        {/* Title */}
+        {/* Title + optional description */}
         <CardContent
           sx={{
-            pt: { xs: 1, md: 1.25 },
-            pb: { xs: 1.25, md: 2 },
-            px: { xs: 1.25, md: 2 },
+            padding: "0 !important",
             width: "100%",
             display: "flex",
-            justifyContent: "center",
-            alignItems: "center",
-            textAlign: "center",
+            flexDirection: "column",
+            justifyContent: "flex-start",
+            alignItems: "flex-start",
+            textAlign: "left",
             flex: 1,
+            gap: "0.5rem",
+            minHeight: 0,
           }}
         >
           <Typography
@@ -125,13 +133,28 @@ export function AboutMeMoreCard({
             sx={{
               fontFamily: "var(--font-poppins)",
               fontWeight: 500,
-              color: "#011114",
-              lineHeight: 1.15,
-              fontSize: { xs: "1rem", md: "1.05rem" },
+              color: "#074c5f",
+              lineHeight: 1.3,
+              fontSize: "18px",
             }}
           >
             {title}
           </Typography>
+          {description ? (
+            <Typography
+              component="p"
+              sx={{
+                margin: 0,
+                fontFamily: "var(--font-poppins)",
+                fontWeight: 300,
+                color: "#074c5f",
+                lineHeight: 1.4,
+                fontSize: "16px",
+              }}
+            >
+              {description}
+            </Typography>
+          ) : null}
         </CardContent>
       </CardActionArea>
     </Card>

--- a/app/aboutme/components/AboutMeMore/AboutMeMoreCarousel.tsx
+++ b/app/aboutme/components/AboutMeMore/AboutMeMoreCarousel.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import ArrowBackIosNewIcon from "@mui/icons-material/ArrowBackIosNew";
+import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
+
+import {
+  AboutMeMoreCard,
+  type AboutMeMoreCardType,
+} from "@/app/aboutme/components/AboutMeMore/AboutMeMoreCard";
+import { usePrefersReducedMotion } from "@/lib/hooks/usePrefersReducedMotion";
+
+import styles from "./about-me-more-carousel.module.scss";
+
+const SCROLL_EDGE_EPSILON = 8;
+
+export type AboutMeMoreCarouselItem = {
+  type: AboutMeMoreCardType;
+  title: string;
+  description?: string;
+};
+
+type AboutMeMoreCarouselProps = {
+  items: readonly AboutMeMoreCarouselItem[];
+  selected: AboutMeMoreCardType;
+  onSelect: (type: AboutMeMoreCardType) => void;
+};
+
+function readScrollStepPx(track: HTMLDivElement): number {
+  const first = track.querySelector<HTMLElement>("[data-carousel-card]");
+  if (!first) return 304;
+  const w = first.getBoundingClientRect().width;
+  const marginEnd = Number.parseFloat(getComputedStyle(first).marginInlineEnd) || 0;
+  const cardStep = w + marginEnd;
+  const visibleCards = Math.max(1, Math.round(track.clientWidth / cardStep));
+  return cardStep * visibleCards;
+}
+
+function cardsPeekOffscreen(track: HTMLDivElement): {
+  peeksLeft: boolean;
+  peeksRight: boolean;
+} {
+  const cards = track.querySelectorAll<HTMLElement>("[data-carousel-card]");
+  if (!cards.length) return { peeksLeft: false, peeksRight: false };
+
+  const trackRect = track.getBoundingClientRect();
+  const firstRect = cards[0].getBoundingClientRect();
+  const lastRect = cards[cards.length - 1].getBoundingClientRect();
+
+  return {
+    peeksLeft: firstRect.left < trackRect.left - SCROLL_EDGE_EPSILON,
+    peeksRight: lastRect.right > trackRect.right + SCROLL_EDGE_EPSILON,
+  };
+}
+
+function AnimatedCardShell({
+  children,
+  index,
+}: {
+  children: ReactNode;
+  index: number;
+}) {
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [inView, setInView] = useState(prefersReducedMotion);
+
+  useEffect(() => {
+    if (prefersReducedMotion) {
+      setInView(true);
+      return;
+    }
+
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setInView(true);
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      {
+        root: null,
+        threshold: 0.15,
+        rootMargin: "0px 0px -10% 0px",
+      },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [prefersReducedMotion]);
+
+  return (
+    <div
+      ref={ref}
+      data-carousel-card
+      className={`${styles.cardShell} ${inView ? styles.cardInView : ""}`}
+      style={{
+        transitionDelay:
+          inView && !prefersReducedMotion ? `${index * 90}ms` : "0ms",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function AboutMeMoreCarousel({
+  items,
+  selected,
+  onSelect,
+}: AboutMeMoreCarouselProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollPrev, setCanScrollPrev] = useState(false);
+  const [canScrollNext, setCanScrollNext] = useState(false);
+  const [needsCarouselNav, setNeedsCarouselNav] = useState(false);
+
+  const updateScrollHints = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    const { peeksLeft, peeksRight } = cardsPeekOffscreen(el);
+    const overflow = peeksLeft || peeksRight;
+    const { scrollLeft, scrollWidth, clientWidth } = el;
+    const nextPrev = peeksLeft || scrollLeft > SCROLL_EDGE_EPSILON;
+    const nextNext =
+      peeksRight ||
+      scrollLeft + clientWidth < scrollWidth - SCROLL_EDGE_EPSILON;
+
+    setNeedsCarouselNav((p) => (p === overflow ? p : overflow));
+    setCanScrollPrev((p) => (p === nextPrev ? p : nextPrev));
+    setCanScrollNext((p) => (p === nextNext ? p : nextNext));
+  }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollLeft = 0;
+    const id = requestAnimationFrame(() => updateScrollHints());
+    return () => cancelAnimationFrame(id);
+  }, [items.length, updateScrollHints]);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    const onScroll = () => updateScrollHints();
+    el.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", updateScrollHints);
+
+    const resizeObserver = new ResizeObserver(() => updateScrollHints());
+    resizeObserver.observe(el);
+
+    return () => {
+      el.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", updateScrollHints);
+      resizeObserver.disconnect();
+    };
+  }, [items.length, updateScrollHints]);
+
+  const scrollByStep = (direction: 1 | -1) => {
+    const track = scrollRef.current;
+    if (!track) return;
+    track.scrollBy({
+      left: direction * readScrollStepPx(track),
+      behavior: "smooth",
+    });
+  };
+
+  if (!items.length) return null;
+
+  return (
+    <div
+      className={styles.carousel}
+      role="region"
+      aria-label="Experience, education, and training topics"
+    >
+      <div ref={scrollRef} className={styles.track}>
+        <div className={styles.gutterSpacer} aria-hidden="true" />
+        {items.map((item, index) => (
+          <AnimatedCardShell key={item.type} index={index}>
+            <AboutMeMoreCard
+              type={item.type}
+              title={item.title}
+              description={item.description}
+              selected={item.type === selected}
+              onClick={(type) => {
+                if (type) onSelect(type);
+              }}
+            />
+          </AnimatedCardShell>
+        ))}
+        <div className={styles.gutterSpacer} aria-hidden="true" />
+      </div>
+
+      {needsCarouselNav ? (
+        <div className={styles.nav}>
+          <button
+            type="button"
+            className={styles.navButton}
+            aria-label="Show previous topics"
+            disabled={!canScrollPrev}
+            onClick={() => {
+              if (canScrollPrev) scrollByStep(-1);
+            }}
+          >
+            <ArrowBackIosNewIcon sx={{ fontSize: 16 }} />
+          </button>
+          <button
+            type="button"
+            className={`${styles.navButton} ${styles.navButtonNext}`}
+            aria-label="Show more topics"
+            disabled={!canScrollNext}
+            onClick={() => {
+              if (canScrollNext) scrollByStep(1);
+            }}
+          >
+            <ArrowForwardIosIcon sx={{ fontSize: 16 }} />
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export default AboutMeMoreCarousel;

--- a/app/aboutme/components/AboutMeMore/about-me-more-carousel.module.scss
+++ b/app/aboutme/components/AboutMeMore/about-me-more-carousel.module.scss
@@ -1,0 +1,143 @@
+@use "../../../home/home-layout" as home;
+
+$card-width: 280px;
+$card-height: 210px;
+$card-gap: 24px;
+
+.carousel {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.track {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  align-items: stretch;
+  gap: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+  scroll-behavior: smooth;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+  scroll-snap-type: x proximity;
+  /*
+   * Hover uses translateY(-6px) + box-shadow 0 18px 45px.
+   * Scroll tracks clip overflow, so pad enough for lift + shadow,
+   * then pull layout back with negative margins.
+   */
+  padding-top: 14px;
+  padding-bottom: 56px;
+  margin-top: -14px;
+  margin-bottom: -16px;
+  scroll-padding-inline: var(
+    --about-me-more-gutter,
+    #{home.$home-layout-margin-mobile}
+  );
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.gutterSpacer {
+  flex: 0 0 var(--about-me-more-gutter, #{home.$home-layout-margin-mobile});
+  width: var(--about-me-more-gutter, #{home.$home-layout-margin-mobile});
+  height: 1px;
+  pointer-events: none;
+}
+
+.cardShell {
+  flex: 0 0 auto;
+  width: $card-width;
+  height: $card-height;
+  scroll-snap-align: start;
+  display: flex;
+  border-radius: 12px;
+  overflow: visible;
+  opacity: 0;
+  transform: translateY(24px);
+  transition:
+    opacity 0.6s ease-out,
+    transform 0.6s ease-out;
+
+  &:not(:nth-last-child(2)) {
+    margin-inline-end: $card-gap;
+  }
+
+  :global(.MuiPaper-root) {
+    border-radius: 12px !important;
+    overflow: hidden;
+  }
+}
+
+.cardInView {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.nav {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1.5rem;
+  box-sizing: border-box;
+  padding-inline: var(
+    --about-me-more-gutter,
+    #{home.$home-layout-margin-mobile}
+  );
+}
+
+.navButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  background-color: #f1f1f3;
+  color: #074c5f;
+  transition: background-color 0.2s ease;
+
+  &:hover:not(:disabled) {
+    background-color: #e8e8ec;
+  }
+
+  &:disabled {
+    cursor: default;
+    color: rgba(7, 76, 95, 0.28);
+  }
+}
+
+.navButtonNext {
+  background-color: #074c5f;
+  color: #ffffff;
+
+  &:hover:not(:disabled) {
+    background-color: #0a6280;
+  }
+
+  &:disabled {
+    background-color: #f1f1f3;
+    color: rgba(7, 76, 95, 0.28);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cardShell {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+
+  .track {
+    scroll-behavior: auto;
+  }
+}

--- a/app/aboutme/components/AboutMeMore/aboutmeMore.module.scss
+++ b/app/aboutme/components/AboutMeMore/aboutmeMore.module.scss
@@ -1,15 +1,39 @@
+@use "../../../home/home-layout" as home;
 @import "@/styles/variables";
 @import "@/styles/mixins";
 
-.aboutmeMore{
+.aboutmeMore {
+  /* Break out of About Me page gutters so the carousel can edge-peek like What I do */
+  position: relative;
+  box-sizing: border-box;
+  width: 100vw;
+  max-width: none;
+  margin-left: calc(50% - 50vw);
+  margin-right: calc(50% - 50vw);
   display: flex;
   flex-direction: column;
-  width: 100%;
-  align-items: center;
+  align-items: stretch;
+  overflow-x: clip;
+  overflow-y: visible;
+  --about-me-more-gutter: #{home.$home-layout-margin-mobile};
+
+  @media screen and (min-width: $tablet-min) {
+    --about-me-more-gutter: calc(
+      (100vw - min(100vw, #{home.$home-layout-max-width-tablet})) / 2 +
+        #{home.$home-layout-margin-tablet}
+    );
+  }
+
+  @media screen and (min-width: $desktop-min) {
+    --about-me-more-gutter: calc(
+      (100vw - min(100vw, #{home.$home-layout-max-width-desktop})) / 2 +
+        #{home.$home-layout-margin-desktop}
+    );
+  }
 
   &Header {
-    text-align: center;
-    max-width: 40rem;
+    @include home.home-page-gutter;
+    text-align: left;
     // Gap before cards — same rhythm as cards → timeline (30 / 50 / 80).
     margin-bottom: 30px;
 
@@ -23,51 +47,42 @@
   }
 
   &Title {
-    // Same typography as About Me intro title ("Hello, I'm Antonio").
     font-family: var(--font-montserrat);
-    @include fluid-type(20px, 26px, 26px);
+    font-size: clamp(1.8rem, 4vw, 2.2rem);
     font-weight: bold;
     color: $font-color-bold;
     margin: 0;
   }
 
-  .aboutmeMoreCards {
-    display: flex;
-    flex-wrap: wrap;
-    //gap: 32px;
-
-    @media #{$lg} {
-      gap: 1.5rem;  
-    }
-
-    @media #{$md} {
-      gap: 1rem;  
-    }
-
-    @media #{$sm, $xs} {
-      gap: 0.5rem;  
-    }
-
-    justify-content: center;
+  &Eyebrow {
+    margin: 0 0 0.55rem;
+    font-family: var(--font-poppins);
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    line-height: 1.2;
+    text-transform: uppercase;
+    color: #f59f0a;
   }
 
- 
-  &Cards {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    grid-template-rows: 1fr;
-    grid-column-gap: 32px;
-    grid-row-gap: 0px;
+  &CarouselStrip {
+    width: 100%;
+    box-sizing: border-box;
+    position: relative;
+    z-index: 2;
   }
 
   &Section {
+    @include home.home-page-gutter;
     // Gap between cards and timeline — proportional to desktop 80px (3:5:8 rhythm).
-    margin-top: 30px; // mobile (~3/8 of 80)
-    max-width: 700px;
+    margin-top: 30px;
     width: 100%;
+    box-sizing: border-box;
+    display: flex;
+    justify-content: center;
 
     @media screen and (min-width: $tablet-min) {
-      margin-top: 50px; // tablet (~5/8 of 80)
+      margin-top: 50px;
     }
 
     @media screen and (min-width: $desktop-min) {
@@ -75,14 +90,8 @@
     }
   }
 
-  @media #{$sm} {
-    align-items: center;
-
-    &Cards {
-      width: 295px;
-      grid-template-columns: repeat(2, 1fr);
-      grid-column-gap: 15px;
-      grid-row-gap: 15px;
-    }
+  &SectionInner {
+    width: 100%;
+    max-width: 700px;
   }
 }

--- a/app/aboutme/components/AboutMeMore/index.tsx
+++ b/app/aboutme/components/AboutMeMore/index.tsx
@@ -3,35 +3,17 @@
 import { useEffect, useState, type ReactNode } from 'react';
 import styles from './aboutmeMore.module.scss';
 import { AboutMeMoreProfesionalExperience } from './AboutMeMoreProfesionalExperience';
-import { AboutMeMoreCard, AboutMeMoreCardType } from './AboutMeMoreCard';
+import { AboutMeMoreCardType } from './AboutMeMoreCard';
 import { AboutMeMoreEducation } from './AboutMeMoreEducation';
 import { AboutMeMoreCertifications } from './AboutMeMoreCertifications';
 import { AboutMeMorePersonalTime } from './AboutMeMorePersonalTime';
+import { AboutMeMoreCarousel } from './AboutMeMoreCarousel';
 import { ExperienceTrainingContext } from './ExperienceTrainingContext';
 import {
   experienceTrainingFallback,
   type ExperienceTrainingData,
 } from '@/app/aboutme/data/experience-training-data';
 import { subscribeExperienceTrainingData } from '@/app/aboutme/lib/experience-training.firestore';
-
-const availableCards = [
-  {
-    type: AboutMeMoreCardType.professional_experience,
-    title: 'Professional Experience'
-  },
-  {
-    type: AboutMeMoreCardType.education,
-    title: 'Education'
-  },
-  {
-    type: AboutMeMoreCardType.certifications,
-    title: 'Certifications'
-  },
-  {
-    type: AboutMeMoreCardType.personal,
-    title: 'When I am not working...'
-  },
-] as const;
 
 export function AboutMeMore() {
   const [selected, setSelected] = useState<AboutMeMoreCardType>(
@@ -45,6 +27,12 @@ export function AboutMeMore() {
     return subscribeExperienceTrainingData(setData);
   }, []);
 
+  const availableCards = data.topicCards.map((card) => ({
+    type: card.id as AboutMeMoreCardType,
+    title: card.title,
+    ...(card.description ? { description: card.description } : {}),
+  }));
+
   const sections: Record<AboutMeMoreCardType, ReactNode> = {
     professional_experience: (
       <AboutMeMoreProfesionalExperience key="professional_experience" />
@@ -57,28 +45,28 @@ export function AboutMeMore() {
   return (
     <ExperienceTrainingContext.Provider value={data}>
       <section
+        id="about-me-more"
         className={styles.aboutmeMore}
         aria-labelledby="about-me-more-title"
       >
         <header className={styles.aboutmeMoreHeader}>
+          <p className={styles.aboutmeMoreEyebrow}>Background</p>
           <h2 id="about-me-more-title" className={styles.aboutmeMoreTitle}>
             {data.sectionTitle}
           </h2>
         </header>
-        <div className={styles.aboutmeMoreCards}>
-          {availableCards.map((card, index) => (
-            <AboutMeMoreCard
-              key={`${index}-about-me-card`}
-              type={card.type}
-              title={card.title}
-              selected={card.type === selected}
-              onClick={(type) => {
-                if (type) setSelected(type);
-              }}
-            />
-          ))}
+        <div className={styles.aboutmeMoreCarouselStrip}>
+          <AboutMeMoreCarousel
+            items={availableCards}
+            selected={selected}
+            onSelect={setSelected}
+          />
         </div>
-        <div className={styles.aboutmeMoreSection}>{sections[selected]}</div>
+        <div className={styles.aboutmeMoreSection}>
+          <div className={styles.aboutmeMoreSectionInner}>
+            {sections[selected]}
+          </div>
+        </div>
       </section>
     </ExperienceTrainingContext.Provider>
   );

--- a/app/aboutme/components/CapabilityMap/CapabilityMapChart.tsx
+++ b/app/aboutme/components/CapabilityMap/CapabilityMapChart.tsx
@@ -32,8 +32,8 @@ const HUB_RATIO = 0.3;
 const DOMAIN_LABEL_RATIO = 1.34;
 /** Pull top/bottom domain labels closer (vertical stack clears the rim more). */
 const DOMAIN_LABEL_VERTICAL_INSET = 0.1;
-/** Push left/right domain labels farther out (text extends into the chart). */
-const DOMAIN_LABEL_SIDE_OUTSET = 0.06;
+/** Slight pull-in on left/right; textAnchor grows labels inward so they stay on-canvas. */
+const DOMAIN_LABEL_SIDE_OUTSET = -0.02;
 /** Skill labels sit outside the outermost expertise ring. */
 const SKILL_LABEL_RATIO = 0.93;
 /** Soft wrap length for skill labels (keeps rim labels compact). */
@@ -155,9 +155,14 @@ function wrapLabel(label: string, maxChars: number): string[] {
   return lines.slice(0, 3);
 }
 
-/** Domain labels: pull in at top/bottom; push out on sides (horizontal text overlaps the rim). */
+/** Normalize chart angle (0° at top, clockwise) to [0, 360). */
+function angleDegrees(angleRadians: number): number {
+  return (((angleRadians * 180) / Math.PI) % 360 + 360) % 360;
+}
+
+/** Domain labels: pull in at top/bottom; nudge sides (horizontal text overlaps the rim). */
 function domainLabelRatioForAngle(angleRadians: number): number {
-  const deg = (((angleRadians * 180) / Math.PI) % 360 + 360) % 360;
+  const deg = angleDegrees(angleRadians);
   const nearBottom = deg > 160 && deg < 210;
   const nearTop = deg < 25 || deg > 335;
   const nearSide =
@@ -170,6 +175,34 @@ function domainLabelRatioForAngle(angleRadians: number): number {
     return DOMAIN_LABEL_RATIO + DOMAIN_LABEL_SIDE_OUTSET;
   }
   return DOMAIN_LABEL_RATIO;
+}
+
+/**
+ * Side labels grow toward the hub so long titles (e.g. "Data & Analytics")
+ * stay inside the SVG instead of clipping past the left/right edge.
+ */
+function textAnchorForAngle(angleRadians: number): "start" | "middle" | "end" {
+  const deg = angleDegrees(angleRadians);
+  if (deg > 45 && deg < 135) return "end"; // right → grow left into chart
+  if (deg > 225 && deg < 315) return "start"; // left → grow right into chart
+  return "middle";
+}
+
+/**
+ * Clockwise label placement nudge (degrees). Wedge geometry stays put —
+ * only the title moves along the outer rim.
+ */
+function domainLabelAngleNudgeDegrees(domainId: string): number {
+  // Clockwise positive. Left-side labels need counter-clockwise to move down.
+  if (domainId === "ai-intelligent-systems") return 16;
+  if (domainId === "data-analytics") return -12;
+  return 0;
+}
+
+/** Prefer intentional wraps for long domain titles. */
+function wrapDomainLabel(label: string): string[] {
+  if (label === "Data & Analytics") return ["Data &", "Analytics"];
+  return wrapLabel(label, 18);
 }
 
 type ExpertiseVertex = CapabilitySkillLayout & { x: number; y: number };
@@ -186,7 +219,7 @@ export function CapabilityMapChart({
 
   const size = Math.min(width, height);
   // Fraction of the square reserved for domain/skill labels around the rings.
-  const margin = showSkillLabels ? size * 0.17 : size * 0.13;
+  const margin = showSkillLabels ? size * 0.12 : size * 0.09;
   const radius = (size - margin * 2) / 2;
   const cx = size / 2;
   const cy = size / 2;
@@ -498,16 +531,24 @@ function DomainLabel({
   domain: CapabilityDomainLayout;
   radius: number;
 }) {
-  const labelRatio = domainLabelRatioForAngle(domain.midAngle);
-  const point = polarToCartesian(0, 0, radius * labelRatio, domain.midAngle);
-  const lines = wrapLabel(domain.label, 18);
-  const dy = lines.length > 1 ? -((lines.length - 1) * 6) : 0;
+  const labelAngle =
+    domain.midAngle +
+    (domainLabelAngleNudgeDegrees(domain.id) * Math.PI) / 180;
+  const labelRatio = domainLabelRatioForAngle(labelAngle);
+  const point = polarToCartesian(0, 0, radius * labelRatio, labelAngle);
+  const textAnchor = textAnchorForAngle(labelAngle);
+  const lines = wrapDomainLabel(domain.label);
+  // Side multi-line labels: keep baseline at the anchor (no upward pull into viz).
+  const dy =
+    textAnchor === "middle" && lines.length > 1
+      ? -((lines.length - 1) * 6)
+      : 0;
 
   return (
     <text
       x={point.x}
       y={point.y}
-      textAnchor="middle"
+      textAnchor={textAnchor}
       dy={dy}
       className={styles.capabilityMapDomainLabel}
       fill={domain.color}

--- a/app/aboutme/components/CapabilityMap/CapabilityMapChart.tsx
+++ b/app/aboutme/components/CapabilityMap/CapabilityMapChart.tsx
@@ -185,7 +185,8 @@ export function CapabilityMapChart({
   if (width < 120 || height < 120) return null;
 
   const size = Math.min(width, height);
-  const margin = showSkillLabels ? size * 0.22 : size * 0.16;
+  // Fraction of the square reserved for domain/skill labels around the rings.
+  const margin = showSkillLabels ? size * 0.17 : size * 0.13;
   const radius = (size - margin * 2) / 2;
   const cx = size / 2;
   const cy = size / 2;

--- a/app/aboutme/components/CapabilityMap/capability-map.module.scss
+++ b/app/aboutme/components/CapabilityMap/capability-map.module.scss
@@ -117,25 +117,29 @@
 
   &Card {
     box-sizing: border-box;
+    // max-width comes from CAPABILITY_MAP_SIZE.maxChartSize (inline) so the
+    // white card hugs the viz instead of stretching full section width.
     width: 100%;
     margin-top: 1.75rem;
-    padding: 0.75rem 0.75rem 1.25rem;
+    // Keep horizontal padding tight — domain labels need the SVG edge.
+    padding: 0.5rem 0.35rem 1rem;
     background-color: #ffffff;
     border-radius: 16px;
     box-shadow: 0 4px 24px rgba(7, 76, 95, 0.08);
     display: flex;
     flex-direction: column;
     align-items: center;
+    overflow: visible;
 
     @media screen and (min-width: $tablet-min) {
       margin-top: 2.25rem;
-      padding: 1rem 1rem 1.5rem;
+      padding: 0.65rem 0.4rem 1.15rem;
       border-radius: 18px;
     }
 
     @media screen and (min-width: $desktop-min) {
       margin-top: 2.75rem;
-      padding: 1.25rem 1.25rem 1.75rem;
+      padding: 0.75rem 0.5rem 1.35rem;
       border-radius: 20px;
     }
   }

--- a/app/aboutme/components/CapabilityMap/capability-map.module.scss
+++ b/app/aboutme/components/CapabilityMap/capability-map.module.scss
@@ -8,7 +8,7 @@
   margin-left: calc(50% - 50vw);
   margin-right: calc(50% - 50vw);
   box-sizing: border-box;
-  background-color: #F7FBFF;
+  background-color: #f9f7f2;
   // Vertical padding — 3:5:8 rhythm scaled to 80px desktop.
   padding-top: 30px;
   padding-bottom: 30px;
@@ -41,28 +41,49 @@
   color: $font-color-bold;
 
   &Header {
-    text-align: center;
-    max-width: 40rem;
-    margin-bottom: 0rem;
+    text-align: left;
+    width: 100%;
+    max-width: none;
+    margin-bottom: 0;
+    align-self: stretch;
+  }
+
+  &Eyebrow {
+    margin: 0 0 0.55rem;
+    font-family: var(--font-poppins);
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    line-height: 1.2;
+    text-transform: uppercase;
+    color: #f59f0a;
+    text-align: left;
   }
 
   &Title {
     // Same typography as About Me intro title ("Hello, I'm Antonio").
     font-family: var(--font-montserrat);
-    @include fluid-type(20px, 26px, 26px);
+    font-size: clamp(1.8rem, 4vw, 2.2rem);
     font-weight: bold;
     color: $font-color-bold;
     margin: 0 0 0.5rem;
-    text-align: center;
+    text-align: left;
   }
 
   &Tagline {
-    // Match About Me intro paragraphs (`aboutmeIntroDesc p`).
+    // Match About Me intro paragraphs (`aboutmeIntroDesc p`) — same column width as
+    // `.aboutmeIntroInfo` (60% beside the portrait).
     @include fluid-type(16px, 20px, 24px);
     font-weight: 500;
     color: $font-color-bold;
     margin: 0 0 0.75rem;
     text-align: left;
+    width: 100%;
+    max-width: 60%;
+
+    @media #{$xs}, #{$sm} {
+      max-width: 100%;
+    }
   }
 
   &Description {
@@ -72,6 +93,12 @@
     color: #3a5560;
     margin: 0;
     text-align: left;
+    width: 100%;
+    max-width: 60%;
+
+    @media #{$xs}, #{$sm} {
+      max-width: 100%;
+    }
   }
 
   &ChartWrap {
@@ -81,11 +108,36 @@
     // Square box sized by width — avoids tall empty space above the SVG.
     aspect-ratio: 1 / 1;
     height: auto;
-    margin: -5.25rem auto 0;
+    margin: 0 auto;
     overflow: visible;
     display: flex;
     justify-content: center;
     align-items: center;
+  }
+
+  &Card {
+    box-sizing: border-box;
+    width: 100%;
+    margin-top: 1.75rem;
+    padding: 0.75rem 0.75rem 1.25rem;
+    background-color: #ffffff;
+    border-radius: 16px;
+    box-shadow: 0 4px 24px rgba(7, 76, 95, 0.08);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    @media screen and (min-width: $tablet-min) {
+      margin-top: 2.25rem;
+      padding: 1rem 1rem 1.5rem;
+      border-radius: 18px;
+    }
+
+    @media screen and (min-width: $desktop-min) {
+      margin-top: 2.75rem;
+      padding: 1.25rem 1.25rem 1.75rem;
+      border-radius: 20px;
+    }
   }
 
   &ChartInner {
@@ -103,64 +155,49 @@
   }
 
   &LabelsWrap {
-    // Compact legend card under the chart, right-aligned.
-    // Negative margin pulls it into the empty square below the circular map.
-    align-self: flex-end;
+    // Expertise legend sits under the chart inside the white card.
+    align-self: center;
     width: fit-content;
     max-width: 100%;
-    margin-top: -4.5rem;
+    margin-top: 0.75rem;
     position: relative;
     z-index: 1;
 
     @media screen and (min-width: $tablet-min) {
-      margin-top: -7rem;
+      margin-top: 1rem;
     }
 
     @media screen and (min-width: $desktop-min) {
-      margin-top: -11rem;
+      margin-top: 1.25rem;
     }
   }
 
   &Labels {
     box-sizing: border-box;
-    width: fit-content;
+    width: 100%;
     max-width: 100%;
-    // Mobile-first; scale up at tablet / desktop.
-    padding: 0.55rem 0.7rem 0.6rem;
-    border: 0.75px solid #A9C4FA;
-    border-radius: 6px;
-    background-color: #f9fcff;
-
-    @media screen and (min-width: $tablet-min) {
-      padding: 0.7rem 0.85rem 0.75rem;
-      border-width: 1.25px;
-      border-radius: 7px;
-    }
-
-    @media screen and (min-width: $desktop-min) {
-      padding: 0.875rem 1.05rem 0.95rem;
-      border-width: 1.5px;
-      border-radius: 8px;
-    }
+    padding: 0;
+    border: none;
+    background: transparent;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
   }
 
   &LabelsTitle {
-    margin: 0 0 0.75rem;
+    margin: 0;
     text-align: center;
-    font-family: var(--font-montserrat);
-    font-size: 0.58rem;
+    font-family: var(--font-poppins);
+    font-size: 0.6875rem;
     font-weight: 600;
+    letter-spacing: 0.08em;
     line-height: 1.2;
-    color: $font-color-bold;
+    text-transform: uppercase;
+    color: #6b7c85;
 
     @media screen and (min-width: $tablet-min) {
-      margin-bottom: 0.95rem;
-      font-size: 0.65rem;
-    }
-
-    @media screen and (min-width: $desktop-min) {
-      margin-bottom: 1.15rem;
-      font-size: 16px;
+      font-size: 0.75rem;
     }
   }
 
@@ -169,15 +206,18 @@
     padding: 0;
     list-style: none;
     display: flex;
-    flex-direction: column;
-    gap: 0.4rem;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    gap: 0.85rem 1.25rem;
 
     @media screen and (min-width: $tablet-min) {
-      gap: 0.5rem;
+      gap: 1rem 1.75rem;
     }
 
     @media screen and (min-width: $desktop-min) {
-      gap: 0.63rem;
+      gap: 1.1rem 2.25rem;
     }
   }
 
@@ -185,76 +225,54 @@
     display: flex;
     flex-direction: row;
     align-items: center;
-    gap: 0.4rem;
+    gap: 0.45rem;
 
     @media screen and (min-width: $tablet-min) {
-      gap: 0.5rem;
-    }
-
-    @media screen and (min-width: $desktop-min) {
-      gap: 0.6rem;
+      gap: 0.55rem;
     }
   }
 
   &LabelCircleSlot {
-    width: 1.25rem;
+    width: 1.35rem;
     flex-shrink: 0;
     display: flex;
     justify-content: center;
     align-items: center;
 
     @media screen and (min-width: $tablet-min) {
-      width: 1.55rem;
+      width: 1.6rem;
     }
 
     @media screen and (min-width: $desktop-min) {
-      width: 1.925rem;
+      width: 1.85rem;
     }
   }
 
   &LabelCircle {
     box-sizing: border-box;
     flex-shrink: 0;
-    border: 1px solid $font-color-bold;
+    border: 1.5px solid #5c6b73;
     border-radius: 50%;
     background: transparent;
-
-    @media screen and (min-width: $tablet-min) {
-      border-width: 1.15px;
-    }
-
-    @media screen and (min-width: $desktop-min) {
-      border-width: 1.25px;
-    }
   }
 
   &LabelCircleSm {
-    width: 0.4rem;
-    height: 0.4rem;
+    width: 0.45rem;
+    height: 0.45rem;
 
     @media screen and (min-width: $tablet-min) {
-      width: 0.5rem;
-      height: 0.5rem;
-    }
-
-    @media screen and (min-width: $desktop-min) {
-      width: 0.61rem;
-      height: 0.61rem;
+      width: 0.55rem;
+      height: 0.55rem;
     }
   }
 
   &LabelCircleMd {
-    width: 0.62rem;
-    height: 0.62rem;
+    width: 0.65rem;
+    height: 0.65rem;
 
     @media screen and (min-width: $tablet-min) {
-      width: 0.78rem;
-      height: 0.78rem;
-    }
-
-    @media screen and (min-width: $desktop-min) {
-      width: 0.96rem;
-      height: 0.96rem;
+      width: 0.8rem;
+      height: 0.8rem;
     }
   }
 
@@ -263,45 +281,31 @@
     height: 0.9rem;
 
     @media screen and (min-width: $tablet-min) {
-      width: 1.15rem;
-      height: 1.15rem;
-    }
-
-    @media screen and (min-width: $desktop-min) {
-      width: 1.4rem;
-      height: 1.4rem;
+      width: 1.1rem;
+      height: 1.1rem;
     }
   }
 
   &LabelCircleXl {
-    width: 1.2rem;
-    height: 1.2rem;
+    width: 1.15rem;
+    height: 1.15rem;
 
     @media screen and (min-width: $tablet-min) {
-      width: 1.5rem;
-      height: 1.5rem;
-    }
-
-    @media screen and (min-width: $desktop-min) {
-      width: 1.84rem;
-      height: 1.84rem;
+      width: 1.35rem;
+      height: 1.35rem;
     }
   }
 
   &LabelText {
-    font-family: var(--font-montserrat);
-    font-size: 0.58rem;
+    font-family: var(--font-poppins);
+    font-size: 0.75rem;
     font-weight: 400;
     line-height: 1.2;
-    color: $font-color-bold;
+    color: #5c6b73;
     white-space: nowrap;
 
     @media screen and (min-width: $tablet-min) {
-      font-size: 0.65rem;
-    }
-
-    @media screen and (min-width: $desktop-min) {
-      font-size: 0.735rem;
+      font-size: 0.8125rem;
     }
   }
 

--- a/app/aboutme/components/CapabilityMap/capability-map.size.ts
+++ b/app/aboutme/components/CapabilityMap/capability-map.size.ts
@@ -9,7 +9,7 @@ export const CAPABILITY_MAP_SIZE = {
    * Hard cap on the square chart width/height (px).
    * Example: 800 → viz block is at most 800×800.
    */
-  maxChartSize: 1000,
+  maxChartSize: 780,
   /** Max width for the section (header/footer copy); chart is capped separately. */
   sectionMaxWidth: 1100,
 } as const;

--- a/app/aboutme/components/CapabilityMap/index.tsx
+++ b/app/aboutme/components/CapabilityMap/index.tsx
@@ -36,6 +36,7 @@ export function CapabilityMap() {
           style={{ maxWidth: sizeStyles.sectionMaxWidth }}
         >
           <header className={styles.capabilityMapHeader}>
+            <p className={styles.capabilityMapEyebrow}>Expertise</p>
             <h2 id="capability-map-title" className={styles.capabilityMapTitle}>
               {data.header.title}
             </h2>
@@ -47,43 +48,45 @@ export function CapabilityMap() {
             ) : null}
           </header>
 
-          <div
-            className={styles.capabilityMapChartWrap}
-            style={{ maxWidth: sizeStyles.chartMaxSize }}
-          >
-            {hasMounted ? (
-              <ParentSize
-                debounceTime={10}
-                parentSizeStyles={{
-                  width: "100%",
-                  height: "100%",
-                  overflow: "visible",
-                }}
-              >
-                {({ width, height }) => {
-                  if (width < 120 || height < 120) {
-                    return null;
-                  }
+          <div className={styles.capabilityMapCard}>
+            <div
+              className={styles.capabilityMapChartWrap}
+              style={{ maxWidth: sizeStyles.chartMaxSize }}
+            >
+              {hasMounted ? (
+                <ParentSize
+                  debounceTime={10}
+                  parentSizeStyles={{
+                    width: "100%",
+                    height: "100%",
+                    overflow: "visible",
+                  }}
+                >
+                  {({ width, height }) => {
+                    if (width < 120 || height < 120) {
+                      return null;
+                    }
 
-                  return (
-                    <div className={styles.capabilityMapChartInner}>
-                      <CapabilityMapChart
-                        data={data}
-                        width={width}
-                        height={height}
-                        showSkillLabels={width >= 640}
-                      />
-                    </div>
-                  );
-                }}
-              </ParentSize>
-            ) : (
-              <div className={styles.capabilityMapChartPlaceholder} aria-hidden />
-            )}
-          </div>
+                    return (
+                      <div className={styles.capabilityMapChartInner}>
+                        <CapabilityMapChart
+                          data={data}
+                          width={width}
+                          height={height}
+                          showSkillLabels={width >= 640}
+                        />
+                      </div>
+                    );
+                  }}
+                </ParentSize>
+              ) : (
+                <div className={styles.capabilityMapChartPlaceholder} aria-hidden />
+              )}
+            </div>
 
-          <div className={styles.capabilityMapLabelsWrap}>
-            <CapabilityMapLabels />
+            <div className={styles.capabilityMapLabelsWrap}>
+              <CapabilityMapLabels />
+            </div>
           </div>
         </div>
       </div>

--- a/app/aboutme/components/CapabilityMap/index.tsx
+++ b/app/aboutme/components/CapabilityMap/index.tsx
@@ -48,11 +48,11 @@ export function CapabilityMap() {
             ) : null}
           </header>
 
-          <div className={styles.capabilityMapCard}>
-            <div
-              className={styles.capabilityMapChartWrap}
-              style={{ maxWidth: sizeStyles.chartMaxSize }}
-            >
+          <div
+            className={styles.capabilityMapCard}
+            style={{ maxWidth: sizeStyles.chartMaxSize }}
+          >
+            <div className={styles.capabilityMapChartWrap}>
               {hasMounted ? (
                 <ParentSize
                   debounceTime={10}

--- a/app/aboutme/data/experience-training-data.ts
+++ b/app/aboutme/data/experience-training-data.ts
@@ -39,17 +39,56 @@ export type EducationEntryData = {
   details: string;
 };
 
+export type ExperienceTopicCardId =
+  | "professional_experience"
+  | "education"
+  | "certifications"
+  | "personal";
+
+export type ExperienceTopicCardData = {
+  id: ExperienceTopicCardId;
+  title: string;
+  /** Optional one-line blurb under the title on the Background cards. */
+  description?: string;
+};
+
 export type ExperienceTrainingData = {
   version: number;
   sectionTitle: string;
+  /** Topic cards in the Background carousel (title + summary). */
+  topicCards: ExperienceTopicCardData[];
   experience: ExperienceEntryData[];
   education: EducationEntryData[];
   certification: EducationEntryData[];
 };
 
 export const experienceTrainingFallback: ExperienceTrainingData = {
-  version: 1,
+  version: 2,
   sectionTitle: "Experience, Education & Formal Training",
+  topicCards: [
+    {
+      id: "professional_experience",
+      title: "Professional Experience",
+      description:
+        "Lead & senior engineering roles building interactive dashboards, web platforms, and AI-driven tools.",
+    },
+    {
+      id: "education",
+      title: "Education",
+      description:
+        "Formal training in computer science, design, and human-computer interaction.",
+    },
+    {
+      id: "certifications",
+      title: "Certifications",
+      description:
+        "Continuous learning in cloud, AI product design, and modern frontend frameworks.",
+    },
+    {
+      id: "personal",
+      title: "When I am not working...",
+    },
+  ],
   experience: [
     {
       logoKey: "disney",

--- a/app/aboutme/lib/experience-training.firestore.ts
+++ b/app/aboutme/lib/experience-training.firestore.ts
@@ -7,6 +7,8 @@ import {
   type ExperienceEntryData,
   type ExperienceLogoKey,
   type ExperiencePositionData,
+  type ExperienceTopicCardData,
+  type ExperienceTopicCardId,
   type ExperienceTrainingData,
 } from "@/app/aboutme/data/experience-training-data";
 
@@ -23,6 +25,27 @@ const LOGO_KEYS = new Set<ExperienceLogoKey>([
   "emerson",
   "mit",
 ]);
+
+const TOPIC_CARD_IDS = new Set<ExperienceTopicCardId>([
+  "professional_experience",
+  "education",
+  "certifications",
+  "personal",
+]);
+
+function parseTopicCard(raw: unknown): ExperienceTopicCardData | null {
+  if (!raw || typeof raw !== "object") return null;
+  const record = raw as Record<string, unknown>;
+  const id = asString(record.id) as ExperienceTopicCardId;
+  const title = asString(record.title);
+  if (!TOPIC_CARD_IDS.has(id) || !title) return null;
+  const description = asString(record.description);
+  return {
+    id,
+    title,
+    ...(description ? { description } : {}),
+  };
+}
 
 function asString(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
@@ -109,6 +132,11 @@ export function parseExperienceTrainingDocument(
     ? data.certification
     : [];
 
+  const topicCardsRaw = Array.isArray(data.topicCards) ? data.topicCards : [];
+  const topicCards = topicCardsRaw
+    .map(parseTopicCard)
+    .filter((c): c is ExperienceTopicCardData => c !== null);
+
   const experience = experienceRaw
     .map(parseExperienceEntry)
     .filter((e): e is ExperienceEntryData => e !== null);
@@ -128,6 +156,10 @@ export function parseExperienceTrainingDocument(
   return {
     version: asNumber(data.version, 1),
     sectionTitle,
+    topicCards:
+      topicCards.length > 0
+        ? topicCards
+        : experienceTrainingFallback.topicCards,
     experience:
       experience.length > 0
         ? experience

--- a/app/home/latest-projects.module.scss
+++ b/app/home/latest-projects.module.scss
@@ -170,7 +170,7 @@
     min-height: 44px;
     padding: 0.7rem 1.25rem;
     border-radius: 8px;
-    background-color: #1e3a4c;
+    background-color: #074c5f;
     color: #ffffff;
     font-family: var(--font-poppins);
     font-size: 0.875rem;
@@ -184,7 +184,7 @@
 
     &:hover {
       transform: translateY(-2px);
-      background-color: #074c5f;
+      background-color: #0a6280;
       box-shadow: 0 8px 18px rgba(7, 76, 95, 0.2);
     }
 


### PR DESCRIPTION
### Summary
About Me page layout polish aligned with the landing-page patterns (eyebrows, cream bands, carousel cards), plus Capability Map sizing/label fixes for laptop screens.

**Profile (Intro)**

- Orange PROFILE eyebrow and title sizing matched to “What I do”
- Read full biography → text link to #about-me-more
- Extra top spacing under the sticky nav

**Expertise (Capability Map)**

- EXPERTISE eyebrow, left-aligned title/tagline, cream band, white chart card
- Chart capped at 780px; card hugs the viz (less empty side padding)
- Domain labels: inward text anchors, AI/Data nudges, Data & / Analytics wrap
- Expertise Level legend kept inside the card
- Background (Experience / Education / Certifications / Personal)

**BACKGROUND eyebrow and left-aligned section title**

- Full-bleed carousel (snap, edge peek, nav) with 280×210 cards
- Card titles + short descriptions from experience-training seed data (topicCards)
- Firestore parser updated to read topicCards

**Other**

- Selected Work CTA button colors aligned to site navy