### PR TITLE
Finding nemo/final page improvements

### DIFF
--- a/app/projects/finding-nemo/FindingNemoPage.tsx
+++ b/app/projects/finding-nemo/FindingNemoPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useSetAtom } from "jotai";
 import Box from "@mui/material/Box";
 import List from "@mui/material/List";
@@ -20,7 +20,10 @@ import ProblemDemoPanel from "@/app/projects/finding-nemo/components/ProbleDemoC
 import PanelSection from "@/app/projects/finding-nemo/components/PanelSection";
 import PersonasRow from "@/app/projects/finding-nemo/components/PersonasRow";
 import ProjectHeader from "@/app/projects/finding-nemo/components/ProjectHeader";
+import ProjectMetaBar from "@/app/projects/finding-nemo/components/ProjectMetaBar";
+import RecognitionDialog from "@/app/projects/finding-nemo/components/RecognitionDialog";
 import SectionParagraph from "@/app/projects/finding-nemo/components/SectionParagraph";
+import SolutionOverviewSection from "@/app/projects/finding-nemo/components/SolutionOverviewSection";
 import { interactiveCardHoverSx } from "@/app/projects/finding-nemo/components/interactiveCardStyles";
 import { bodyTypeSx, FINDING_NEMO_HEADLINE_COLOR, titleTypeSx } from "@/app/projects/finding-nemo/typography";
 import {
@@ -35,7 +38,6 @@ import {
   SECTION_GAPS,
   SECTION_TITLE_CONTENT_GAP,
   sectionTitleContentGapMtSx,
-  SOLUTION_OVERVIEW_IMAGE_DISPLAY,
   SYSTEM_WORKFLOW_ILLUSTRATION_DISPLAY,
   CONCEPTUAL_MVP_ARCHITECTURE_ILLUSTRATION_DISPLAY,
 } from "@/app/projects/finding-nemo/layoutConfig";
@@ -52,25 +54,7 @@ import {
   footerState,
 } from "@/components/Footer/FooterState";
 import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
-import ProjectImage from "@/lib/media/ProjectImage";
 import ProjectImageLightbox from "@/lib/media/ProjectImageLightbox";
-
-const solutionOverviewImageSizes = [
-  `(max-width: 767px) ${SOLUTION_OVERVIEW_IMAGE_DISPLAY.mobile.width}px`,
-  `(max-width: 1023px) ${SOLUTION_OVERVIEW_IMAGE_DISPLAY.tablet.width}px`,
-  `${SOLUTION_OVERVIEW_IMAGE_DISPLAY.desktop.width}px`,
-].join(", ");
-
-const solutionOverviewImageBoxSx = {
-  width: `${SOLUTION_OVERVIEW_IMAGE_DISPLAY.mobile.width}px`,
-  maxWidth: "100%",
-  [breakpointMediaQuery.tabletUp]: {
-    width: `${SOLUTION_OVERVIEW_IMAGE_DISPLAY.tablet.width}px`,
-  },
-  [breakpointMediaQuery.desktopUp]: {
-    width: `${SOLUTION_OVERVIEW_IMAGE_DISPLAY.desktop.width}px`,
-  },
-} as const;
 
 const mobileExperienceMockupsRowSx = {
   width: "100%",
@@ -138,7 +122,16 @@ export function FindingNemoPage({
   const setLayoutState = useSetAtom(layoutState);
   const setHeaderState = useSetAtom(headerState);
   const setFooterState = useSetAtom(footerState);
+  const [recognitionOpen, setRecognitionOpen] = useState(false);
   const hasProject = project != null;
+
+  const recognitionDialogTitle = useMemo(() => {
+    if (!project?.projectHeader) return "";
+    const headline = project.projectHeader.awardLines.filter(
+      (line) => !/view recognition/i.test(line),
+    );
+    return `🏆 ${headline.join(" ")}`;
+  }, [project?.projectHeader]);
 
   useEffect(() => {
     setLayoutState({ isFullWidth: true });
@@ -160,10 +153,27 @@ export function FindingNemoPage({
             data={project.projectHeader}
             onReady={onProjectHeaderReady}
           />
+          <ProjectMetaBar
+            items={project.projectMetaBar ?? []}
+            onOpenRecognition={
+              project.projectHeader.recognition
+                ? () => setRecognitionOpen(true)
+                : undefined
+            }
+          />
+          {project.projectHeader.recognition ? (
+            <RecognitionDialog
+              open={recognitionOpen}
+              onClose={() => setRecognitionOpen(false)}
+              title={recognitionDialogTitle}
+              data={project.projectHeader.recognition}
+            />
+          ) : null}
           <Overview data={project.overview} />
           {project.problemDemoPanel ? (
             <ProblemDemoPanel data={project.problemDemoPanel} />
           ) : null}
+          <SolutionOverviewSection data={project.solutionOverview} />
           <MyContributions data={project.myContributions} />
           <DesigningHumanCenteredAiSection data={project.designingHumanCenteredAi} />
           <IdentifyAiOpportunitySection
@@ -209,66 +219,6 @@ export function FindingNemoPage({
                 titleVariant="subtitle"
               />
               <PersonasRow personas={project.personas.items} />
-            </Stack>
-            <Stack
-              spacing={{ xs: 4, md: 6 }}
-              sx={{
-                mt: SECTION_GAPS.mobile,
-                [breakpointMediaQuery.tabletUp]: {
-                  mt: SECTION_GAPS.tablet,
-                },
-                [breakpointMediaQuery.desktopUp]: {
-                  mt: SECTION_GAPS.desktop,
-                },
-              }}
-            >
-              <SectionParagraph
-                title={project.solutionOverview.subtitle}
-                body={project.solutionOverview.paragraphs}
-                titleVariant="subtitle"
-              />
-              <Box
-                sx={{
-                  width: "100%",
-                  display: "flex",
-                  justifyContent: "center",
-                }}
-              >
-                <Stack
-                  alignItems="center"
-                  spacing={{ xs: 2, md: 2.5 }}
-                  sx={solutionOverviewImageBoxSx}
-                >
-                  <Box sx={{ width: "100%" }}>
-                    <ProjectImage
-                      objectPath={project.solutionOverview.image.objectPath}
-                      alt={project.solutionOverview.image.alt}
-                      width={project.solutionOverview.image.width}
-                      height={project.solutionOverview.image.height}
-                      sizes={solutionOverviewImageSizes}
-                      style={{
-                        display: "block",
-                        width: "100%",
-                        height: "auto",
-                      }}
-                    />
-                  </Box>
-                  {project.solutionOverview.image.annotation ? (
-                    <Typography
-                      component="p"
-                      sx={bodyTypeSx("smallCaption", {
-                        fontWeight: 400,
-                        lineHeight: 1.5,
-                        textAlign: "center",
-                        m: 0,
-                        width: "100%",
-                      })}
-                    >
-                      {project.solutionOverview.image.annotation}
-                    </Typography>
-                  ) : null}
-                </Stack>
-              </Box>
             </Stack>
           </FullBleedBand>
           <FullBleedBand backgroundColor={BAND_COLORS.aiTechnologyMvpArchitecture}>

--- a/app/projects/finding-nemo/FindingNemoPage.tsx
+++ b/app/projects/finding-nemo/FindingNemoPage.tsx
@@ -474,7 +474,10 @@ export function FindingNemoPage({
             </Stack>
           </FullBleedBand>
           <FullBleedBand backgroundColor={BAND_COLORS.designDecisionSupportExperience}>
-            <SectionParagraph title={project.mobileExperienceConcepts.title} />
+            <StageSectionHeader
+              sectionLabel={project.mobileExperienceConcepts.sectionLabel}
+              title={project.mobileExperienceConcepts.title}
+            />
             {project.mobileExperienceConcepts.paragraphAfterSubtitle ? (
               <Stack sx={sectionTitleContentGapMtSx}>
                 <SectionParagraph
@@ -496,7 +499,6 @@ export function FindingNemoPage({
               >
                 <PanelSection
                   {...project.mobileExperienceConcepts.conceptEvolutionPanel}
-                  panelBackgroundColor={PANEL_COLORS.default}
                 />
               </Stack>
             ) : null}

--- a/app/projects/finding-nemo/FindingNemoPage.tsx
+++ b/app/projects/finding-nemo/FindingNemoPage.tsx
@@ -8,13 +8,10 @@ import ListItem from "@mui/material/ListItem";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 
-import {
-  PRIMARY_USERS_CARD_HEIGHT_PX,
-  PRIMARY_USERS_CARD_WIDTH_PX,
-} from "@/app/projects/finding-nemo/components/ContentCard";
 import DesigningHumanCenteredAiSection from "@/app/projects/finding-nemo/components/DesigningHumanCenteredAiSection";
 import IdentifyAiOpportunitySection from "@/app/projects/finding-nemo/components/IdentifyAiOpportunitySection";
-import ContentCardsRow from "@/app/projects/finding-nemo/components/ContentCardsRow";
+import StageSectionHeader from "@/app/projects/finding-nemo/components/StageSectionHeader";
+import StageInfoCardsRow from "@/app/projects/finding-nemo/components/StageInfoCardsRow";
 import FullBleedBand from "@/app/projects/finding-nemo/components/FullBleedBand";
 import MobileExperienceMockup from "@/app/projects/finding-nemo/components/MobileExperienceMockup";
 import MyContributions from "@/app/projects/finding-nemo/components/MyContributions";
@@ -34,6 +31,7 @@ import {
   PANEL_COLORS,
   PANEL_SECTION_GAPS,
   PANEL_SHELL_SX,
+  PRIMARY_USERS_CARD,
   SECTION_GAPS,
   sectionTitleContentGapMtSx,
   SOLUTION_OVERVIEW_IMAGE_DISPLAY,
@@ -170,8 +168,56 @@ export function FindingNemoPage({
             businessOpportunities={project.businessOpportunities}
           />
           <FullBleedBand backgroundColor={BAND_COLORS.defineAiSolution}>
-            <Stack spacing={{ xs: 4, md: 6 }}>
-              <SectionParagraph title={project.solutionOverview.title} />
+            <StageSectionHeader
+              sectionLabel={project.solutionOverview.sectionLabel}
+              title={project.solutionOverview.title}
+            />
+            <Stack
+              spacing={{ xs: 4, md: 6 }}
+              sx={sectionTitleContentGapMtSx}
+            >
+              <SectionParagraph
+                title={project.primaryUsers.title}
+                body={project.primaryUsers.paragraphs}
+                titleVariant="subtitle"
+              />
+              <StageInfoCardsRow
+                cards={project.primaryUsers.cards}
+                widthPx={PRIMARY_USERS_CARD.widthPx}
+                centered
+              />
+            </Stack>
+            <Stack
+              spacing={{ xs: 4, md: 6 }}
+              sx={{
+                mt: SECTION_GAPS.mobile,
+                [breakpointMediaQuery.tabletUp]: {
+                  mt: SECTION_GAPS.tablet,
+                },
+                [breakpointMediaQuery.desktopUp]: {
+                  mt: SECTION_GAPS.desktop,
+                },
+              }}
+            >
+              <SectionParagraph
+                title={project.personas.title}
+                body={project.personas.paragraphs}
+                titleVariant="subtitle"
+              />
+              <PersonasRow personas={project.personas.items} />
+            </Stack>
+            <Stack
+              spacing={{ xs: 4, md: 6 }}
+              sx={{
+                mt: SECTION_GAPS.mobile,
+                [breakpointMediaQuery.tabletUp]: {
+                  mt: SECTION_GAPS.tablet,
+                },
+                [breakpointMediaQuery.desktopUp]: {
+                  mt: SECTION_GAPS.desktop,
+                },
+              }}
+            >
               <SectionParagraph
                 title={project.solutionOverview.subtitle}
                 body={project.solutionOverview.paragraphs}
@@ -207,7 +253,6 @@ export function FindingNemoPage({
                     <Typography
                       component="p"
                       sx={bodyTypeSx("smallCaption", {
-                        color: "common.black",
                         fontWeight: 400,
                         lineHeight: 1.5,
                         textAlign: "center",
@@ -220,51 +265,6 @@ export function FindingNemoPage({
                   ) : null}
                 </Stack>
               </Box>
-            </Stack>
-            <Stack
-              spacing={{ xs: 4, md: 6 }}
-              sx={{
-                mt: SECTION_GAPS.mobile,
-                [breakpointMediaQuery.tabletUp]: {
-                  mt: SECTION_GAPS.tablet,
-                },
-                [breakpointMediaQuery.desktopUp]: {
-                  mt: SECTION_GAPS.desktop,
-                },
-              }}
-            >
-              <SectionParagraph
-                title={project.primaryUsers.title}
-                body={project.primaryUsers.paragraphs}
-                titleVariant="subtitle"
-              />
-              <ContentCardsRow
-                cards={project.primaryUsers.cards.map((card) => ({
-                  title: card.title,
-                  description: card.description,
-                  widthPx: PRIMARY_USERS_CARD_WIDTH_PX,
-                  heightPx: PRIMARY_USERS_CARD_HEIGHT_PX,
-                }))}
-              />
-            </Stack>
-            <Stack
-              spacing={{ xs: 4, md: 6 }}
-              sx={{
-                mt: SECTION_GAPS.mobile,
-                [breakpointMediaQuery.tabletUp]: {
-                  mt: SECTION_GAPS.tablet,
-                },
-                [breakpointMediaQuery.desktopUp]: {
-                  mt: SECTION_GAPS.desktop,
-                },
-              }}
-            >
-              <SectionParagraph
-                title={project.personas.title}
-                body={project.personas.paragraphs}
-                titleVariant="subtitle"
-              />
-              <PersonasRow personas={project.personas.items} />
             </Stack>
           </FullBleedBand>
           <FullBleedBand backgroundColor={BAND_COLORS.neutralPanel}>
@@ -310,7 +310,6 @@ export function FindingNemoPage({
                     <Typography
                       component="p"
                       sx={bodyTypeSx("smallCaption", {
-                        color: "common.black",
                         fontWeight: 400,
                         lineHeight: 1.5,
                         textAlign: "center",
@@ -324,7 +323,6 @@ export function FindingNemoPage({
                       <Typography
                         component="p"
                         sx={bodyTypeSx("smallCaption", {
-                          color: "common.black",
                           fontWeight: 400,
                           lineHeight: 1.5,
                           textAlign: "center",
@@ -401,7 +399,6 @@ export function FindingNemoPage({
                     <Typography
                       component="p"
                       sx={bodyTypeSx("smallCaption", {
-                        color: "common.black",
                         fontWeight: 400,
                         lineHeight: 1.5,
                         textAlign: "center",
@@ -418,7 +415,6 @@ export function FindingNemoPage({
                       <Typography
                         component="p"
                         sx={bodyTypeSx("smallCaption", {
-                          color: "common.black",
                           fontWeight: 400,
                           lineHeight: 1.5,
                           textAlign: "center",
@@ -584,7 +580,6 @@ export function FindingNemoPage({
                         sx={{
                           display: "list-item",
                           py: { xs: 1.5, md: 2 },
-                          color: "common.black",
                           "&:first-of-type": { pt: 0 },
                         }}
                       >
@@ -602,7 +597,6 @@ export function FindingNemoPage({
                           <Typography
                             component="p"
                             sx={bodyTypeSx("sectionDescription", {
-                              color: "common.black",
                               fontWeight: 400,
                               lineHeight: 1.5,
                               m: 0,

--- a/app/projects/finding-nemo/FindingNemoPage.tsx
+++ b/app/projects/finding-nemo/FindingNemoPage.tsx
@@ -9,11 +9,13 @@ import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 
 import DesigningHumanCenteredAiSection from "@/app/projects/finding-nemo/components/DesigningHumanCenteredAiSection";
+import ComputerVisionPipelineCard from "@/app/projects/finding-nemo/components/ComputerVisionPipelineCard";
 import IdentifyAiOpportunitySection from "@/app/projects/finding-nemo/components/IdentifyAiOpportunitySection";
 import StageSectionHeader from "@/app/projects/finding-nemo/components/StageSectionHeader";
 import StageInfoCardsRow from "@/app/projects/finding-nemo/components/StageInfoCardsRow";
 import FullBleedBand from "@/app/projects/finding-nemo/components/FullBleedBand";
 import MobileExperienceMockup from "@/app/projects/finding-nemo/components/MobileExperienceMockup";
+import MetadataDrivenArchitectureCard from "@/app/projects/finding-nemo/components/MetadataDrivenArchitectureCard";
 import MyContributions from "@/app/projects/finding-nemo/components/MyContributions";
 import Overview from "@/app/projects/finding-nemo/components/Overview";
 import ProblemDemoPanel from "@/app/projects/finding-nemo/components/ProbleDemoCarousel";
@@ -28,17 +30,16 @@ import { interactiveCardHoverSx } from "@/app/projects/finding-nemo/components/i
 import { bodyTypeSx, FINDING_NEMO_HEADLINE_COLOR, titleTypeSx } from "@/app/projects/finding-nemo/typography";
 import {
   BAND_COLORS,
+  IDENTIFY_AI_OPPORTUNITY_CARD,
   LAYOUT_DIMENSIONS,
   MOBILE_EXPERIENCE_MOCKUP_GAPS,
   PANEL_CONTENT_MAX_WIDTH_PX,
   PANEL_COLORS,
   PANEL_SECTION_GAPS,
   PANEL_SHELL_SX,
-  PRIMARY_USERS_CARD,
   SECTION_GAPS,
   SECTION_TITLE_CONTENT_GAP,
   sectionTitleContentGapMtSx,
-  SYSTEM_WORKFLOW_ILLUSTRATION_DISPLAY,
   CONCEPTUAL_MVP_ARCHITECTURE_ILLUSTRATION_DISPLAY,
 } from "@/app/projects/finding-nemo/layoutConfig";
 import { FINDING_NEMO_HEADER_THEME } from "@/app/projects/finding-nemo/headerTheme";
@@ -60,34 +61,31 @@ const mobileExperienceMockupsRowSx = {
   width: "100%",
   maxWidth: `${PANEL_CONTENT_MAX_WIDTH_PX}px`,
   mx: "auto",
-  display: "flex",
-  flexDirection: { xs: "column", md: "row" },
-  flexWrap: "wrap",
-  justifyContent: "center",
-  alignItems: { xs: "center", md: "flex-start" },
-  gap: MOBILE_EXPERIENCE_MOCKUP_GAPS.mobile,
+  display: "grid",
+  gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+  alignItems: "start",
+  justifyItems: "center",
+  columnGap: "12px",
+  rowGap: MOBILE_EXPERIENCE_MOCKUP_GAPS.mobile,
   [breakpointMediaQuery.tabletUp]: {
     gap: MOBILE_EXPERIENCE_MOCKUP_GAPS.tablet,
   },
   [breakpointMediaQuery.desktopUp]: {
+    gridTemplateColumns: "repeat(4, minmax(0, 1fr))",
     gap: MOBILE_EXPERIENCE_MOCKUP_GAPS.desktop,
   },
 } as const;
 
-const SYSTEM_WORKFLOW_LIGHTBOX_ID = "finding-nemo-system-workflow";
 const ARCHITECTURE_TECHNOLOGY_LIGHTBOX_ID =
   "finding-nemo-architecture-technology";
 
-const systemWorkflowImageBoxSx = {
-  width: `${SYSTEM_WORKFLOW_ILLUSTRATION_DISPLAY.mobile.width}px`,
-  maxWidth: "100%",
-  [breakpointMediaQuery.tabletUp]: {
-    width: `${SYSTEM_WORKFLOW_ILLUSTRATION_DISPLAY.tablet.width}px`,
-  },
-  [breakpointMediaQuery.desktopUp]: {
-    width: `${SYSTEM_WORKFLOW_ILLUSTRATION_DISPLAY.desktop.width}px`,
-  },
+const ARCHITECTURAL_PRINCIPLE_CARD_WIDTH = {
+  mobile: 360,
+  tablet: 360,
+  desktop: 360,
 } as const;
+
+const ARCHITECTURAL_PRINCIPLE_WIDE_DESKTOP_WIDTH_PX = 257;
 
 const conceptualMvpArchitectureImageBoxSx = {
   width: `${CONCEPTUAL_MVP_ARCHITECTURE_ILLUSTRATION_DISPLAY.mobile.width}px`,
@@ -186,20 +184,116 @@ export function FindingNemoPage({
               sectionLabel={project.solutionOverview.sectionLabel}
               title={project.solutionOverview.title}
             />
+            {project.mobileExperienceConcepts.paragraphAfterSubtitle ? (
+              <Stack sx={sectionTitleContentGapMtSx}>
+                <SectionParagraph
+                  body={[
+                    project.mobileExperienceConcepts.paragraphAfterSubtitle,
+                    ...project.primaryUsers.paragraphs,
+                  ]}
+                />
+              </Stack>
+            ) : null}
+            {project.mobileExperienceConcepts.conceptEvolutionPanel ? (
+              <Stack
+                spacing={1}
+                sx={{
+                  mt: SECTION_GAPS.mobile,
+                  [breakpointMediaQuery.tabletUp]: {
+                    mt: SECTION_GAPS.tablet,
+                  },
+                  [breakpointMediaQuery.desktopUp]: {
+                    mt: SECTION_GAPS.desktop,
+                  },
+                }}
+              >
+                {project.mobileExperienceConcepts.conceptEvolutionLabel ? (
+                  <Typography
+                    component="p"
+                    sx={titleTypeSx("smallCaption", {
+                      color: "#0B6E9F",
+                      fontWeight: 700,
+                      lineHeight: 1.2,
+                      letterSpacing: "0.18em",
+                      textTransform: "uppercase",
+                      m: 0,
+                    })}
+                  >
+                    {project.mobileExperienceConcepts.conceptEvolutionLabel}
+                  </Typography>
+                ) : null}
+                <PanelSection
+                  {...project.mobileExperienceConcepts.conceptEvolutionPanel}
+                />
+              </Stack>
+            ) : null}
+            {project.mobileExperienceConcepts.corePrinciplesPanel ? (
+              <Stack
+                spacing={1}
+                sx={{
+                  mt: SECTION_GAPS.mobile,
+                  [breakpointMediaQuery.tabletUp]: {
+                    mt: SECTION_GAPS.tablet,
+                  },
+                  [breakpointMediaQuery.desktopUp]: {
+                    mt: SECTION_GAPS.desktop,
+                  },
+                }}
+              >
+                {project.mobileExperienceConcepts.corePrinciplesLabel ? (
+                  <Typography
+                    component="p"
+                    sx={titleTypeSx("smallCaption", {
+                      color: "#0B6E9F",
+                      fontWeight: 700,
+                      lineHeight: 1.2,
+                      letterSpacing: "0.18em",
+                      textTransform: "uppercase",
+                      m: 0,
+                    })}
+                  >
+                    {project.mobileExperienceConcepts.corePrinciplesLabel}
+                  </Typography>
+                ) : null}
+                <PanelSection
+                  {...project.mobileExperienceConcepts.corePrinciplesPanel}
+                  panelBackgroundColor={PANEL_COLORS.default}
+                />
+              </Stack>
+            ) : null}
             <Stack
               spacing={{ xs: 4, md: 6 }}
-              sx={sectionTitleContentGapMtSx}
+              sx={{
+                mt: SECTION_TITLE_CONTENT_GAP.mobile,
+                [breakpointMediaQuery.tabletUp]: {
+                  mt: SECTION_TITLE_CONTENT_GAP.tablet,
+                },
+                [breakpointMediaQuery.desktopUp]: {
+                  mt: SECTION_TITLE_CONTENT_GAP.desktop,
+                },
+              }}
             >
-              <SectionParagraph
-                title={project.primaryUsers.title}
-                body={project.primaryUsers.paragraphs}
-                titleVariant="subtitle"
-              />
-              <StageInfoCardsRow
-                cards={project.primaryUsers.cards}
-                widthPx={PRIMARY_USERS_CARD.widthPx}
-                centered
-              />
+              <Stack spacing={1}>
+                <Typography
+                  component="p"
+                  sx={titleTypeSx("smallCaption", {
+                    color: "#0B6E9F",
+                    fontWeight: 700,
+                    lineHeight: 1.2,
+                    letterSpacing: "0.18em",
+                    textTransform: "uppercase",
+                    m: 0,
+                  })}
+                >
+                  Who It Serves
+                </Typography>
+                <SectionParagraph
+                  title={project.personas.title}
+                  body={project.personas.paragraphs}
+                  titleVariant="subtitle"
+                />
+              </Stack>
+              <PersonasRow personas={project.personas.items} />
             </Stack>
             <Stack
               spacing={{ xs: 4, md: 6 }}
@@ -213,12 +307,62 @@ export function FindingNemoPage({
                 },
               }}
             >
-              <SectionParagraph
-                title={project.personas.title}
-                body={project.personas.paragraphs}
-                titleVariant="subtitle"
-              />
-              <PersonasRow personas={project.personas.items} />
+              <Stack spacing={{ xs: 2, md: 2.5 }}>
+                <Stack spacing={1}>
+                  <Typography
+                    component="p"
+                    sx={titleTypeSx("smallCaption", {
+                      color: "#0B6E9F",
+                      fontWeight: 700,
+                      lineHeight: 1.2,
+                      letterSpacing: "0.18em",
+                      textTransform: "uppercase",
+                      m: 0,
+                    })}
+                  >
+                    {project.mobileExperienceConcepts.subtitle}
+                  </Typography>
+                  <Typography
+                    component="h3"
+                    sx={titleTypeSx("sectionSubtitle", {
+                      color: FINDING_NEMO_HEADLINE_COLOR,
+                      fontWeight: 700,
+                      lineHeight: 1.2,
+                      m: 0,
+                    })}
+                  >
+                    {project.mobileExperienceConcepts.experienceTitle}
+                  </Typography>
+                </Stack>
+                <SectionParagraph
+                  body={project.mobileExperienceConcepts.paragraphs}
+                />
+              </Stack>
+              <Stack spacing={{ xs: 4, md: 6 }} sx={{ width: "100%" }}>
+                {project.mobileExperienceConcepts.mockups[0] ? (
+                  <Box
+                    sx={{
+                      width: "100%",
+                      display: "flex",
+                      justifyContent: "center",
+                    }}
+                  >
+                    <MobileExperienceMockup
+                      {...project.mobileExperienceConcepts.mockups[0]}
+                      variant="notification"
+                    />
+                  </Box>
+                ) : null}
+                {project.mobileExperienceConcepts.mockups.length > 1 ? (
+                  <Box sx={mobileExperienceMockupsRowSx}>
+                    {project.mobileExperienceConcepts.mockups
+                      .slice(1)
+                      .map((mockup) => (
+                        <MobileExperienceMockup key={mockup.title} {...mockup} />
+                      ))}
+                  </Box>
+                ) : null}
+              </Stack>
             </Stack>
           </FullBleedBand>
           <FullBleedBand backgroundColor={BAND_COLORS.aiTechnologyMvpArchitecture}>
@@ -239,93 +383,74 @@ export function FindingNemoPage({
                   title={project.systemWorkflowArchitecture.title}
                 />
                 <SectionParagraph
-                  title={project.systemWorkflowArchitecture.subtitle}
                   body={project.systemWorkflowArchitecture.paragraphs}
+                />
+              </Stack>
+              <Stack spacing={1}>
+                {project.systemWorkflowArchitecture.coreMvpComponents.eyebrow ? (
+                  <Typography
+                    component="p"
+                    sx={titleTypeSx("smallCaption", {
+                      color: "#0B6E9F",
+                      fontWeight: 700,
+                      lineHeight: 1.2,
+                      letterSpacing: "0.18em",
+                      textTransform: "uppercase",
+                      m: 0,
+                    })}
+                  >
+                    {
+                      project.systemWorkflowArchitecture.coreMvpComponents
+                        .eyebrow
+                    }
+                  </Typography>
+                ) : null}
+                <PanelSection
+                  type="principles-image"
+                  title={
+                    project.systemWorkflowArchitecture.coreMvpComponents.title
+                  }
+                  principles={
+                    project.systemWorkflowArchitecture.coreMvpComponents
+                      .principles
+                  }
+                  image={
+                    project.systemWorkflowArchitecture.coreMvpComponents.image
+                  }
+                />
+              </Stack>
+              <Stack spacing={1}>
+                {project.systemWorkflowArchitecture.conceptualMvpArchitecture
+                  .eyebrow ? (
+                  <Typography
+                    component="p"
+                    sx={titleTypeSx("smallCaption", {
+                      color: "#0B6E9F",
+                      fontWeight: 700,
+                      lineHeight: 1.2,
+                      letterSpacing: "0.18em",
+                      textTransform: "uppercase",
+                      m: 0,
+                    })}
+                  >
+                    {
+                      project.systemWorkflowArchitecture
+                        .conceptualMvpArchitecture.eyebrow
+                    }
+                  </Typography>
+                ) : null}
+                <SectionParagraph
+                  title={
+                    project.systemWorkflowArchitecture.conceptualMvpArchitecture
+                      .title
+                  }
+                  body={
+                    project.systemWorkflowArchitecture.conceptualMvpArchitecture
+                      .paragraphs
+                  }
                   titleVariant="subtitle"
                 />
               </Stack>
-              <Box
-                sx={{
-                  width: "100%",
-                  display: "flex",
-                  justifyContent: "center",
-                }}
-              >
-                <Stack
-                  alignItems="center"
-                  spacing={{ xs: 2, md: 2.5 }}
-                  sx={systemWorkflowImageBoxSx}
-                >
-                  <ProjectImageLightbox
-                    objectPath={
-                      project.systemWorkflowArchitecture.illustration.objectPath
-                    }
-                    alt={project.systemWorkflowArchitecture.illustration.alt}
-                    lightboxId={SYSTEM_WORKFLOW_LIGHTBOX_ID}
-                    width={
-                      project.systemWorkflowArchitecture.illustration.width
-                    }
-                    height={
-                      project.systemWorkflowArchitecture.illustration.height
-                    }
-                    style={{
-                      display: "block",
-                      width: "100%",
-                      height: "auto",
-                      maxWidth: "100%",
-                    }}
-                  />
-                  <Stack alignItems="center" spacing="6px" sx={{ width: "100%" }}>
-                    <Typography
-                      component="p"
-                      sx={bodyTypeSx("smallCaption", {
-                        fontWeight: 400,
-                        lineHeight: 1.5,
-                        textAlign: "center",
-                        m: 0,
-                      })}
-                    >
-                      {project.systemWorkflowArchitecture.illustration.annotation}
-                    </Typography>
-                    {project.systemWorkflowArchitecture.illustration
-                      .annotationInstruction ? (
-                      <Typography
-                        component="p"
-                        sx={bodyTypeSx("smallCaption", {
-                          fontWeight: 400,
-                          lineHeight: 1.5,
-                          textAlign: "center",
-                          m: 0,
-                          opacity: 0.75,
-                        })}
-                      >
-                        {
-                          project.systemWorkflowArchitecture.illustration
-                            .annotationInstruction
-                        }
-                      </Typography>
-                    ) : null}
-                  </Stack>
-                </Stack>
-              </Box>
-              <PanelSection
-                type="principles-image"
-                title={project.systemWorkflowArchitecture.coreMvpComponents.title}
-                principles={
-                  project.systemWorkflowArchitecture.coreMvpComponents.principles
-                }
-                image={project.systemWorkflowArchitecture.coreMvpComponents.image}
-              />
-              <SectionParagraph
-                title={
-                  project.systemWorkflowArchitecture.conceptualMvpArchitecture.title
-                }
-                body={
-                  project.systemWorkflowArchitecture.conceptualMvpArchitecture
-                    .paragraphs
-                }
-                titleVariant="subtitle"
-              />
               <Box
                 sx={{
                   width: "100%",
@@ -419,10 +544,30 @@ export function FindingNemoPage({
                 }
               />
               {project.systemWorkflowArchitecture.definingSuccessPanel ? (
-                <PanelSection
-                  {...project.systemWorkflowArchitecture.definingSuccessPanel}
-                  panelBackgroundColor="#FFFFFF"
-                />
+                <Stack spacing={1}>
+                  {project.systemWorkflowArchitecture.definingSuccessEyebrow ? (
+                    <Typography
+                      component="p"
+                      sx={titleTypeSx("smallCaption", {
+                        color: "#0B6E9F",
+                        fontWeight: 700,
+                        lineHeight: 1.2,
+                        letterSpacing: "0.18em",
+                        textTransform: "uppercase",
+                        m: 0,
+                      })}
+                    >
+                      {
+                        project.systemWorkflowArchitecture
+                          .definingSuccessEyebrow
+                      }
+                    </Typography>
+                  ) : null}
+                  <PanelSection
+                    {...project.systemWorkflowArchitecture.definingSuccessPanel}
+                    panelBackgroundColor="#FFFFFF"
+                  />
+                </Stack>
               ) : null}
             </Stack>
           </FullBleedBand>
@@ -430,92 +575,243 @@ export function FindingNemoPage({
             <StageSectionHeader
               sectionLabel={project.mobileExperienceConcepts.sectionLabel}
               title={project.mobileExperienceConcepts.title}
+              paragraphs={project.mobileExperienceConcepts.stageParagraphs}
             />
-            {project.mobileExperienceConcepts.paragraphAfterSubtitle ? (
-              <Stack sx={sectionTitleContentGapMtSx}>
-                <SectionParagraph
-                  body={project.mobileExperienceConcepts.paragraphAfterSubtitle}
-                />
-              </Stack>
-            ) : null}
-            {project.mobileExperienceConcepts.conceptEvolutionPanel ? (
-              <Stack
-                sx={{
-                  mt: SECTION_GAPS.mobile,
-                  [breakpointMediaQuery.tabletUp]: {
-                    mt: SECTION_GAPS.tablet,
-                  },
-                  [breakpointMediaQuery.desktopUp]: {
-                    mt: SECTION_GAPS.desktop,
-                  },
-                }}
-              >
-                <PanelSection
-                  {...project.mobileExperienceConcepts.conceptEvolutionPanel}
-                />
-              </Stack>
-            ) : null}
-            {project.mobileExperienceConcepts.corePrinciplesPanel ? (
-              <Stack
-                sx={{
-                  mt: SECTION_GAPS.mobile,
-                  [breakpointMediaQuery.tabletUp]: {
-                    mt: SECTION_GAPS.tablet,
-                  },
-                  [breakpointMediaQuery.desktopUp]: {
-                    mt: SECTION_GAPS.desktop,
-                  },
-                }}
-              >
-                <PanelSection
-                  {...project.mobileExperienceConcepts.corePrinciplesPanel}
-                  panelBackgroundColor={PANEL_COLORS.default}
-                />
-              </Stack>
-            ) : null}
-            <Stack
-              spacing={{ xs: 4, md: 6 }}
-              sx={{
-                mt: SECTION_GAPS.mobile,
-                [breakpointMediaQuery.tabletUp]: {
-                  mt: SECTION_GAPS.tablet,
-                },
-                [breakpointMediaQuery.desktopUp]: {
-                  mt: SECTION_GAPS.desktop,
-                },
-              }}
-            >
-              <SectionParagraph
-                title={project.mobileExperienceConcepts.subtitle}
-                body={project.mobileExperienceConcepts.paragraphs}
-                titleVariant="subtitle"
+            <Stack sx={sectionTitleContentGapMtSx}>
+              <ComputerVisionPipelineCard
+                data={project.systemWorkflowArchitecture}
               />
-              <Stack spacing={{ xs: 4, md: 6 }} sx={{ width: "100%" }}>
-                {project.mobileExperienceConcepts.mockups[0] ? (
-                  <Box
-                    sx={{
-                      width: "100%",
-                      display: "flex",
-                      justifyContent: "center",
-                    }}
-                  >
-                    <MobileExperienceMockup
-                      {...project.mobileExperienceConcepts.mockups[0]}
-                      variant="notification"
-                    />
-                  </Box>
-                ) : null}
-                {project.mobileExperienceConcepts.mockups.length > 1 ? (
-                  <Box sx={mobileExperienceMockupsRowSx}>
-                    {project.mobileExperienceConcepts.mockups
-                      .slice(1)
-                      .map((mockup) => (
-                        <MobileExperienceMockup key={mockup.title} {...mockup} />
-                      ))}
-                  </Box>
-                ) : null}
-              </Stack>
             </Stack>
+            {project.mobileExperienceConcepts.architecturalPrinciples ? (
+              <Stack
+                spacing={{ xs: 4, md: 6 }}
+                sx={{
+                  mt: SECTION_GAPS.mobile,
+                  [breakpointMediaQuery.tabletUp]: {
+                    mt: SECTION_GAPS.tablet,
+                  },
+                  [breakpointMediaQuery.desktopUp]: {
+                    mt: SECTION_GAPS.desktop,
+                  },
+                }}
+              >
+                <Stack spacing={1}>
+                  {project.mobileExperienceConcepts.architecturalPrinciples
+                    .eyebrow ? (
+                    <Typography
+                      component="p"
+                      sx={titleTypeSx("smallCaption", {
+                        color: "#0B6E9F",
+                        fontWeight: 700,
+                        lineHeight: 1.2,
+                        letterSpacing: "0.18em",
+                        textTransform: "uppercase",
+                        m: 0,
+                      })}
+                    >
+                      {
+                        project.mobileExperienceConcepts.architecturalPrinciples
+                          .eyebrow
+                      }
+                    </Typography>
+                  ) : null}
+                  <SectionParagraph
+                    title={
+                      project.mobileExperienceConcepts.architecturalPrinciples
+                        .title
+                    }
+                    body={
+                      project.mobileExperienceConcepts.architecturalPrinciples
+                        .intro
+                    }
+                    titleVariant="subtitle"
+                  />
+                </Stack>
+                <StageInfoCardsRow
+                  cards={project.mobileExperienceConcepts.architecturalPrinciples.principles.map(
+                    (principle) => ({
+                      title: principle.subtitle,
+                      description: principle.description,
+                    }),
+                  )}
+                  titleColor={
+                    IDENTIFY_AI_OPPORTUNITY_CARD.opportunityTitleColor
+                  }
+                  widthPx={ARCHITECTURAL_PRINCIPLE_CARD_WIDTH}
+                  centered
+                  titleMinLines={2}
+                  sx={{
+                    [breakpointMediaQuery.tabletUp]: {
+                      display: "grid",
+                      gridTemplateColumns: `repeat(2, minmax(0, ${ARCHITECTURAL_PRINCIPLE_CARD_WIDTH.tablet}px))`,
+                    },
+                    [breakpointMediaQuery.desktopUp]: {
+                      gridTemplateColumns: `repeat(2, ${ARCHITECTURAL_PRINCIPLE_CARD_WIDTH.desktop}px)`,
+                    },
+                    "@media (min-width: 1260px)": {
+                      gridTemplateColumns: `repeat(4, ${ARCHITECTURAL_PRINCIPLE_WIDE_DESKTOP_WIDTH_PX}px)`,
+                    },
+                  }}
+                />
+              </Stack>
+            ) : null}
+            {project.mobileExperienceConcepts.businessRuleEvaluation ? (
+              <Stack
+                sx={{
+                  mt: SECTION_GAPS.mobile,
+                  [breakpointMediaQuery.tabletUp]: {
+                    mt: SECTION_GAPS.tablet,
+                  },
+                  [breakpointMediaQuery.desktopUp]: {
+                    mt: SECTION_GAPS.desktop,
+                  },
+                }}
+              >
+                <Stack spacing={1}>
+                  {project.mobileExperienceConcepts.businessRuleEvaluation
+                    .eyebrow ? (
+                    <Typography
+                      component="p"
+                      sx={titleTypeSx("smallCaption", {
+                        color: "#0B6E9F",
+                        fontWeight: 700,
+                        lineHeight: 1.2,
+                        letterSpacing: "0.18em",
+                        textTransform: "uppercase",
+                        m: 0,
+                      })}
+                    >
+                      {
+                        project.mobileExperienceConcepts.businessRuleEvaluation
+                          .eyebrow
+                      }
+                    </Typography>
+                  ) : null}
+                  <SectionParagraph
+                    title={
+                      project.mobileExperienceConcepts.businessRuleEvaluation
+                        .title
+                    }
+                    body={
+                      project.mobileExperienceConcepts.businessRuleEvaluation
+                        .paragraphs
+                    }
+                    titleVariant="subtitle"
+                  />
+                </Stack>
+              </Stack>
+            ) : null}
+            {project.mobileExperienceConcepts.metadataDrivenArchitecture ? (
+              <Stack
+                sx={{
+                  mt: SECTION_GAPS.mobile,
+                  [breakpointMediaQuery.tabletUp]: {
+                    mt: SECTION_GAPS.tablet,
+                  },
+                  [breakpointMediaQuery.desktopUp]: {
+                    mt: SECTION_GAPS.desktop,
+                  },
+                }}
+              >
+                <MetadataDrivenArchitectureCard
+                  data={
+                    project.mobileExperienceConcepts.metadataDrivenArchitecture
+                  }
+                />
+              </Stack>
+            ) : null}
+            {project.mobileExperienceConcepts.eventDrivenOperationalDashboard ? (
+              <Stack
+                sx={{
+                  mt: SECTION_GAPS.mobile,
+                  [breakpointMediaQuery.tabletUp]: {
+                    mt: SECTION_GAPS.tablet,
+                  },
+                  [breakpointMediaQuery.desktopUp]: {
+                    mt: SECTION_GAPS.desktop,
+                  },
+                }}
+              >
+                <Stack spacing={1}>
+                  {project.mobileExperienceConcepts
+                    .eventDrivenOperationalDashboard.eyebrow ? (
+                    <Typography
+                      component="p"
+                      sx={titleTypeSx("smallCaption", {
+                        color: "#0B6E9F",
+                        fontWeight: 700,
+                        lineHeight: 1.2,
+                        letterSpacing: "0.18em",
+                        textTransform: "uppercase",
+                        m: 0,
+                      })}
+                    >
+                      {
+                        project.mobileExperienceConcepts
+                          .eventDrivenOperationalDashboard.eyebrow
+                      }
+                    </Typography>
+                  ) : null}
+                  <SectionParagraph
+                    title={
+                      project.mobileExperienceConcepts
+                        .eventDrivenOperationalDashboard.title
+                    }
+                    body={
+                      project.mobileExperienceConcepts
+                        .eventDrivenOperationalDashboard.paragraphs
+                    }
+                    titleVariant="subtitle"
+                  />
+                </Stack>
+              </Stack>
+            ) : null}
+            {project.mobileExperienceConcepts.extendingTheExperience ? (
+              <Stack
+                sx={{
+                  mt: SECTION_GAPS.mobile,
+                  [breakpointMediaQuery.tabletUp]: {
+                    mt: SECTION_GAPS.tablet,
+                  },
+                  [breakpointMediaQuery.desktopUp]: {
+                    mt: SECTION_GAPS.desktop,
+                  },
+                }}
+              >
+                <Stack spacing={1}>
+                  {project.mobileExperienceConcepts.extendingTheExperience
+                    .eyebrow ? (
+                    <Typography
+                      component="p"
+                      sx={titleTypeSx("smallCaption", {
+                        color: "#0B6E9F",
+                        fontWeight: 700,
+                        lineHeight: 1.2,
+                        letterSpacing: "0.18em",
+                        textTransform: "uppercase",
+                        m: 0,
+                      })}
+                    >
+                      {
+                        project.mobileExperienceConcepts.extendingTheExperience
+                          .eyebrow
+                      }
+                    </Typography>
+                  ) : null}
+                  <SectionParagraph
+                    title={
+                      project.mobileExperienceConcepts.extendingTheExperience
+                        .title
+                    }
+                    body={
+                      project.mobileExperienceConcepts.extendingTheExperience
+                        .paragraphs
+                    }
+                    titleVariant="subtitle"
+                  />
+                </Stack>
+              </Stack>
+            ) : null}
           </FullBleedBand>
           <FullBleedBand backgroundColor={BAND_COLORS.expectedImpactAndReflections}>
             <SectionParagraph title={project.expectedImpact.title} />

--- a/app/projects/finding-nemo/FindingNemoPage.tsx
+++ b/app/projects/finding-nemo/FindingNemoPage.tsx
@@ -21,18 +21,19 @@ import PanelSection from "@/app/projects/finding-nemo/components/PanelSection";
 import PersonasRow from "@/app/projects/finding-nemo/components/PersonasRow";
 import ProjectHeader from "@/app/projects/finding-nemo/components/ProjectHeader";
 import SectionParagraph from "@/app/projects/finding-nemo/components/SectionParagraph";
-import { bodyTypeSx, titleTypeSx } from "@/app/projects/finding-nemo/typography";
+import { interactiveCardHoverSx } from "@/app/projects/finding-nemo/components/interactiveCardStyles";
+import { bodyTypeSx, FINDING_NEMO_HEADLINE_COLOR, titleTypeSx } from "@/app/projects/finding-nemo/typography";
 import {
   BAND_COLORS,
   LAYOUT_DIMENSIONS,
   MOBILE_EXPERIENCE_MOCKUP_GAPS,
-  MY_CONTRIBUTIONS_CARD,
   PANEL_CONTENT_MAX_WIDTH_PX,
   PANEL_COLORS,
   PANEL_SECTION_GAPS,
   PANEL_SHELL_SX,
   PRIMARY_USERS_CARD,
   SECTION_GAPS,
+  SECTION_TITLE_CONTENT_GAP,
   sectionTitleContentGapMtSx,
   SOLUTION_OVERVIEW_IMAGE_DISPLAY,
   SYSTEM_WORKFLOW_ILLUSTRATION_DISPLAY,
@@ -267,14 +268,29 @@ export function FindingNemoPage({
               </Box>
             </Stack>
           </FullBleedBand>
-          <FullBleedBand backgroundColor={BAND_COLORS.neutralPanel}>
+          <FullBleedBand backgroundColor={BAND_COLORS.aiTechnologyMvpArchitecture}>
             <Stack sx={panelSectionStackSx}>
-              <SectionParagraph title={project.systemWorkflowArchitecture.title} />
-              <SectionParagraph
-                title={project.systemWorkflowArchitecture.subtitle}
-                body={project.systemWorkflowArchitecture.paragraphs}
-                titleVariant="subtitle"
-              />
+              <Stack
+                sx={{
+                  gap: SECTION_TITLE_CONTENT_GAP.mobile,
+                  [breakpointMediaQuery.tabletUp]: {
+                    gap: SECTION_TITLE_CONTENT_GAP.tablet,
+                  },
+                  [breakpointMediaQuery.desktopUp]: {
+                    gap: SECTION_TITLE_CONTENT_GAP.desktop,
+                  },
+                }}
+              >
+                <StageSectionHeader
+                  sectionLabel={project.systemWorkflowArchitecture.sectionLabel}
+                  title={project.systemWorkflowArchitecture.title}
+                />
+                <SectionParagraph
+                  title={project.systemWorkflowArchitecture.subtitle}
+                  body={project.systemWorkflowArchitecture.paragraphs}
+                  titleVariant="subtitle"
+                />
+              </Stack>
               <Box
                 sx={{
                   width: "100%",
@@ -346,7 +362,6 @@ export function FindingNemoPage({
                   project.systemWorkflowArchitecture.coreMvpComponents.principles
                 }
                 image={project.systemWorkflowArchitecture.coreMvpComponents.image}
-                panelBackgroundColor={MY_CONTRIBUTIONS_CARD.background}
               />
               <SectionParagraph
                 title={
@@ -370,31 +385,43 @@ export function FindingNemoPage({
                   spacing={{ xs: 2, md: 2.5 }}
                   sx={conceptualMvpArchitectureImageBoxSx}
                 >
-                  <ProjectImageLightbox
-                    objectPath={
-                      project.systemWorkflowArchitecture.conceptualMvpArchitecture
-                        .illustration.objectPath
-                    }
-                    alt={
-                      project.systemWorkflowArchitecture.conceptualMvpArchitecture
-                        .illustration.alt
-                    }
-                    lightboxId={ARCHITECTURE_TECHNOLOGY_LIGHTBOX_ID}
-                    width={
-                      project.systemWorkflowArchitecture.conceptualMvpArchitecture
-                        .illustration.width
-                    }
-                    height={
-                      project.systemWorkflowArchitecture.conceptualMvpArchitecture
-                        .illustration.height
-                    }
-                    style={{
-                      display: "block",
+                  <Box
+                    sx={{
                       width: "100%",
-                      height: "auto",
-                      maxWidth: "100%",
+                      ...interactiveCardHoverSx,
+                      "&:hover": {
+                        ...interactiveCardHoverSx["&:hover"],
+                        bgcolor: "transparent",
+                        backgroundColor: "transparent",
+                      },
                     }}
-                  />
+                  >
+                    <ProjectImageLightbox
+                      objectPath={
+                        project.systemWorkflowArchitecture.conceptualMvpArchitecture
+                          .illustration.objectPath
+                      }
+                      alt={
+                        project.systemWorkflowArchitecture.conceptualMvpArchitecture
+                          .illustration.alt
+                      }
+                      lightboxId={ARCHITECTURE_TECHNOLOGY_LIGHTBOX_ID}
+                      width={
+                        project.systemWorkflowArchitecture.conceptualMvpArchitecture
+                          .illustration.width
+                      }
+                      height={
+                        project.systemWorkflowArchitecture.conceptualMvpArchitecture
+                          .illustration.height
+                      }
+                      style={{
+                        display: "block",
+                        width: "100%",
+                        height: "auto",
+                        maxWidth: "100%",
+                      }}
+                    />
+                  </Box>
                   <Stack alignItems="center" spacing="6px" sx={{ width: "100%" }}>
                     <Typography
                       component="p"
@@ -441,7 +468,7 @@ export function FindingNemoPage({
               {project.systemWorkflowArchitecture.definingSuccessPanel ? (
                 <PanelSection
                   {...project.systemWorkflowArchitecture.definingSuccessPanel}
-                  panelBackgroundColor={MY_CONTRIBUTIONS_CARD.background}
+                  panelBackgroundColor="#FFFFFF"
                 />
               ) : null}
             </Stack>
@@ -589,7 +616,7 @@ export function FindingNemoPage({
                             sx={titleTypeSx("personaSectionTitle", {
                               fontWeight: 700,
                               lineHeight: 1.2,
-                              color: "common.black",
+                              color: FINDING_NEMO_HEADLINE_COLOR,
                             })}
                           >
                             {item.subtitle}

--- a/app/projects/finding-nemo/FindingNemoPage.tsx
+++ b/app/projects/finding-nemo/FindingNemoPage.tsx
@@ -9,11 +9,11 @@ import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 
 import {
-  CHALLENGES_CARD_HEIGHT_PX,
   PRIMARY_USERS_CARD_HEIGHT_PX,
   PRIMARY_USERS_CARD_WIDTH_PX,
 } from "@/app/projects/finding-nemo/components/ContentCard";
 import DesigningHumanCenteredAiSection from "@/app/projects/finding-nemo/components/DesigningHumanCenteredAiSection";
+import IdentifyAiOpportunitySection from "@/app/projects/finding-nemo/components/IdentifyAiOpportunitySection";
 import ContentCardsRow from "@/app/projects/finding-nemo/components/ContentCardsRow";
 import FullBleedBand from "@/app/projects/finding-nemo/components/FullBleedBand";
 import MobileExperienceMockup from "@/app/projects/finding-nemo/components/MobileExperienceMockup";
@@ -164,52 +164,11 @@ export function FindingNemoPage({
           ) : null}
           <MyContributions data={project.myContributions} />
           <DesigningHumanCenteredAiSection data={project.designingHumanCenteredAi} />
-          <FullBleedBand backgroundColor={BAND_COLORS.identifyAiOpportunity}>
-            <SectionParagraph title={project.problemSpaceFraming.title} />
-            <Stack
-              spacing={{ xs: 4, md: 6 }}
-              sx={sectionTitleContentGapMtSx}
-            >
-              <SectionParagraph
-                title={project.challenges.title}
-                body={project.challenges.paragraphs}
-                titleVariant="subtitle"
-              />
-              <ContentCardsRow
-                cardBackgroundColor={MY_CONTRIBUTIONS_CARD.background}
-                cards={project.challenges.cards.map((card) => ({
-                  title: card.title,
-                  description: card.description,
-                  heightPx: CHALLENGES_CARD_HEIGHT_PX,
-                }))}
-              />
-            </Stack>
-            <Stack
-              spacing={{ xs: 4, md: 6 }}
-              sx={{
-                mt: SECTION_GAPS.mobile,
-                [breakpointMediaQuery.tabletUp]: {
-                  mt: SECTION_GAPS.tablet,
-                },
-                [breakpointMediaQuery.desktopUp]: {
-                  mt: SECTION_GAPS.desktop,
-                },
-              }}
-            >
-              <SectionParagraph
-                title={project.businessOpportunities.title}
-                body={project.businessOpportunities.paragraphs}
-                titleVariant="subtitle"
-              />
-              <ContentCardsRow
-                cardBackgroundColor={MY_CONTRIBUTIONS_CARD.background}
-                cards={project.businessOpportunities.cards.map((card) => ({
-                  title: card.title,
-                  description: card.description,
-                }))}
-              />
-            </Stack>
-          </FullBleedBand>
+          <IdentifyAiOpportunitySection
+            framing={project.problemSpaceFraming}
+            challenges={project.challenges}
+            businessOpportunities={project.businessOpportunities}
+          />
           <FullBleedBand backgroundColor={BAND_COLORS.defineAiSolution}>
             <Stack spacing={{ xs: 4, md: 6 }}>
               <SectionParagraph title={project.solutionOverview.title} />

--- a/app/projects/finding-nemo/FindingNemoPage.tsx
+++ b/app/projects/finding-nemo/FindingNemoPage.tsx
@@ -39,13 +39,18 @@ import {
   SYSTEM_WORKFLOW_ILLUSTRATION_DISPLAY,
   CONCEPTUAL_MVP_ARCHITECTURE_ILLUSTRATION_DISPLAY,
 } from "@/app/projects/finding-nemo/layoutConfig";
-import { FINDING_NEMO_HEADER_LOGO } from "@/app/projects/finding-nemo/headerTheme";
+import { FINDING_NEMO_HEADER_THEME } from "@/app/projects/finding-nemo/headerTheme";
+import { FINDING_NEMO_FOOTER_THEME } from "@/app/projects/finding-nemo/footerTheme";
 import type { FindingNemoProjectDocument } from "@/app/projects/finding-nemo/lib/finding-nemo.firestore";
 import { layoutState } from "@/app/(public)/layout-state";
 import {
   defaultHeaderState,
   headerState,
 } from "@/components/Header/HeaderState";
+import {
+  defaultFooterState,
+  footerState,
+} from "@/components/Footer/FooterState";
 import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
 import ProjectImage from "@/lib/media/ProjectImage";
 import ProjectImageLightbox from "@/lib/media/ProjectImageLightbox";
@@ -132,22 +137,20 @@ export function FindingNemoPage({
 }: FindingNemoPageProps) {
   const setLayoutState = useSetAtom(layoutState);
   const setHeaderState = useSetAtom(headerState);
+  const setFooterState = useSetAtom(footerState);
   const hasProject = project != null;
 
   useEffect(() => {
     setLayoutState({ isFullWidth: true });
-    setHeaderState({
-      position: "absolute",
-      isDark: false,
-      logoPrimaryColor: FINDING_NEMO_HEADER_LOGO.primary,
-      logoAccentColor: FINDING_NEMO_HEADER_LOGO.accent,
-    });
+    setHeaderState({ ...FINDING_NEMO_HEADER_THEME });
+    setFooterState({ ...FINDING_NEMO_FOOTER_THEME });
 
     return () => {
       setLayoutState({ isFullWidth: false });
       setHeaderState({ ...defaultHeaderState });
+      setFooterState({ ...defaultFooterState });
     };
-  }, [setLayoutState, setHeaderState]);
+  }, [setLayoutState, setHeaderState, setFooterState]);
 
   return (
     <Box component="main">
@@ -566,79 +569,89 @@ export function FindingNemoPage({
           </FullBleedBand>
           <FullBleedBand backgroundColor={BAND_COLORS.expectedImpactAndReflections}>
             <SectionParagraph title={project.expectedImpact.title} />
-            <Stack sx={{ ...panelSectionStackSx, ...sectionTitleContentGapMtSx }}>
+            <Stack sx={sectionTitleContentGapMtSx}>
               <Box
                 component="section"
                 sx={{
                   ...PANEL_SHELL_SX,
-                  pt: 0,
                   bgcolor: PANEL_COLORS.default,
                 }}
               >
                 <SectionParagraph body={project.expectedImpact.paragraphs} />
               </Box>
-              <Stack spacing={{ xs: 4, md: 6 }}>
-                <SectionParagraph
-                  title={project.reflectionsAndKeyLearnings.title}
-                />
-                <Box
+            </Stack>
+            <Stack
+              spacing={{ xs: 4, md: 6 }}
+              sx={{
+                mt: SECTION_GAPS.mobile,
+                [breakpointMediaQuery.tabletUp]: {
+                  mt: SECTION_GAPS.tablet,
+                },
+                [breakpointMediaQuery.desktopUp]: {
+                  mt: SECTION_GAPS.desktop,
+                },
+              }}
+            >
+              <SectionParagraph
+                title={project.reflectionsAndKeyLearnings.title}
+              />
+              <Box
+                sx={{
+                  px: LAYOUT_DIMENSIONS.mobile.margin,
+                  [breakpointMediaQuery.tabletUp]: {
+                    px: LAYOUT_DIMENSIONS.tablet.margin,
+                  },
+                  [breakpointMediaQuery.desktopUp]: {
+                    px: LAYOUT_DIMENSIONS.desktop.margin,
+                  },
+                }}
+              >
+                <List
                   sx={{
-                    px: LAYOUT_DIMENSIONS.mobile.margin,
-                    [breakpointMediaQuery.tabletUp]: {
-                      px: LAYOUT_DIMENSIONS.tablet.margin,
-                    },
-                    [breakpointMediaQuery.desktopUp]: {
-                      px: LAYOUT_DIMENSIONS.desktop.margin,
-                    },
+                    width: "100%",
+                    my: 0,
+                    p: 0,
+                    listStyleType: "disc",
+                    listStylePosition: "outside",
+                    pl: { xs: 2.5, md: 3 },
                   }}
                 >
-                  <List
-                    sx={{
-                      width: "100%",
-                      my: 0,
-                      p: 0,
-                      listStyleType: "disc",
-                      listStylePosition: "outside",
-                      pl: { xs: 2.5, md: 3 },
-                    }}
-                  >
-                    {project.reflectionsAndKeyLearnings.items.map((item) => (
-                      <ListItem
-                        key={item.subtitle}
-                        disableGutters
-                        sx={{
-                          display: "list-item",
-                          py: { xs: 1.5, md: 2 },
-                          "&:first-of-type": { pt: 0 },
-                        }}
-                      >
-                        <Stack spacing={1} sx={{ width: "100%" }}>
-                          <Typography
-                            component="h3"
-                            sx={titleTypeSx("personaSectionTitle", {
-                              fontWeight: 700,
-                              lineHeight: 1.2,
-                              color: FINDING_NEMO_HEADLINE_COLOR,
-                            })}
-                          >
-                            {item.subtitle}
-                          </Typography>
-                          <Typography
-                            component="p"
-                            sx={bodyTypeSx("sectionDescription", {
-                              fontWeight: 400,
-                              lineHeight: 1.5,
-                              m: 0,
-                            })}
-                          >
-                            {item.description}
-                          </Typography>
-                        </Stack>
-                      </ListItem>
-                    ))}
-                  </List>
-                </Box>
-              </Stack>
+                  {project.reflectionsAndKeyLearnings.items.map((item) => (
+                    <ListItem
+                      key={item.subtitle}
+                      disableGutters
+                      sx={{
+                        display: "list-item",
+                        py: { xs: 1.5, md: 2 },
+                        "&:first-of-type": { pt: 0 },
+                      }}
+                    >
+                      <Stack spacing={1} sx={{ width: "100%" }}>
+                        <Typography
+                          component="h3"
+                          sx={titleTypeSx("personaSectionTitle", {
+                            fontWeight: 700,
+                            lineHeight: 1.2,
+                            color: FINDING_NEMO_HEADLINE_COLOR,
+                          })}
+                        >
+                          {item.subtitle}
+                        </Typography>
+                        <Typography
+                          component="p"
+                          sx={bodyTypeSx("sectionDescription", {
+                            fontWeight: 400,
+                            lineHeight: 1.5,
+                            m: 0,
+                          })}
+                        >
+                          {item.description}
+                        </Typography>
+                      </Stack>
+                    </ListItem>
+                  ))}
+                </List>
+              </Box>
             </Stack>
           </FullBleedBand>
         </>

--- a/app/projects/finding-nemo/components/ComputerVisionPipelineCard.tsx
+++ b/app/projects/finding-nemo/components/ComputerVisionPipelineCard.tsx
@@ -1,0 +1,141 @@
+import { Box, Stack, Typography } from "@mui/material";
+
+import { interactiveCardHoverSx } from "@/app/projects/finding-nemo/components/interactiveCardStyles";
+import { IDENTIFY_AI_OPPORTUNITY_CARD } from "@/app/projects/finding-nemo/layoutConfig";
+import {
+  bodyTypeSx,
+  FINDING_NEMO_HEADLINE_COLOR,
+  titleTypeSx,
+} from "@/app/projects/finding-nemo/typography";
+import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
+import ProjectImage from "@/lib/media/ProjectImage";
+import type { FindingNemoDataProjectDocument } from "@/scripts/project-2.data";
+
+type ComputerVisionPipelineCardProps = {
+  data: FindingNemoDataProjectDocument["systemWorkflowArchitecture"];
+};
+
+export default function ComputerVisionPipelineCard({
+  data,
+}: ComputerVisionPipelineCardProps) {
+  return (
+    <Box
+      component="section"
+      sx={{
+        width: "100%",
+        boxSizing: "border-box",
+        borderRadius: `${IDENTIFY_AI_OPPORTUNITY_CARD.borderRadiusPx}px`,
+        border: `1px solid ${IDENTIFY_AI_OPPORTUNITY_CARD.border}`,
+        bgcolor: IDENTIFY_AI_OPPORTUNITY_CARD.background,
+        backgroundColor: IDENTIFY_AI_OPPORTUNITY_CARD.background,
+        px: { xs: 2.5, md: 3, lg: 4 },
+        py: { xs: 3, md: 4 },
+        ...interactiveCardHoverSx,
+        "&:hover": {
+          ...interactiveCardHoverSx["&:hover"],
+          bgcolor: IDENTIFY_AI_OPPORTUNITY_CARD.background,
+          backgroundColor: IDENTIFY_AI_OPPORTUNITY_CARD.background,
+        },
+      }}
+    >
+      <Stack spacing={{ xs: 4, md: 5 }}>
+        <Stack spacing={1}>
+          <Typography
+            component="p"
+            sx={titleTypeSx("smallCaption", {
+              color: "#0B6E9F",
+              fontWeight: 700,
+              lineHeight: 1.2,
+              letterSpacing: "0.18em",
+              textTransform: "uppercase",
+              m: 0,
+            })}
+          >
+            {data.subtitle}
+          </Typography>
+          <Typography
+            component="h3"
+            sx={titleTypeSx("contentCardTitle", {
+              color: FINDING_NEMO_HEADLINE_COLOR,
+              fontWeight: 700,
+              lineHeight: 1.2,
+              m: 0,
+            })}
+          >
+            {data.illustration.title}
+          </Typography>
+        </Stack>
+
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: "1fr",
+            alignItems: "center",
+            gap: { xs: 4, md: 6 },
+            [breakpointMediaQuery.desktopUp]: {
+              gridTemplateColumns: "minmax(0, 1fr) minmax(360px, 1fr)",
+              gap: 7,
+            },
+          }}
+        >
+          <Stack spacing={{ xs: 2.5, md: 3 }}>
+            {data.illustration.paragraphs?.map((paragraph) => (
+              <Typography
+                key={paragraph}
+                component="p"
+                sx={bodyTypeSx("contentCardBody", {
+                  fontWeight: 400,
+                  lineHeight: 1.6,
+                  m: 0,
+                })}
+              >
+                {paragraph}
+              </Typography>
+            ))}
+          </Stack>
+
+          <Box
+            sx={{
+              width: "100%",
+              maxWidth: 440,
+              mx: "auto",
+            }}
+          >
+            <ProjectImage
+              objectPath={data.illustration.objectPath}
+              alt={data.illustration.alt}
+              width={data.illustration.width}
+              height={data.illustration.height}
+              style={{
+                display: "block",
+                width: "100%",
+                height: "auto",
+                maxWidth: "100%",
+              }}
+            />
+          </Box>
+        </Box>
+
+        <Box
+          sx={{
+            width: "100%",
+            borderTop: `1px solid ${IDENTIFY_AI_OPPORTUNITY_CARD.border}`,
+            pt: { xs: 2, md: 2.5 },
+          }}
+        >
+          <Typography
+            component="p"
+            sx={bodyTypeSx("smallCaption", {
+              fontWeight: 400,
+              lineHeight: 1.5,
+              textAlign: "center",
+              m: 0,
+            })}
+          >
+            {data.illustration.annotation}
+          </Typography>
+        </Box>
+      </Stack>
+    </Box>
+  );
+}

--- a/app/projects/finding-nemo/components/ContentCard.tsx
+++ b/app/projects/finding-nemo/components/ContentCard.tsx
@@ -156,7 +156,6 @@ export default function ContentCard({
                     {
                       display: "list-item",
                       py: 0.25,
-                      color: "common.black",
                     },
                     bodyTypeSx("contentCardBody", {
                       lineHeight: 1.6,
@@ -185,7 +184,6 @@ export default function ContentCard({
             component="p"
             sx={bodyTypeSx("contentCardBody", {
               width: "100%",
-              color: "common.black",
               lineHeight: 1.6,
               textAlign: descriptionTextAlign,
               fontWeight: 400,

--- a/app/projects/finding-nemo/components/DesigningHumanCenteredAiSection.tsx
+++ b/app/projects/finding-nemo/components/DesigningHumanCenteredAiSection.tsx
@@ -1,24 +1,121 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
 import { Box, Container, Stack, Typography } from "@mui/material";
 
-import ContentCardsRow from "@/app/projects/finding-nemo/components/ContentCardsRow";
 import {
   HUMAN_CENTERED_AI_FRAMEWORK_CARD,
   HUMAN_CENTERED_AI_FRAMEWORK_CARD_GAP,
   INTRO_SECTIONS_BACKGROUND,
-  MY_CONTRIBUTIONS_CARD,
+  PANEL_CONTENT_MAX_WIDTH_PX,
   PROJECT_CONTENT_CONTAINER_SX,
   sectionTitleContentGapMbSx,
 } from "@/app/projects/finding-nemo/layoutConfig";
 import { bodyTypeSx, titleTypeSx } from "@/app/projects/finding-nemo/typography";
+import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
 import type { FindingNemoDataProjectDocument } from "@/scripts/project-2.data";
 
 type DesigningHumanCenteredAiSectionProps = {
   data: FindingNemoDataProjectDocument["designingHumanCenteredAi"];
 };
 
+const CARD_REVEAL_STAGGER_MS = 90;
+
+const sectionLabelSx = [
+  titleTypeSx("heroSubtitle", {
+    fontWeight: 500,
+    color: "#0B6E9F",
+    lineHeight: 1.2,
+    mb: 1.5,
+    textTransform: "uppercase",
+    letterSpacing: "0.04em",
+  }),
+  {
+    [breakpointMediaQuery.desktopUp]: {
+      fontSize: "22px",
+    },
+  },
+] as const;
+
+const sectionHeadlineSx = titleTypeSx("sectionTitle", {
+  fontWeight: 700,
+  color: "#073B5E",
+  lineHeight: 1.2,
+});
+
+const frameworkCardsRowSx = {
+  width: "100%",
+  display: "flex",
+  flexDirection: "row",
+  flexWrap: "wrap",
+  alignItems: "stretch",
+  justifyContent: "center",
+  gap: `${HUMAN_CENTERED_AI_FRAMEWORK_CARD_GAP.mobile}px`,
+  [breakpointMediaQuery.tabletUp]: {
+    justifyContent: "flex-start",
+    gap: `${HUMAN_CENTERED_AI_FRAMEWORK_CARD_GAP.tablet}px`,
+  },
+  [breakpointMediaQuery.desktopUp]: {
+    gap: `${HUMAN_CENTERED_AI_FRAMEWORK_CARD_GAP.desktop}px`,
+  },
+} as const;
+
+const frameworkCardShellSx = {
+  flex: "0 1 auto",
+  width: HUMAN_CENTERED_AI_FRAMEWORK_CARD.widthPx.mobile,
+  maxWidth: "100%",
+  boxSizing: "border-box",
+  borderRadius: `${HUMAN_CENTERED_AI_FRAMEWORK_CARD.borderRadiusPx}px`,
+  bgcolor: HUMAN_CENTERED_AI_FRAMEWORK_CARD.background,
+  border: `1px solid ${HUMAN_CENTERED_AI_FRAMEWORK_CARD.border}`,
+  px: { xs: 2.5, md: 3 },
+  py: { xs: 2.5, md: 3 },
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "flex-start",
+  gap: 1.5,
+  [breakpointMediaQuery.tabletUp]: {
+    width: HUMAN_CENTERED_AI_FRAMEWORK_CARD.widthPx.tablet,
+  },
+  [breakpointMediaQuery.desktopUp]: {
+    width: HUMAN_CENTERED_AI_FRAMEWORK_CARD.widthPx.desktop,
+  },
+} as const;
+
+function formatStageNumber(index: number) {
+  return String(index + 1).padStart(2, "0");
+}
+
 export default function DesigningHumanCenteredAiSection({
   data,
 }: DesigningHumanCenteredAiSectionProps) {
+  const cardsRef = useRef<HTMLDivElement | null>(null);
+  const [cardsInView, setCardsInView] = useState(false);
+
+  useEffect(() => {
+    const el = cardsRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setCardsInView(true);
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      {
+        root: null,
+        threshold: 0.15,
+        rootMargin: "0px 0px -10% 0px",
+      },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <Box
       component="section"
@@ -29,26 +126,24 @@ export default function DesigningHumanCenteredAiSection({
     >
       <Container maxWidth={false} sx={PROJECT_CONTENT_CONTAINER_SX}>
         <Stack spacing={{ xs: 5, md: 6, lg: 8 }} sx={{ width: "100%" }}>
-          <Box sx={{ width: "100%" }}>
-            <Typography
-              component="h2"
-              align="center"
-              sx={titleTypeSx("sectionTitle", {
-                fontWeight: 700,
-                color: "text.primary",
-                lineHeight: 1.2,
-                ...sectionTitleContentGapMbSx,
-              })}
-            >
-              {data.title}
-            </Typography>
+          <Box sx={{ width: "100%", maxWidth: PANEL_CONTENT_MAX_WIDTH_PX }}>
+            <Stack sx={sectionTitleContentGapMbSx}>
+              {data.sectionLabel ? (
+                <Typography component="p" align="left" sx={sectionLabelSx}>
+                  {data.sectionLabel}
+                </Typography>
+              ) : null}
+              <Typography component="h2" align="left" sx={sectionHeadlineSx}>
+                {data.title}
+              </Typography>
+            </Stack>
             <Box component="article">
               {data.paragraphs.map((paragraph, index) => (
                 <Typography
                   key={index}
                   component="p"
                   sx={bodyTypeSx("sectionDescription", {
-                    color: "text.primary",
+                    color: "#3F5266",
                     fontWeight: 400,
                     lineHeight: 1.5,
                     textAlign: "left",
@@ -61,33 +156,70 @@ export default function DesigningHumanCenteredAiSection({
             </Box>
           </Box>
 
-          <ContentCardsRow
-            layout="grid"
-            cardBackgroundColor={MY_CONTRIBUTIONS_CARD.background}
-            centeredFixedGrid={{
-              gaps: HUMAN_CENTERED_AI_FRAMEWORK_CARD_GAP,
-              cardWidths: {
-                mobile: HUMAN_CENTERED_AI_FRAMEWORK_CARD.mobile.width,
-                tablet: HUMAN_CENTERED_AI_FRAMEWORK_CARD.tablet.width,
-                desktop: HUMAN_CENTERED_AI_FRAMEWORK_CARD.desktop.width,
-              },
-            }}
-            cards={data.cards.map((card) => ({
-              title: card.title,
-              description: card.description,
-              responsiveDimensions: HUMAN_CENTERED_AI_FRAMEWORK_CARD,
-              descriptionTextAlign: "center",
-            }))}
-          />
+          <Box ref={cardsRef} sx={frameworkCardsRowSx}>
+            {data.cards.map((card, cardIndex) => (
+              <Box
+                key={card.title}
+                component="article"
+                sx={{
+                  ...frameworkCardShellSx,
+                  opacity: cardsInView ? 1 : 0,
+                  transform: cardsInView ? "translateY(0)" : "translateY(24px)",
+                  transition: "opacity 0.6s ease-out, transform 0.6s ease-out",
+                  transitionDelay: cardsInView
+                    ? `${cardIndex * CARD_REVEAL_STAGGER_MS}ms`
+                    : "0ms",
+                }}
+              >
+                <Typography
+                  component="span"
+                  sx={titleTypeSx("sectionTitle", {
+                    color: HUMAN_CENTERED_AI_FRAMEWORK_CARD.numberColor,
+                    fontWeight: 700,
+                    lineHeight: 1,
+                    m: 0,
+                  })}
+                >
+                  {formatStageNumber(cardIndex)}
+                </Typography>
+                <Typography
+                  component="h3"
+                  sx={titleTypeSx("contentCardTitle", {
+                    color: HUMAN_CENTERED_AI_FRAMEWORK_CARD.titleColor,
+                    fontWeight: 700,
+                    lineHeight: 1.2,
+                    m: 0,
+                  })}
+                >
+                  {card.title}
+                </Typography>
+                <Typography
+                  component="p"
+                  sx={bodyTypeSx("contentCardBody", {
+                    color: HUMAN_CENTERED_AI_FRAMEWORK_CARD.bodyColor,
+                    fontWeight: 400,
+                    lineHeight: 1.5,
+                    textAlign: "left",
+                    m: 0,
+                  })}
+                >
+                  {Array.isArray(card.description)
+                    ? card.description.join(" ")
+                    : card.description}
+                </Typography>
+              </Box>
+            ))}
+          </Box>
 
           {data.paragraphAfterCards ? (
             <Typography
               component="p"
               sx={bodyTypeSx("sectionDescription", {
-                color: "text.primary",
+                color: "#3F5266",
                 fontWeight: 400,
                 lineHeight: 1.5,
                 textAlign: "left",
+                maxWidth: PANEL_CONTENT_MAX_WIDTH_PX,
                 m: 0,
               })}
             >

--- a/app/projects/finding-nemo/components/DesigningHumanCenteredAiSection.tsx
+++ b/app/projects/finding-nemo/components/DesigningHumanCenteredAiSection.tsx
@@ -143,7 +143,6 @@ export default function DesigningHumanCenteredAiSection({
                   key={index}
                   component="p"
                   sx={bodyTypeSx("sectionDescription", {
-                    color: "#3F5266",
                     fontWeight: 400,
                     lineHeight: 1.5,
                     textAlign: "left",
@@ -196,7 +195,6 @@ export default function DesigningHumanCenteredAiSection({
                 <Typography
                   component="p"
                   sx={bodyTypeSx("contentCardBody", {
-                    color: HUMAN_CENTERED_AI_FRAMEWORK_CARD.bodyColor,
                     fontWeight: 400,
                     lineHeight: 1.5,
                     textAlign: "left",
@@ -215,7 +213,6 @@ export default function DesigningHumanCenteredAiSection({
             <Typography
               component="p"
               sx={bodyTypeSx("sectionDescription", {
-                color: "#3F5266",
                 fontWeight: 400,
                 lineHeight: 1.5,
                 textAlign: "left",

--- a/app/projects/finding-nemo/components/DesigningHumanCenteredAiSection.tsx
+++ b/app/projects/finding-nemo/components/DesigningHumanCenteredAiSection.tsx
@@ -45,23 +45,23 @@ const sectionHeadlineSx = titleTypeSx("sectionTitle", {
 
 const frameworkCardsRowSx = {
   width: "100%",
-  display: "flex",
-  flexDirection: "row",
-  flexWrap: "wrap",
+  display: "grid",
+  gridTemplateColumns: "1fr",
   alignItems: "stretch",
-  justifyContent: "center",
+  justifyItems: "center",
   gap: `${HUMAN_CENTERED_AI_FRAMEWORK_CARD_GAP.mobile}px`,
   [breakpointMediaQuery.tabletUp]: {
-    justifyContent: "flex-start",
+    gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+    justifyItems: "stretch",
     gap: `${HUMAN_CENTERED_AI_FRAMEWORK_CARD_GAP.tablet}px`,
   },
   [breakpointMediaQuery.desktopUp]: {
+    gridTemplateColumns: "repeat(4, minmax(0, 1fr))",
     gap: `${HUMAN_CENTERED_AI_FRAMEWORK_CARD_GAP.desktop}px`,
   },
 } as const;
 
 const frameworkCardShellSx = {
-  flex: "0 1 auto",
   width: HUMAN_CENTERED_AI_FRAMEWORK_CARD.widthPx.mobile,
   maxWidth: "100%",
   boxSizing: "border-box",
@@ -75,10 +75,7 @@ const frameworkCardShellSx = {
   alignItems: "flex-start",
   gap: 1.5,
   [breakpointMediaQuery.tabletUp]: {
-    width: HUMAN_CENTERED_AI_FRAMEWORK_CARD.widthPx.tablet,
-  },
-  [breakpointMediaQuery.desktopUp]: {
-    width: HUMAN_CENTERED_AI_FRAMEWORK_CARD.widthPx.desktop,
+    width: "100%",
   },
 } as const;
 

--- a/app/projects/finding-nemo/components/IdentifyAiOpportunitySection.tsx
+++ b/app/projects/finding-nemo/components/IdentifyAiOpportunitySection.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/app/projects/finding-nemo/layoutConfig";
 import FullBleedBand from "@/app/projects/finding-nemo/components/FullBleedBand";
 import StageInfoCardsRow from "@/app/projects/finding-nemo/components/StageInfoCardsRow";
-import { bodyTypeSx, titleTypeSx } from "@/app/projects/finding-nemo/typography";
+import { bodyTypeSx, FINDING_NEMO_HEADLINE_COLOR, titleTypeSx } from "@/app/projects/finding-nemo/typography";
 import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
 import type { FindingNemoDataProjectDocument } from "@/scripts/project-2.data";
 
@@ -40,13 +40,13 @@ const sectionLabelSx = [
 
 const sectionHeadlineSx = titleTypeSx("sectionTitle", {
   fontWeight: 700,
-  color: "#073B5E",
+  color: FINDING_NEMO_HEADLINE_COLOR,
   lineHeight: 1.2,
 });
 
 const subsectionTitleSx = titleTypeSx("sectionSubtitle", {
   fontWeight: 700,
-  color: "#073B5E",
+  color: FINDING_NEMO_HEADLINE_COLOR,
   lineHeight: 1.2,
 });
 

--- a/app/projects/finding-nemo/components/IdentifyAiOpportunitySection.tsx
+++ b/app/projects/finding-nemo/components/IdentifyAiOpportunitySection.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import { Box, List, ListItem, Stack, Typography } from "@mui/material";
-import type { SxProps, Theme } from "@mui/material/styles";
+import { Box, Stack, Typography } from "@mui/material";
 
 import {
   BAND_COLORS,
@@ -13,6 +11,7 @@ import {
   sectionTitleContentGapMtSx,
 } from "@/app/projects/finding-nemo/layoutConfig";
 import FullBleedBand from "@/app/projects/finding-nemo/components/FullBleedBand";
+import StageInfoCardsRow from "@/app/projects/finding-nemo/components/StageInfoCardsRow";
 import { bodyTypeSx, titleTypeSx } from "@/app/projects/finding-nemo/typography";
 import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
 import type { FindingNemoDataProjectDocument } from "@/scripts/project-2.data";
@@ -22,8 +21,6 @@ type IdentifyAiOpportunitySectionProps = {
   challenges: FindingNemoDataProjectDocument["challenges"];
   businessOpportunities: FindingNemoDataProjectDocument["businessOpportunities"];
 };
-
-const CARD_REVEAL_STAGGER_MS = 90;
 
 const sectionLabelSx = [
   titleTypeSx("heroSubtitle", {
@@ -53,45 +50,6 @@ const subsectionTitleSx = titleTypeSx("sectionSubtitle", {
   lineHeight: 1.2,
 });
 
-const cardsRowSx = {
-  width: "100%",
-  display: "flex",
-  flexDirection: "row",
-  flexWrap: "wrap",
-  alignItems: "stretch",
-  justifyContent: "center",
-  gap: `${IDENTIFY_AI_OPPORTUNITY_CARD.gap.mobile}px`,
-  [breakpointMediaQuery.tabletUp]: {
-    justifyContent: "flex-start",
-    gap: `${IDENTIFY_AI_OPPORTUNITY_CARD.gap.tablet}px`,
-  },
-  [breakpointMediaQuery.desktopUp]: {
-    gap: `${IDENTIFY_AI_OPPORTUNITY_CARD.gap.desktop}px`,
-  },
-} as const;
-
-const cardShellSx = {
-  flex: "0 1 auto",
-  width: IDENTIFY_AI_OPPORTUNITY_CARD.widthPx.mobile,
-  maxWidth: "100%",
-  boxSizing: "border-box",
-  borderRadius: `${IDENTIFY_AI_OPPORTUNITY_CARD.borderRadiusPx}px`,
-  bgcolor: IDENTIFY_AI_OPPORTUNITY_CARD.background,
-  border: `1px solid ${IDENTIFY_AI_OPPORTUNITY_CARD.border}`,
-  px: { xs: 2.5, md: 3 },
-  py: { xs: 2.5, md: 3 },
-  display: "flex",
-  flexDirection: "column",
-  alignItems: "flex-start",
-  gap: 1.5,
-  [breakpointMediaQuery.tabletUp]: {
-    width: IDENTIFY_AI_OPPORTUNITY_CARD.widthPx.tablet,
-  },
-  [breakpointMediaQuery.desktopUp]: {
-    width: IDENTIFY_AI_OPPORTUNITY_CARD.widthPx.desktop,
-  },
-} as const;
-
 const sectionStackGapSx = {
   mt: SECTION_GAPS.mobile,
   [breakpointMediaQuery.tabletUp]: {
@@ -102,151 +60,11 @@ const sectionStackGapSx = {
   },
 } as const;
 
-type StageCardProps = {
-  title: string;
-  description: string | string[];
-  titleColor: string;
-  index: number;
-  inView: boolean;
-  rowOffsetMs?: number;
-};
-
-function StageCard({
-  title,
-  description,
-  titleColor,
-  index,
-  inView,
-  rowOffsetMs = 0,
-}: StageCardProps) {
-  const bulletItems = Array.isArray(description) ? description : null;
-
-  return (
-    <Box
-      component="article"
-      sx={{
-        ...cardShellSx,
-        opacity: inView ? 1 : 0,
-        transform: inView ? "translateY(0)" : "translateY(24px)",
-        transition: "opacity 0.6s ease-out, transform 0.6s ease-out",
-        transitionDelay: inView
-          ? `${rowOffsetMs + index * CARD_REVEAL_STAGGER_MS}ms`
-          : "0ms",
-      }}
-    >
-      <Typography
-        component="h3"
-        sx={[
-          titleTypeSx("contentCardTitle", {
-            fontWeight: 700,
-            lineHeight: 1.2,
-            m: 0,
-          }),
-          { color: titleColor },
-        ]}
-      >
-        {title}
-      </Typography>
-      {bulletItems ? (
-        <List
-          sx={{
-            width: "100%",
-            my: 0,
-            p: 0,
-            listStyleType: "disc",
-            listStylePosition: "outside",
-            pl: 2.5,
-          }}
-        >
-          {bulletItems.map((item) => (
-            <ListItem
-              key={item}
-              disableGutters
-              sx={
-                [
-                  {
-                    display: "list-item",
-                    py: 0.25,
-                    color: IDENTIFY_AI_OPPORTUNITY_CARD.bodyColor,
-                  },
-                  bodyTypeSx("contentCardBody", {
-                    lineHeight: 1.55,
-                    fontWeight: 400,
-                  }),
-                ] as SxProps<Theme>
-              }
-            >
-              <Typography
-                component="span"
-                sx={{
-                  fontSize: "inherit",
-                  lineHeight: "inherit",
-                  color: "inherit",
-                  fontFamily: "inherit",
-                  fontWeight: 400,
-                }}
-              >
-                {item}
-              </Typography>
-            </ListItem>
-          ))}
-        </List>
-      ) : (
-        <Typography
-          component="p"
-          sx={bodyTypeSx("contentCardBody", {
-            color: IDENTIFY_AI_OPPORTUNITY_CARD.bodyColor,
-            fontWeight: 400,
-            lineHeight: 1.5,
-            textAlign: "left",
-            m: 0,
-          })}
-        >
-          {description}
-        </Typography>
-      )}
-    </Box>
-  );
-}
-
-function useCardsInView() {
-  const ref = useRef<HTMLDivElement | null>(null);
-  const [inView, setInView] = useState(false);
-
-  useEffect(() => {
-    const el = ref.current;
-    if (!el) return;
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            setInView(true);
-            observer.unobserve(entry.target);
-          }
-        });
-      },
-      {
-        root: null,
-        threshold: 0.12,
-        rootMargin: "0px 0px -10% 0px",
-      },
-    );
-
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, []);
-
-  return { ref, inView };
-}
-
 export default function IdentifyAiOpportunitySection({
   framing,
   challenges,
   businessOpportunities,
 }: IdentifyAiOpportunitySectionProps) {
-  const challengeReveal = useCardsInView();
-  const opportunityReveal = useCardsInView();
   const introParagraphs = framing.paragraphs ?? [];
 
   return (
@@ -270,7 +88,6 @@ export default function IdentifyAiOpportunitySection({
                   key={index}
                   component="p"
                   sx={bodyTypeSx("sectionDescription", {
-                    color: "#3F5266",
                     fontWeight: 400,
                     lineHeight: 1.5,
                     textAlign: "left",
@@ -284,38 +101,20 @@ export default function IdentifyAiOpportunitySection({
           ) : null}
         </Box>
 
-        <Box
-          ref={challengeReveal.ref}
-          sx={{ ...cardsRowSx, ...sectionTitleContentGapMtSx }}
-        >
-          {challenges.cards.map((card, index) => (
-            <StageCard
-              key={card.title}
-              title={card.title}
-              description={card.description}
-              titleColor={IDENTIFY_AI_OPPORTUNITY_CARD.opportunityTitleColor}
-              index={index}
-              inView={challengeReveal.inView}
-            />
-          ))}
-        </Box>
+        <StageInfoCardsRow
+          cards={challenges.cards}
+          titleColor={IDENTIFY_AI_OPPORTUNITY_CARD.opportunityTitleColor}
+          sx={sectionTitleContentGapMtSx}
+        />
 
         <Stack spacing={{ xs: 3, md: 4 }} sx={sectionStackGapSx}>
           <Typography component="h3" align="left" sx={subsectionTitleSx}>
             {businessOpportunities.title}
           </Typography>
-          <Box ref={opportunityReveal.ref} sx={cardsRowSx}>
-            {businessOpportunities.cards.map((card, index) => (
-              <StageCard
-                key={card.title}
-                title={card.title}
-                description={card.description}
-                titleColor={IDENTIFY_AI_OPPORTUNITY_CARD.opportunityTitleColor}
-                index={index}
-                inView={opportunityReveal.inView}
-              />
-            ))}
-          </Box>
+          <StageInfoCardsRow
+            cards={businessOpportunities.cards}
+            titleColor={IDENTIFY_AI_OPPORTUNITY_CARD.opportunityTitleColor}
+          />
         </Stack>
       </Stack>
     </FullBleedBand>

--- a/app/projects/finding-nemo/components/IdentifyAiOpportunitySection.tsx
+++ b/app/projects/finding-nemo/components/IdentifyAiOpportunitySection.tsx
@@ -1,0 +1,323 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Box, List, ListItem, Stack, Typography } from "@mui/material";
+import type { SxProps, Theme } from "@mui/material/styles";
+
+import {
+  BAND_COLORS,
+  IDENTIFY_AI_OPPORTUNITY_CARD,
+  PANEL_CONTENT_MAX_WIDTH_PX,
+  SECTION_GAPS,
+  sectionTitleContentGapMbSx,
+  sectionTitleContentGapMtSx,
+} from "@/app/projects/finding-nemo/layoutConfig";
+import FullBleedBand from "@/app/projects/finding-nemo/components/FullBleedBand";
+import { bodyTypeSx, titleTypeSx } from "@/app/projects/finding-nemo/typography";
+import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
+import type { FindingNemoDataProjectDocument } from "@/scripts/project-2.data";
+
+type IdentifyAiOpportunitySectionProps = {
+  framing: FindingNemoDataProjectDocument["problemSpaceFraming"];
+  challenges: FindingNemoDataProjectDocument["challenges"];
+  businessOpportunities: FindingNemoDataProjectDocument["businessOpportunities"];
+};
+
+const CARD_REVEAL_STAGGER_MS = 90;
+
+const sectionLabelSx = [
+  titleTypeSx("heroSubtitle", {
+    fontWeight: 500,
+    color: "#0B6E9F",
+    lineHeight: 1.2,
+    mb: 1.5,
+    textTransform: "uppercase",
+    letterSpacing: "0.04em",
+  }),
+  {
+    [breakpointMediaQuery.desktopUp]: {
+      fontSize: "22px",
+    },
+  },
+] as const;
+
+const sectionHeadlineSx = titleTypeSx("sectionTitle", {
+  fontWeight: 700,
+  color: "#073B5E",
+  lineHeight: 1.2,
+});
+
+const subsectionTitleSx = titleTypeSx("sectionSubtitle", {
+  fontWeight: 700,
+  color: "#073B5E",
+  lineHeight: 1.2,
+});
+
+const cardsRowSx = {
+  width: "100%",
+  display: "flex",
+  flexDirection: "row",
+  flexWrap: "wrap",
+  alignItems: "stretch",
+  justifyContent: "center",
+  gap: `${IDENTIFY_AI_OPPORTUNITY_CARD.gap.mobile}px`,
+  [breakpointMediaQuery.tabletUp]: {
+    justifyContent: "flex-start",
+    gap: `${IDENTIFY_AI_OPPORTUNITY_CARD.gap.tablet}px`,
+  },
+  [breakpointMediaQuery.desktopUp]: {
+    gap: `${IDENTIFY_AI_OPPORTUNITY_CARD.gap.desktop}px`,
+  },
+} as const;
+
+const cardShellSx = {
+  flex: "0 1 auto",
+  width: IDENTIFY_AI_OPPORTUNITY_CARD.widthPx.mobile,
+  maxWidth: "100%",
+  boxSizing: "border-box",
+  borderRadius: `${IDENTIFY_AI_OPPORTUNITY_CARD.borderRadiusPx}px`,
+  bgcolor: IDENTIFY_AI_OPPORTUNITY_CARD.background,
+  border: `1px solid ${IDENTIFY_AI_OPPORTUNITY_CARD.border}`,
+  px: { xs: 2.5, md: 3 },
+  py: { xs: 2.5, md: 3 },
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "flex-start",
+  gap: 1.5,
+  [breakpointMediaQuery.tabletUp]: {
+    width: IDENTIFY_AI_OPPORTUNITY_CARD.widthPx.tablet,
+  },
+  [breakpointMediaQuery.desktopUp]: {
+    width: IDENTIFY_AI_OPPORTUNITY_CARD.widthPx.desktop,
+  },
+} as const;
+
+const sectionStackGapSx = {
+  mt: SECTION_GAPS.mobile,
+  [breakpointMediaQuery.tabletUp]: {
+    mt: SECTION_GAPS.tablet,
+  },
+  [breakpointMediaQuery.desktopUp]: {
+    mt: SECTION_GAPS.desktop,
+  },
+} as const;
+
+type StageCardProps = {
+  title: string;
+  description: string | string[];
+  titleColor: string;
+  index: number;
+  inView: boolean;
+  rowOffsetMs?: number;
+};
+
+function StageCard({
+  title,
+  description,
+  titleColor,
+  index,
+  inView,
+  rowOffsetMs = 0,
+}: StageCardProps) {
+  const bulletItems = Array.isArray(description) ? description : null;
+
+  return (
+    <Box
+      component="article"
+      sx={{
+        ...cardShellSx,
+        opacity: inView ? 1 : 0,
+        transform: inView ? "translateY(0)" : "translateY(24px)",
+        transition: "opacity 0.6s ease-out, transform 0.6s ease-out",
+        transitionDelay: inView
+          ? `${rowOffsetMs + index * CARD_REVEAL_STAGGER_MS}ms`
+          : "0ms",
+      }}
+    >
+      <Typography
+        component="h3"
+        sx={[
+          titleTypeSx("contentCardTitle", {
+            fontWeight: 700,
+            lineHeight: 1.2,
+            m: 0,
+          }),
+          { color: titleColor },
+        ]}
+      >
+        {title}
+      </Typography>
+      {bulletItems ? (
+        <List
+          sx={{
+            width: "100%",
+            my: 0,
+            p: 0,
+            listStyleType: "disc",
+            listStylePosition: "outside",
+            pl: 2.5,
+          }}
+        >
+          {bulletItems.map((item) => (
+            <ListItem
+              key={item}
+              disableGutters
+              sx={
+                [
+                  {
+                    display: "list-item",
+                    py: 0.25,
+                    color: IDENTIFY_AI_OPPORTUNITY_CARD.bodyColor,
+                  },
+                  bodyTypeSx("contentCardBody", {
+                    lineHeight: 1.55,
+                    fontWeight: 400,
+                  }),
+                ] as SxProps<Theme>
+              }
+            >
+              <Typography
+                component="span"
+                sx={{
+                  fontSize: "inherit",
+                  lineHeight: "inherit",
+                  color: "inherit",
+                  fontFamily: "inherit",
+                  fontWeight: 400,
+                }}
+              >
+                {item}
+              </Typography>
+            </ListItem>
+          ))}
+        </List>
+      ) : (
+        <Typography
+          component="p"
+          sx={bodyTypeSx("contentCardBody", {
+            color: IDENTIFY_AI_OPPORTUNITY_CARD.bodyColor,
+            fontWeight: 400,
+            lineHeight: 1.5,
+            textAlign: "left",
+            m: 0,
+          })}
+        >
+          {description}
+        </Typography>
+      )}
+    </Box>
+  );
+}
+
+function useCardsInView() {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setInView(true);
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      {
+        root: null,
+        threshold: 0.12,
+        rootMargin: "0px 0px -10% 0px",
+      },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return { ref, inView };
+}
+
+export default function IdentifyAiOpportunitySection({
+  framing,
+  challenges,
+  businessOpportunities,
+}: IdentifyAiOpportunitySectionProps) {
+  const challengeReveal = useCardsInView();
+  const opportunityReveal = useCardsInView();
+  const introParagraphs = framing.paragraphs ?? [];
+
+  return (
+    <FullBleedBand backgroundColor={BAND_COLORS.identifyAiOpportunity}>
+      <Stack spacing={0} sx={{ width: "100%" }}>
+        <Box sx={{ width: "100%", maxWidth: PANEL_CONTENT_MAX_WIDTH_PX }}>
+          <Stack sx={sectionTitleContentGapMbSx}>
+            {framing.sectionLabel ? (
+              <Typography component="p" align="left" sx={sectionLabelSx}>
+                {framing.sectionLabel}
+              </Typography>
+            ) : null}
+            <Typography component="h2" align="left" sx={sectionHeadlineSx}>
+              {framing.title}
+            </Typography>
+          </Stack>
+          {introParagraphs.length > 0 ? (
+            <Box component="article">
+              {introParagraphs.map((paragraph, index) => (
+                <Typography
+                  key={index}
+                  component="p"
+                  sx={bodyTypeSx("sectionDescription", {
+                    color: "#3F5266",
+                    fontWeight: 400,
+                    lineHeight: 1.5,
+                    textAlign: "left",
+                    mb: index === introParagraphs.length - 1 ? 0 : 3.5,
+                  })}
+                >
+                  {paragraph}
+                </Typography>
+              ))}
+            </Box>
+          ) : null}
+        </Box>
+
+        <Box
+          ref={challengeReveal.ref}
+          sx={{ ...cardsRowSx, ...sectionTitleContentGapMtSx }}
+        >
+          {challenges.cards.map((card, index) => (
+            <StageCard
+              key={card.title}
+              title={card.title}
+              description={card.description}
+              titleColor={IDENTIFY_AI_OPPORTUNITY_CARD.opportunityTitleColor}
+              index={index}
+              inView={challengeReveal.inView}
+            />
+          ))}
+        </Box>
+
+        <Stack spacing={{ xs: 3, md: 4 }} sx={sectionStackGapSx}>
+          <Typography component="h3" align="left" sx={subsectionTitleSx}>
+            {businessOpportunities.title}
+          </Typography>
+          <Box ref={opportunityReveal.ref} sx={cardsRowSx}>
+            {businessOpportunities.cards.map((card, index) => (
+              <StageCard
+                key={card.title}
+                title={card.title}
+                description={card.description}
+                titleColor={IDENTIFY_AI_OPPORTUNITY_CARD.opportunityTitleColor}
+                index={index}
+                inView={opportunityReveal.inView}
+              />
+            ))}
+          </Box>
+        </Stack>
+      </Stack>
+    </FullBleedBand>
+  );
+}

--- a/app/projects/finding-nemo/components/KpiCard.tsx
+++ b/app/projects/finding-nemo/components/KpiCard.tsx
@@ -1,10 +1,6 @@
 import { Box, Typography } from "@mui/material";
 
-import {
-  FINDING_NEMO_BODY_FONT,
-  FINDING_NEMO_TITLE_FONT,
-  TYPOGRAPHY,
-} from "@/app/projects/finding-nemo/typography";
+import { FINDING_NEMO_BODY_COLOR, FINDING_NEMO_BODY_FONT, FINDING_NEMO_TITLE_FONT, TYPOGRAPHY } from "@/app/projects/finding-nemo/typography";
 import {
   DEFINING_SUCCESS_KPI_CARD,
 } from "@/app/projects/finding-nemo/layoutConfig";
@@ -90,7 +86,7 @@ export default function KpiCard({ icon, title, description }: KpiCardProps) {
             fontFamily: FINDING_NEMO_BODY_FONT,
             fontWeight: 400,
             lineHeight: 1.5,
-            color: "common.black",
+            color: FINDING_NEMO_BODY_COLOR,
             fontSize: {
               xs: TYPOGRAPHY.kpiCardBody.mobile,
               md: TYPOGRAPHY.kpiCardBody.tablet,

--- a/app/projects/finding-nemo/components/KpiCard.tsx
+++ b/app/projects/finding-nemo/components/KpiCard.tsx
@@ -1,102 +1,110 @@
 import { Box, Typography } from "@mui/material";
 
-import { FINDING_NEMO_BODY_COLOR, FINDING_NEMO_BODY_FONT, FINDING_NEMO_TITLE_FONT, TYPOGRAPHY } from "@/app/projects/finding-nemo/typography";
-import {
-  DEFINING_SUCCESS_KPI_CARD,
-} from "@/app/projects/finding-nemo/layoutConfig";
-import type { FindingNemoKpiCardItem } from "@/scripts/project-2.data";
-
+import { IDENTIFY_AI_OPPORTUNITY_CARD } from "@/app/projects/finding-nemo/layoutConfig";
 import { interactiveCardHoverSx } from "@/app/projects/finding-nemo/components/interactiveCardStyles";
-
-export const KPI_CARD_WIDTH_PX = 300;
-export const KPI_CARD_HEIGHT_PX = 280;
+import {
+  bodyTypeSx,
+  FINDING_NEMO_HEADLINE_COLOR,
+  titleTypeSx,
+} from "@/app/projects/finding-nemo/typography";
+import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
+import type { FindingNemoKpiCardItem } from "@/scripts/project-2.data";
 
 export type KpiCardProps = FindingNemoKpiCardItem;
 
+/**
+ * Defining Success KPI card — same chrome as Business Opportunities
+ * (white surface, border, left-aligned body); titles match section subtitle color.
+ */
 export default function KpiCard({ icon, title, description }: KpiCardProps) {
   return (
     <Box
       component="article"
       sx={{
+        flex: "0 1 auto",
+        width: IDENTIFY_AI_OPPORTUNITY_CARD.widthPx.mobile,
+        maxWidth: "100%",
+        boxSizing: "border-box",
+        borderRadius: `${IDENTIFY_AI_OPPORTUNITY_CARD.borderRadiusPx}px`,
+        bgcolor: IDENTIFY_AI_OPPORTUNITY_CARD.background,
+        backgroundColor: IDENTIFY_AI_OPPORTUNITY_CARD.background,
+        border: `1px solid ${IDENTIFY_AI_OPPORTUNITY_CARD.border}`,
+        px: { xs: 2.5, md: 3 },
+        py: { xs: 2.5, md: 3 },
         display: "flex",
         flexDirection: "column",
-        gap: "32px",
-        width: KPI_CARD_WIDTH_PX,
-        minWidth: KPI_CARD_WIDTH_PX,
-        maxWidth: KPI_CARD_WIDTH_PX,
-        height: KPI_CARD_HEIGHT_PX,
-        minHeight: KPI_CARD_HEIGHT_PX,
-        maxHeight: KPI_CARD_HEIGHT_PX,
-        flexGrow: 0,
-        flexShrink: 0,
-        px: 4,
-        pt: 6,
-        pb: 4,
-        bgcolor: DEFINING_SUCCESS_KPI_CARD.background,
-        borderRadius: "20px",
-        overflow: "hidden",
-        boxSizing: "border-box",
+        alignItems: "flex-start",
+        gap: 2.5,
+        height: "100%",
+        [breakpointMediaQuery.tabletUp]: {
+          width: IDENTIFY_AI_OPPORTUNITY_CARD.widthPx.tablet,
+        },
+        [breakpointMediaQuery.desktopUp]: {
+          width: IDENTIFY_AI_OPPORTUNITY_CARD.widthPx.desktop,
+        },
         ...interactiveCardHoverSx,
         "&:hover": {
           ...interactiveCardHoverSx["&:hover"],
-          bgcolor: DEFINING_SUCCESS_KPI_CARD.background,
+          bgcolor: IDENTIFY_AI_OPPORTUNITY_CARD.background,
+          backgroundColor: IDENTIFY_AI_OPPORTUNITY_CARD.background,
         },
       }}
     >
       <Box
-        component="h3"
         sx={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          gap: 2,
           width: "100%",
-          m: 0,
-          fontFamily: FINDING_NEMO_TITLE_FONT,
-          fontWeight: 600,
-          lineHeight: 1.2,
-          color: "common.black",
-          textAlign: "center",
-          fontSize: {
-            xs: TYPOGRAPHY.kpiCardTitle.mobile,
-            md: TYPOGRAPHY.kpiCardTitle.tablet,
-            lg: TYPOGRAPHY.kpiCardTitle.desktop,
-          },
+          display: "flex",
+          justifyContent: "center",
         }}
       >
         <Box
           component="span"
-          aria-hidden="true"
           sx={{
-            flexShrink: 0,
-            fontSize: "1em",
-            lineHeight: 1,
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 1,
+            maxWidth: "100%",
+            whiteSpace: "nowrap",
           }}
         >
-          {icon}
+          <Box
+            component="span"
+            aria-hidden="true"
+            sx={{
+              flexShrink: 0,
+              fontSize: "1.35em",
+              lineHeight: 1,
+            }}
+          >
+            {icon}
+          </Box>
+          <Typography
+            component="h3"
+            sx={[
+              titleTypeSx("kpiCardTitle", {
+                fontWeight: 700,
+                lineHeight: 1.2,
+                m: 0,
+                textAlign: "left",
+              }),
+              { color: FINDING_NEMO_HEADLINE_COLOR },
+            ]}
+          >
+            {title}
+          </Typography>
         </Box>
-        <Box component="span">{title}</Box>
       </Box>
-      <Box sx={{ display: "flex", alignItems: "flex-start", flex: 1 }}>
-        <Typography
-          component="p"
-          variant="inherit"
-          sx={{
-            m: 0,
-            fontFamily: FINDING_NEMO_BODY_FONT,
-            fontWeight: 400,
-            lineHeight: 1.5,
-            color: FINDING_NEMO_BODY_COLOR,
-            fontSize: {
-              xs: TYPOGRAPHY.kpiCardBody.mobile,
-              md: TYPOGRAPHY.kpiCardBody.tablet,
-              lg: TYPOGRAPHY.kpiCardBody.desktop,
-            },
-          }}
-        >
-          {description}
-        </Typography>
-      </Box>
+      <Typography
+        component="p"
+        sx={bodyTypeSx("contentCardBody", {
+          fontWeight: 400,
+          lineHeight: 1.5,
+          textAlign: "left",
+          m: 0,
+        })}
+      >
+        {description}
+      </Typography>
     </Box>
   );
 }

--- a/app/projects/finding-nemo/components/KpiCardsRow.tsx
+++ b/app/projects/finding-nemo/components/KpiCardsRow.tsx
@@ -4,19 +4,27 @@ import { useEffect, useRef, useState } from "react";
 import Box from "@mui/material/Box";
 
 import KpiCard from "@/app/projects/finding-nemo/components/KpiCard";
+import { IDENTIFY_AI_OPPORTUNITY_CARD } from "@/app/projects/finding-nemo/layoutConfig";
+import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
 import type { FindingNemoKpiCardItem } from "@/scripts/project-2.data";
+
+const CARD_REVEAL_STAGGER_MS = 90;
 
 const kpiCardsRowSx = {
   width: "100%",
   display: "flex",
-  flexDirection: { xs: "column", md: "row" },
-  flexWrap: { xs: "nowrap", md: "wrap" },
+  flexDirection: "row",
+  flexWrap: "wrap",
+  alignItems: "stretch",
   justifyContent: "center",
-  alignItems: { xs: "center", md: "stretch" },
-  gap: { xs: 3, md: 3, lg: 4 },
+  gap: `${IDENTIFY_AI_OPPORTUNITY_CARD.gap.mobile}px`,
+  [breakpointMediaQuery.tabletUp]: {
+    gap: `${IDENTIFY_AI_OPPORTUNITY_CARD.gap.tablet}px`,
+  },
+  [breakpointMediaQuery.desktopUp]: {
+    gap: `${IDENTIFY_AI_OPPORTUNITY_CARD.gap.desktop}px`,
+  },
 } as const;
-
-const CARD_REVEAL_STAGGER_MS = 90;
 
 type KpiCardsRowProps = {
   cards: FindingNemoKpiCardItem[];
@@ -25,8 +33,8 @@ type KpiCardsRowProps = {
 };
 
 /**
- * KPI card row with the same scroll-reveal + stagger pattern as
- * `AnimatedCardWrapper` in `app/home/my-background.tsx`.
+ * KPI card row — Business Opportunities layout (wrapping fixed-width cards)
+ * with the same scroll-reveal stagger as StageInfoCardsRow.
  */
 export default function KpiCardsRow({ cards, rowIndex = 0 }: KpiCardsRowProps) {
   const ref = useRef<HTMLDivElement | null>(null);
@@ -65,7 +73,6 @@ export default function KpiCardsRow({ cards, rowIndex = 0 }: KpiCardsRowProps) {
         <Box
           key={card.title}
           sx={{
-            flexShrink: 0,
             opacity: inView ? 1 : 0,
             transform: inView ? "translateY(0)" : "translateY(24px)",
             transition: "opacity 0.6s ease-out, transform 0.6s ease-out",

--- a/app/projects/finding-nemo/components/MetadataDrivenArchitectureCard.tsx
+++ b/app/projects/finding-nemo/components/MetadataDrivenArchitectureCard.tsx
@@ -1,0 +1,154 @@
+import { Box, Stack, Typography } from "@mui/material";
+
+import { interactiveCardHoverSx } from "@/app/projects/finding-nemo/components/interactiveCardStyles";
+import { IDENTIFY_AI_OPPORTUNITY_CARD } from "@/app/projects/finding-nemo/layoutConfig";
+import {
+  bodyTypeSx,
+  FINDING_NEMO_HEADLINE_COLOR,
+  titleTypeSx,
+} from "@/app/projects/finding-nemo/typography";
+import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
+import type { FindingNemoDataProjectDocument } from "@/scripts/project-2.data";
+
+type MetadataDrivenArchitectureCardProps = {
+  data: NonNullable<
+    FindingNemoDataProjectDocument["mobileExperienceConcepts"]["metadataDrivenArchitecture"]
+  >;
+};
+
+const metadataFieldsGridSx = {
+  width: "100%",
+  display: "grid",
+  gridTemplateColumns: "1fr",
+  gap: 1.5,
+  [breakpointMediaQuery.tabletUp]: {
+    gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+  },
+  [breakpointMediaQuery.desktopUp]: {
+    gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+  },
+} as const;
+
+export default function MetadataDrivenArchitectureCard({
+  data,
+}: MetadataDrivenArchitectureCardProps) {
+  return (
+    <Box
+      component="section"
+      sx={{
+        width: "100%",
+        boxSizing: "border-box",
+        borderRadius: `${IDENTIFY_AI_OPPORTUNITY_CARD.borderRadiusPx}px`,
+        border: `1px solid ${IDENTIFY_AI_OPPORTUNITY_CARD.border}`,
+        bgcolor: IDENTIFY_AI_OPPORTUNITY_CARD.background,
+        backgroundColor: IDENTIFY_AI_OPPORTUNITY_CARD.background,
+        px: { xs: 2.5, md: 3, lg: 4 },
+        py: { xs: 3, md: 4 },
+        ...interactiveCardHoverSx,
+        "&:hover": {
+          ...interactiveCardHoverSx["&:hover"],
+          bgcolor: IDENTIFY_AI_OPPORTUNITY_CARD.background,
+          backgroundColor: IDENTIFY_AI_OPPORTUNITY_CARD.background,
+        },
+      }}
+    >
+      <Stack spacing={{ xs: 3, md: 3.5 }}>
+        <Stack spacing={1}>
+          <Typography
+            component="p"
+            sx={titleTypeSx("smallCaption", {
+              color: "#0B6E9F",
+              fontWeight: 700,
+              lineHeight: 1.2,
+              letterSpacing: "0.18em",
+              textTransform: "uppercase",
+              m: 0,
+            })}
+          >
+            {data.eyebrow}
+          </Typography>
+          <Typography
+            component="h3"
+            sx={titleTypeSx("personaSectionTitle", {
+              color: FINDING_NEMO_HEADLINE_COLOR,
+              fontWeight: 700,
+              lineHeight: 1.2,
+              m: 0,
+            })}
+          >
+            {data.title}
+          </Typography>
+        </Stack>
+
+        <Typography
+          component="p"
+          sx={bodyTypeSx("contentCardBody", {
+            fontWeight: 400,
+            lineHeight: 1.6,
+            m: 0,
+          })}
+        >
+          {data.intro}
+        </Typography>
+
+        <Box sx={metadataFieldsGridSx}>
+          {data.fields.map((field) => (
+            <Box
+              key={field}
+              sx={{
+                minHeight: 42,
+                boxSizing: "border-box",
+                display: "flex",
+                alignItems: "center",
+                gap: 1.25,
+                borderRadius: "8px",
+                border: `1px solid ${IDENTIFY_AI_OPPORTUNITY_CARD.border}`,
+                bgcolor: "#EEF2F6",
+                px: 2,
+                py: 1.25,
+              }}
+            >
+              <Box
+                aria-hidden="true"
+                sx={{
+                  width: 6,
+                  height: 6,
+                  flexShrink: 0,
+                  borderRadius: "50%",
+                  bgcolor:
+                    IDENTIFY_AI_OPPORTUNITY_CARD.opportunityTitleColor,
+                }}
+              />
+              <Typography
+                component="span"
+                sx={bodyTypeSx("smallCaption", {
+                  color: FINDING_NEMO_HEADLINE_COLOR,
+                  fontWeight: 600,
+                  lineHeight: 1.3,
+                })}
+              >
+                {field}
+              </Typography>
+            </Box>
+          ))}
+        </Box>
+
+        <Stack spacing={{ xs: 2.5, md: 3 }}>
+          {data.paragraphs.map((paragraph) => (
+            <Typography
+              key={paragraph}
+              component="p"
+              sx={bodyTypeSx("contentCardBody", {
+                fontWeight: 400,
+                lineHeight: 1.6,
+                m: 0,
+              })}
+            >
+              {paragraph}
+            </Typography>
+          ))}
+        </Stack>
+      </Stack>
+    </Box>
+  );
+}

--- a/app/projects/finding-nemo/components/MobileExperienceMockup.tsx
+++ b/app/projects/finding-nemo/components/MobileExperienceMockup.tsx
@@ -5,7 +5,7 @@ import {
   MOBILE_EXPERIENCE_NOTIFICATION_DISPLAY,
   PROBLEM_DEMO_CAROUSEL_CAPTION_FONT_SIZE,
 } from "@/app/projects/finding-nemo/layoutConfig";
-import { FINDING_NEMO_BODY_FONT } from "@/app/projects/finding-nemo/typography";
+import { FINDING_NEMO_BODY_COLOR, FINDING_NEMO_BODY_FONT } from "@/app/projects/finding-nemo/typography";
 import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
 import ProjectImageLightbox from "@/lib/media/ProjectImageLightbox";
 import type { FindingNemoMobileMockupItem } from "@/scripts/project-2.data";
@@ -17,7 +17,7 @@ export type MobileExperienceMockupProps = FindingNemoMobileMockupItem & {
 
 const mockupAnnotationSx = {
   fontFamily: FINDING_NEMO_BODY_FONT,
-  color: "#000",
+  color: FINDING_NEMO_BODY_COLOR,
   fontSize: PROBLEM_DEMO_CAROUSEL_CAPTION_FONT_SIZE.mobile,
   lineHeight: 1.3,
   fontWeight: 600,

--- a/app/projects/finding-nemo/components/MobileExperienceMockup.tsx
+++ b/app/projects/finding-nemo/components/MobileExperienceMockup.tsx
@@ -1,11 +1,16 @@
-import { Stack, Typography } from "@mui/material";
+import { Chip, Stack, Typography } from "@mui/material";
 
 import {
   MOBILE_EXPERIENCE_MOCKUP_DISPLAY,
   MOBILE_EXPERIENCE_NOTIFICATION_DISPLAY,
   PROBLEM_DEMO_CAROUSEL_CAPTION_FONT_SIZE,
 } from "@/app/projects/finding-nemo/layoutConfig";
-import { FINDING_NEMO_BODY_COLOR, FINDING_NEMO_BODY_FONT } from "@/app/projects/finding-nemo/typography";
+import {
+  FINDING_NEMO_BODY_COLOR,
+  FINDING_NEMO_BODY_FONT,
+  FINDING_NEMO_HEADLINE_COLOR,
+  titleTypeSx,
+} from "@/app/projects/finding-nemo/typography";
 import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
 import ProjectImageLightbox from "@/lib/media/ProjectImageLightbox";
 import type { FindingNemoMobileMockupItem } from "@/scripts/project-2.data";
@@ -31,6 +36,43 @@ const mockupAnnotationSx = {
   },
 } as const;
 
+const mockupDescriptionSx = {
+  fontFamily: FINDING_NEMO_BODY_FONT,
+  color: FINDING_NEMO_BODY_COLOR,
+  fontSize: PROBLEM_DEMO_CAROUSEL_CAPTION_FONT_SIZE.mobile,
+  lineHeight: 1.45,
+  fontWeight: 400,
+  textAlign: "left",
+  width: "100%",
+  m: 0,
+  [breakpointMediaQuery.tabletUp]: {
+    fontSize: PROBLEM_DEMO_CAROUSEL_CAPTION_FONT_SIZE.tablet,
+  },
+  [breakpointMediaQuery.desktopUp]: {
+    fontSize: PROBLEM_DEMO_CAROUSEL_CAPTION_FONT_SIZE.desktop,
+  },
+} as const;
+
+const mockupTitleSx = titleTypeSx("smallCaption", {
+  color: FINDING_NEMO_HEADLINE_COLOR,
+  fontWeight: 700,
+  lineHeight: 1.25,
+  m: 0,
+});
+
+const mockupChipSx = {
+  height: 24,
+  borderRadius: "12px",
+  bgcolor: "#FFF8E6",
+  color: "#D99A00",
+  fontFamily: FINDING_NEMO_BODY_FONT,
+  fontSize: "13px",
+  fontWeight: 700,
+  "& .MuiChip-label": {
+    px: 1.25,
+  },
+} as const;
+
 function getDisplayConfig(variant: "phone" | "notification") {
   return variant === "notification"
     ? MOBILE_EXPERIENCE_NOTIFICATION_DISPLAY
@@ -48,6 +90,8 @@ function mockupLightboxId(objectPath: string): string {
 
 export default function MobileExperienceMockup({
   title,
+  chipLabel,
+  description,
   objectPath,
   width,
   height,
@@ -73,6 +117,30 @@ export default function MobileExperienceMockup({
         },
       }}
     >
+      {chipLabel ? (
+        <Stack
+          direction="row"
+          spacing={1}
+          alignItems="center"
+          justifyContent="center"
+          sx={{
+            width: "100%",
+            height: 64,
+            flexShrink: 0,
+            [breakpointMediaQuery.tabletUp]: {
+              height: 56,
+            },
+            [breakpointMediaQuery.desktopUp]: {
+              height: 48,
+            },
+          }}
+        >
+          <Chip label={chipLabel} size="small" sx={mockupChipSx} />
+          <Typography component="p" sx={mockupTitleSx}>
+            {title}
+          </Typography>
+        </Stack>
+      ) : null}
       <ProjectImageLightbox
         objectPath={objectPath}
         alt={title}
@@ -81,9 +149,16 @@ export default function MobileExperienceMockup({
         height={height}
         style={{ display: "block", width: "100%", height: "auto" }}
       />
-      <Typography component="p" sx={mockupAnnotationSx}>
-        {title}
-      </Typography>
+      {!chipLabel ? (
+        <Typography component="p" sx={mockupAnnotationSx}>
+          {title}
+        </Typography>
+      ) : null}
+      {description ? (
+        <Typography component="p" sx={mockupDescriptionSx}>
+          {description}
+        </Typography>
+      ) : null}
     </Stack>
   );
 }

--- a/app/projects/finding-nemo/components/MyContributions.tsx
+++ b/app/projects/finding-nemo/components/MyContributions.tsx
@@ -1,18 +1,9 @@
-import {
-  Box,
-  Container,
-  List,
-  ListItem,
-  Stack,
-  Typography,
-} from "@mui/material";
-import type { SxProps, Theme } from "@mui/material/styles";
+import { Box, Container, Stack, Typography } from "@mui/material";
 
 import {
-  INTRO_INSET_CARD_TABLET_MAX_WIDTH_PX,
-  INTRO_SECTIONS_BACKGROUND,
-  LAYOUT_DIMENSIONS,
-  MY_CONTRIBUTIONS_CARD,
+  MY_CONTRIBUTIONS_BAND,
+  PROJECT_CONTENT_CONTAINER_SX,
+  sectionTitleContentGapMbSx,
 } from "@/app/projects/finding-nemo/layoutConfig";
 import { bodyTypeSx, titleTypeSx } from "@/app/projects/finding-nemo/typography";
 import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
@@ -22,22 +13,54 @@ type MyContributionsProps = {
   data: FindingNemoDataProjectDocument["myContributions"];
 };
 
-const contributionsCardSx = {
+const sectionLabelSx = [
+  titleTypeSx("heroSubtitle", {
+    fontWeight: 500,
+    color: MY_CONTRIBUTIONS_BAND.titleColor,
+    lineHeight: 1.2,
+    textTransform: "uppercase",
+    letterSpacing: "0.04em",
+  }),
+  {
+    [breakpointMediaQuery.desktopUp]: {
+      fontSize: "22px",
+    },
+  },
+] as const;
+
+const tagsRowSx = {
+  display: "flex",
+  flexWrap: "wrap",
+  alignItems: "center",
+  justifyContent: "flex-start",
+  gap: `${MY_CONTRIBUTIONS_BAND.tagGap.mobile}px`,
   width: "100%",
-  maxWidth: "100%",
-  mx: "auto",
-  boxSizing: "border-box",
-  backgroundColor: MY_CONTRIBUTIONS_CARD.background,
-  borderRadius: `${MY_CONTRIBUTIONS_CARD.borderRadiusPx}px`,
-  p: `${MY_CONTRIBUTIONS_CARD.paddingPx}px`,
-  boxShadow: "0 4px 14px rgba(0, 0, 0, 0.08)",
-  [breakpointMediaQuery.tabletOnly]: {
-    maxWidth: INTRO_INSET_CARD_TABLET_MAX_WIDTH_PX,
+  m: 0,
+  p: 0,
+  listStyle: "none",
+  [breakpointMediaQuery.tabletUp]: {
+    gap: `${MY_CONTRIBUTIONS_BAND.tagGap.tablet}px`,
   },
   [breakpointMediaQuery.desktopUp]: {
-    maxWidth: MY_CONTRIBUTIONS_CARD.maxWidthPx,
+    gap: `${MY_CONTRIBUTIONS_BAND.tagGap.desktop}px`,
   },
 } as const;
+
+const tagChipSx = [
+  bodyTypeSx("bodyText", {
+    display: "inline-flex",
+    alignItems: "center",
+    px: { xs: 2, md: 2.5 },
+    py: { xs: 1, md: 1.25 },
+    borderRadius: "999px",
+    bgcolor: MY_CONTRIBUTIONS_BAND.tagBackground,
+    border: `1px solid ${MY_CONTRIBUTIONS_BAND.tagBorder}`,
+    color: MY_CONTRIBUTIONS_BAND.tagText,
+    fontWeight: 400,
+    lineHeight: 1.35,
+    whiteSpace: "nowrap",
+  }),
+] as const;
 
 export default function MyContributions({ data }: MyContributionsProps) {
   return (
@@ -45,87 +68,28 @@ export default function MyContributions({ data }: MyContributionsProps) {
       component="section"
       aria-labelledby="my-contributions-heading"
       sx={{
-        bgcolor: INTRO_SECTIONS_BACKGROUND,
+        bgcolor: MY_CONTRIBUTIONS_BAND.background,
         py: { xs: 8, md: 10, lg: 12 },
-        px: LAYOUT_DIMENSIONS.mobile.margin,
-        [breakpointMediaQuery.tabletUp]: {
-          px: LAYOUT_DIMENSIONS.tablet.margin,
-        },
-        [breakpointMediaQuery.desktopUp]: {
-          px: LAYOUT_DIMENSIONS.desktop.margin,
-        },
       }}
     >
-      <Container
-        maxWidth={false}
-        sx={{
-          maxWidth: {
-            xs: LAYOUT_DIMENSIONS.mobile.maxWidth,
-            md: LAYOUT_DIMENSIONS.tablet.maxWidth,
-            lg: LAYOUT_DIMENSIONS.desktop.maxWidth,
-          },
-        }}
-      >
-        <Box sx={contributionsCardSx}>
-          <Stack spacing={{ xs: 4, md: 5 }} alignItems="center">
-            <Typography
-              id="my-contributions-heading"
-              component="h2"
-              align="center"
-              sx={titleTypeSx("sectionTitle", {
-                fontWeight: 700,
-                color: "text.primary",
-                lineHeight: 1.2,
-              })}
-            >
-              {data.title}
-            </Typography>
-            <List
-              sx={{
-                width: "fit-content",
-                maxWidth: 520,
-                mx: "auto",
-                my: 0,
-                p: 0,
-                listStyleType: "disc",
-                listStylePosition: "outside",
-                pl: { xs: 4, md: 5 },
-              }}
-            >
-              {data.items.map((item) => (
-                <ListItem
-                  key={item}
-                  disableGutters
-                  sx={
-                    [
-                      {
-                        display: "list-item",
-                        py: 0.5,
-                        color: "text.primary",
-                      },
-                      bodyTypeSx("bodyText", {
-                        lineHeight: 1.65,
-                      }),
-                    ] as SxProps<Theme>
-                  }
-                >
-                  <Typography
-                    component="span"
-                    sx={{
-                      fontSize: "inherit",
-                      lineHeight: "inherit",
-                      color: "inherit",
-                      fontFamily: "inherit",
-                      fontWeight: 400,
-                    }}
-                  >
-                    {item}
-                  </Typography>
-                </ListItem>
-              ))}
-            </List>
-          </Stack>
-        </Box>
+      <Container maxWidth={false} sx={PROJECT_CONTENT_CONTAINER_SX}>
+        <Stack alignItems="flex-start" sx={{ width: "100%" }}>
+          <Typography
+            id="my-contributions-heading"
+            component="h2"
+            align="left"
+            sx={[...sectionLabelSx, sectionTitleContentGapMbSx]}
+          >
+            {data.title}
+          </Typography>
+          <Box component="ul" sx={tagsRowSx}>
+            {data.items.map((item) => (
+              <Box component="li" key={item} sx={tagChipSx}>
+                {item}
+              </Box>
+            ))}
+          </Box>
+        </Stack>
       </Container>
     </Box>
   );

--- a/app/projects/finding-nemo/components/Overview.tsx
+++ b/app/projects/finding-nemo/components/Overview.tsx
@@ -1,6 +1,10 @@
-import { Box, Container, Typography } from "@mui/material";
+import { Box, Container, Stack, Typography } from "@mui/material";
 
-import { INTRO_SECTIONS_BACKGROUND, INTRO_NARRATIVE_MAX_WIDTH_PX, LAYOUT_DIMENSIONS, sectionTitleContentGapMbSx } from "@/app/projects/finding-nemo/layoutConfig";
+import {
+  INTRO_SECTIONS_BACKGROUND,
+  PROJECT_CONTENT_CONTAINER_SX,
+  sectionTitleContentGapMbSx,
+} from "@/app/projects/finding-nemo/layoutConfig";
 import { bodyTypeSx, titleTypeSx } from "@/app/projects/finding-nemo/typography";
 import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
 import type { FindingNemoDataProjectDocument } from "@/scripts/project-2.data";
@@ -16,59 +20,59 @@ export default function OverviewSection({ data }: OverviewSectionProps) {
       sx={{
         bgcolor: INTRO_SECTIONS_BACKGROUND,
         py: { xs: 8, md: 10, lg: 12 },
-        px: LAYOUT_DIMENSIONS.mobile.margin,
-        [breakpointMediaQuery.tabletUp]: {
-          px: LAYOUT_DIMENSIONS.tablet.margin,
-        },
-        [breakpointMediaQuery.desktopUp]: {
-          px: LAYOUT_DIMENSIONS.desktop.margin,
-        },
       }}
     >
-      <Container
-        maxWidth={false}
-        sx={{
-          maxWidth: {
-            xs: LAYOUT_DIMENSIONS.mobile.maxWidth,
-            md: LAYOUT_DIMENSIONS.tablet.maxWidth,
-            lg: LAYOUT_DIMENSIONS.desktop.maxWidth,
-          },
-        }}
-      >
-        <Box
-          sx={{
-            maxWidth: INTRO_NARRATIVE_MAX_WIDTH_PX,
-            mx: "auto",
-          }}
-        >
+      <Container maxWidth={false} sx={PROJECT_CONTENT_CONTAINER_SX}>
+        <Stack sx={sectionTitleContentGapMbSx}>
+          {data.sectionLabel ? (
+            <Typography
+              component="p"
+              align="left"
+              sx={[
+                titleTypeSx("heroSubtitle", {
+                  fontWeight: 500,
+                  color: "#0B6E9F",
+                  lineHeight: 1.2,
+                  mb: 1.5,
+                  textTransform: "uppercase",
+                }),
+                {
+                  [breakpointMediaQuery.desktopUp]: {
+                    fontSize: "22px",
+                  },
+                },
+              ]}
+            >
+              {data.sectionLabel}
+            </Typography>
+          ) : null}
           <Typography
             component="h2"
-            align="center"
+            align="left"
             sx={titleTypeSx("sectionTitle", {
               fontWeight: 700,
-              color: "text.primary",
+              color: "#073B5E",
               lineHeight: 1.2,
-              ...sectionTitleContentGapMbSx,
             })}
           >
             {data.title}
           </Typography>
-          <Box component="article">
-            {data.paragraphs.map((paragraph, index) => (
-              <Typography
-                key={index}
-                component="p"
-                sx={bodyTypeSx("sectionDescription", {
-                  color: "text.primary",
-                  fontWeight: 400,
-                  lineHeight: 1.5,
-                  mb: index === data.paragraphs.length - 1 ? 0 : 3.5,
-                })}
-              >
-                {paragraph}
-              </Typography>
-            ))}
-          </Box>
+        </Stack>
+        <Box component="article">
+          {data.paragraphs.map((paragraph, index) => (
+            <Typography
+              key={index}
+              component="p"
+              sx={bodyTypeSx("sectionDescription", {
+                color: "#3F5266",
+                fontWeight: 400,
+                lineHeight: 1.5,
+                mb: index === data.paragraphs.length - 1 ? 0 : 3.5,
+              })}
+            >
+              {paragraph}
+            </Typography>
+          ))}
         </Box>
       </Container>
     </Box>

--- a/app/projects/finding-nemo/components/Overview.tsx
+++ b/app/projects/finding-nemo/components/Overview.tsx
@@ -64,7 +64,6 @@ export default function OverviewSection({ data }: OverviewSectionProps) {
               key={index}
               component="p"
               sx={bodyTypeSx("sectionDescription", {
-                color: "#3F5266",
                 fontWeight: 400,
                 lineHeight: 1.5,
                 mb: index === data.paragraphs.length - 1 ? 0 : 3.5,

--- a/app/projects/finding-nemo/components/PanelSection.tsx
+++ b/app/projects/finding-nemo/components/PanelSection.tsx
@@ -2,9 +2,16 @@ import { Box, Stack, Typography } from "@mui/material";
 
 import {
   CORE_PRINCIPLES_IMAGE_DISPLAY,
+  IDENTIFY_AI_OPPORTUNITY_CARD,
   PANEL_SHELL_SX,
+  SECTION_TITLE_CONTENT_GAP,
 } from "@/app/projects/finding-nemo/layoutConfig";
-import { bodyTypeSx, titleTypeSx } from "@/app/projects/finding-nemo/typography";
+import { interactiveCardHoverSx } from "@/app/projects/finding-nemo/components/interactiveCardStyles";
+import {
+  bodyTypeSx,
+  FINDING_NEMO_HEADLINE_COLOR,
+  titleTypeSx,
+} from "@/app/projects/finding-nemo/typography";
 import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
 import ProjectImage from "@/lib/media/ProjectImage";
 import KpiCardsRow from "@/app/projects/finding-nemo/components/KpiCardsRow";
@@ -50,7 +57,7 @@ function PanelHeading({ title }: { title: string }) {
       sx={titleTypeSx("sectionSubtitle", {
         fontWeight: 700,
         lineHeight: 1.1,
-        color: "common.black",
+        color: FINDING_NEMO_HEADLINE_COLOR,
       })}
     >
       {title}
@@ -121,7 +128,6 @@ function ImageTextPanel({
 function PrinciplesImagePanel({
   principles,
   image,
-  panelBackgroundColor,
 }: Extract<FindingNemoPanelSectionItem, { type: "principles-image" }> & {
   panelBackgroundColor?: string;
 }) {
@@ -129,13 +135,27 @@ function PrinciplesImagePanel({
     <Box
       component="section"
       sx={{
-        ...panelShellSxWithBackground(panelBackgroundColor),
+        width: "100%",
+        maxWidth: "100%",
+        boxSizing: "border-box",
+        borderRadius: `${IDENTIFY_AI_OPPORTUNITY_CARD.borderRadiusPx}px`,
+        bgcolor: IDENTIFY_AI_OPPORTUNITY_CARD.background,
+        backgroundColor: IDENTIFY_AI_OPPORTUNITY_CARD.background,
+        border: `1px solid ${IDENTIFY_AI_OPPORTUNITY_CARD.border}`,
+        px: { xs: 2.5, md: 3, lg: 4 },
+        py: { xs: 3, md: 4 },
         display: "flex",
         flexDirection: { xs: "column", md: "row" },
         flexWrap: "wrap",
         alignItems: "center",
         justifyContent: "center",
         gap: { xs: 4, md: 8 },
+        ...interactiveCardHoverSx,
+        "&:hover": {
+          ...interactiveCardHoverSx["&:hover"],
+          bgcolor: IDENTIFY_AI_OPPORTUNITY_CARD.background,
+          backgroundColor: IDENTIFY_AI_OPPORTUNITY_CARD.background,
+        },
       }}
     >
       <Stack
@@ -153,7 +173,8 @@ function PrinciplesImagePanel({
               sx={titleTypeSx("personaSectionTitle", {
                 fontWeight: 700,
                 lineHeight: 1.2,
-                color: "common.black",
+                m: 0,
+                color: FINDING_NEMO_HEADLINE_COLOR,
               })}
             >
               {principle.subtitle}
@@ -215,7 +236,7 @@ function TextPanel({
               sx={titleTypeSx("personaSectionTitle", {
                 fontWeight: 700,
                 lineHeight: 1.2,
-                color: "common.black",
+                color: FINDING_NEMO_HEADLINE_COLOR,
               })}
             >
               {row.subtitle}
@@ -232,7 +253,17 @@ export default function PanelSection(props: PanelSectionProps) {
   const { panelBackgroundColor, title } = props;
 
   return (
-    <Stack spacing={{ xs: 3, md: 4 }}>
+    <Stack
+      sx={{
+        gap: SECTION_TITLE_CONTENT_GAP.mobile,
+        [breakpointMediaQuery.tabletUp]: {
+          gap: SECTION_TITLE_CONTENT_GAP.tablet,
+        },
+        [breakpointMediaQuery.desktopUp]: {
+          gap: SECTION_TITLE_CONTENT_GAP.desktop,
+        },
+      }}
+    >
       <PanelHeading title={title} />
       {props.type === "image-text" ? (
         <ImageTextPanel

--- a/app/projects/finding-nemo/components/PanelSection.tsx
+++ b/app/projects/finding-nemo/components/PanelSection.tsx
@@ -105,7 +105,6 @@ function ImageTextPanel({
         <Typography
           component="p"
           sx={bodyTypeSx("sectionDescription", {
-            color: "common.black",
             fontWeight: 400,
             lineHeight: 1.5,
             maxWidth: 540,
@@ -162,7 +161,6 @@ function PrinciplesImagePanel({
             <Typography
               component="p"
               sx={bodyTypeSx("contentCardBody", {
-                color: "common.black",
                 fontWeight: 400,
                 lineHeight: 1.6,
                 m: 0,
@@ -203,7 +201,6 @@ function TextPanel({
         <Typography
           component="p"
           sx={bodyTypeSx("sectionDescription", {
-            color: "common.black",
             fontWeight: 400,
             lineHeight: 1.5,
             m: 0,

--- a/app/projects/finding-nemo/components/PanelSection.tsx
+++ b/app/projects/finding-nemo/components/PanelSection.tsx
@@ -50,6 +50,24 @@ const corePrinciplesImageBoxSx = {
   },
 } as const;
 
+const panelInfoCardShellSx = {
+  width: "100%",
+  maxWidth: "100%",
+  boxSizing: "border-box",
+  borderRadius: `${IDENTIFY_AI_OPPORTUNITY_CARD.borderRadiusPx}px`,
+  bgcolor: IDENTIFY_AI_OPPORTUNITY_CARD.background,
+  backgroundColor: IDENTIFY_AI_OPPORTUNITY_CARD.background,
+  border: `1px solid ${IDENTIFY_AI_OPPORTUNITY_CARD.border}`,
+  px: { xs: 2.5, md: 3, lg: 4 },
+  py: { xs: 3, md: 4 },
+  ...interactiveCardHoverSx,
+  "&:hover": {
+    ...interactiveCardHoverSx["&:hover"],
+    bgcolor: IDENTIFY_AI_OPPORTUNITY_CARD.background,
+    backgroundColor: IDENTIFY_AI_OPPORTUNITY_CARD.background,
+  },
+} as const;
+
 function PanelHeading({ title }: { title: string }) {
   return (
     <Typography
@@ -68,7 +86,6 @@ function PanelHeading({ title }: { title: string }) {
 function ImageTextPanel({
   description,
   image,
-  panelBackgroundColor,
 }: Extract<FindingNemoPanelSectionItem, { type: "image-text" }> & {
   panelBackgroundColor?: string;
 }) {
@@ -76,10 +93,12 @@ function ImageTextPanel({
     <Box
       component="section"
       sx={{
-        ...panelShellSxWithBackground(panelBackgroundColor),
+        ...panelInfoCardShellSx,
         display: "flex",
         flexDirection: { xs: "column", md: "row" },
+        flexWrap: "wrap",
         alignItems: "center",
+        justifyContent: "center",
         gap: { xs: 4, md: 8 },
       }}
     >
@@ -106,15 +125,15 @@ function ImageTextPanel({
           flex: 1,
           display: "flex",
           alignItems: "center",
-          minWidth: 0,
+          minWidth: { xs: "100%", md: 280 },
+          maxWidth: 540,
         }}
       >
         <Typography
           component="p"
-          sx={bodyTypeSx("sectionDescription", {
+          sx={bodyTypeSx("contentCardBody", {
             fontWeight: 400,
-            lineHeight: 1.5,
-            maxWidth: 540,
+            lineHeight: 1.6,
             m: 0,
           })}
         >
@@ -135,27 +154,13 @@ function PrinciplesImagePanel({
     <Box
       component="section"
       sx={{
-        width: "100%",
-        maxWidth: "100%",
-        boxSizing: "border-box",
-        borderRadius: `${IDENTIFY_AI_OPPORTUNITY_CARD.borderRadiusPx}px`,
-        bgcolor: IDENTIFY_AI_OPPORTUNITY_CARD.background,
-        backgroundColor: IDENTIFY_AI_OPPORTUNITY_CARD.background,
-        border: `1px solid ${IDENTIFY_AI_OPPORTUNITY_CARD.border}`,
-        px: { xs: 2.5, md: 3, lg: 4 },
-        py: { xs: 3, md: 4 },
+        ...panelInfoCardShellSx,
         display: "flex",
         flexDirection: { xs: "column", md: "row" },
         flexWrap: "wrap",
         alignItems: "center",
         justifyContent: "center",
         gap: { xs: 4, md: 8 },
-        ...interactiveCardHoverSx,
-        "&:hover": {
-          ...interactiveCardHoverSx["&:hover"],
-          bgcolor: IDENTIFY_AI_OPPORTUNITY_CARD.background,
-          backgroundColor: IDENTIFY_AI_OPPORTUNITY_CARD.background,
-        },
       }}
     >
       <Stack

--- a/app/projects/finding-nemo/components/Persona.tsx
+++ b/app/projects/finding-nemo/components/Persona.tsx
@@ -3,6 +3,7 @@
 import { Box, Paper, Stack, Typography } from "@mui/material";
 
 import { interactiveCardHoverSx } from "@/app/projects/finding-nemo/components/interactiveCardStyles";
+import { IDENTIFY_AI_OPPORTUNITY_CARD } from "@/app/projects/finding-nemo/layoutConfig";
 import { bodyTypeSx, titleTypeSx } from "@/app/projects/finding-nemo/typography";
 import ProjectImage from "@/lib/media/ProjectImage";
 import type { FindingNemoPersonaItem } from "@/scripts/project-2.data";
@@ -36,11 +37,12 @@ export default function Persona({
         display: fillHeight ? "flex" : "block",
         flexDirection: fillHeight ? "column" : undefined,
         mx: "auto",
-        px: 4,
-        pt: 4,
-        pb: 5,
-        borderRadius: "15px",
-        backgroundColor: "#fff",
+        px: { xs: 2.5, md: 3 },
+        py: { xs: 2.5, md: 3 },
+        borderRadius: `${IDENTIFY_AI_OPPORTUNITY_CARD.borderRadiusPx}px`,
+        bgcolor: IDENTIFY_AI_OPPORTUNITY_CARD.background,
+        backgroundColor: IDENTIFY_AI_OPPORTUNITY_CARD.background,
+        border: `1px solid ${IDENTIFY_AI_OPPORTUNITY_CARD.border}`,
         overflow: "hidden",
         boxSizing: "border-box",
         ...(interactive
@@ -48,8 +50,8 @@ export default function Persona({
               ...interactiveCardHoverSx,
               "&:hover": {
                 ...interactiveCardHoverSx["&:hover"],
-                bgcolor: "#fff",
-                backgroundColor: "#fff",
+                bgcolor: IDENTIFY_AI_OPPORTUNITY_CARD.background,
+                backgroundColor: IDENTIFY_AI_OPPORTUNITY_CARD.background,
               },
             }
           : {}),
@@ -89,12 +91,14 @@ export default function Persona({
           <Stack spacing={1} flex={1} minWidth={0}>
             <Typography
               component="h1"
-              sx={titleTypeSx("contentCardTitle", {
-                fontWeight: 700,
-                lineHeight: 1.1,
-                color: "common.black",
-                textAlign: { xs: "center", sm: "left" },
-              })}
+              sx={[
+                titleTypeSx("contentCardTitle", {
+                  fontWeight: 700,
+                  lineHeight: 1.1,
+                  textAlign: { xs: "center", sm: "left" },
+                }),
+                { color: IDENTIFY_AI_OPPORTUNITY_CARD.opportunityTitleColor },
+              ]}
             >
               {title}
             </Typography>
@@ -103,7 +107,6 @@ export default function Persona({
               sx={bodyTypeSx("personaRoleDescription", {
                 fontWeight: 400,
                 lineHeight: 1.25,
-                color: "#022f5d",
                 textAlign: { xs: "center", sm: "left" },
               })}
             >
@@ -130,7 +133,6 @@ export default function Persona({
                 sx={bodyTypeSx("contentCardBody", {
                   lineHeight: 1.6,
                   fontWeight: 400,
-                  color: "common.black",
                 })}
               >
                 {goal}
@@ -158,7 +160,6 @@ export default function Persona({
                   sx={bodyTypeSx("contentCardBody", {
                     lineHeight: 1.6,
                     fontWeight: 400,
-                    color: "common.black",
                   })}
                 >
                   {point}
@@ -175,19 +176,17 @@ export default function Persona({
               maxWidth: 486,
               px: 2.5,
               py: 2,
-              borderRadius: "15px",
-              backgroundColor: "#dee8f380",
-              borderLeft: "5px solid #009d1799",
+              borderRadius: `${IDENTIFY_AI_OPPORTUNITY_CARD.borderRadiusPx}px`,
+              backgroundColor: "#F5F8FB",
+              borderLeft: `5px solid ${IDENTIFY_AI_OPPORTUNITY_CARD.opportunityTitleColor}`,
             }}
           >
             <Typography
               component="blockquote"
-              sx={{
+              sx={bodyTypeSx("contentCardBody", {
                 m: 0,
-                fontSize: 16,
                 lineHeight: 1.35,
-                color: "#000",
-              }}
+              })}
             >
               &ldquo;{quote}&rdquo;
             </Typography>

--- a/app/projects/finding-nemo/components/ProbleDemoCarousel.tsx
+++ b/app/projects/finding-nemo/components/ProbleDemoCarousel.tsx
@@ -6,18 +6,12 @@ import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
 import { Box, Container, IconButton, Stack, Typography } from "@mui/material";
 
 import {
-  INTRO_INSET_CARD_TABLET_MAX_WIDTH_PX,
-  INTRO_NARRATIVE_MAX_WIDTH_PX,
   INTRO_SECTIONS_BACKGROUND,
-  LAYOUT_DIMENSIONS,
   PROBLEM_DEMO_CAROUSEL_IMAGE_DISPLAY,
-  PROBLEM_DEMO_PANEL_BACKGROUND,
-  PROBLEM_DEMO_PANEL_COPY_MIN_WIDTH_PX,
-  PROBLEM_DEMO_PANEL_COPY_WIDTH,
   PROBLEM_DEMO_PANEL_GAP,
-  PROBLEM_DEMO_PANEL_SIDE_BY_SIDE_MIN_WIDTH_PX,
-  PROBLEM_DEMO_PANEL_TITLE_GAP,
   PROBLEM_DEMO_CAROUSEL_CAPTION_FONT_SIZE,
+  PROJECT_CONTENT_CONTAINER_SX,
+  sectionTitleContentGapMbSx,
 } from "@/app/projects/finding-nemo/layoutConfig";
 import { bodyTypeSx, FINDING_NEMO_BODY_FONT, titleTypeSx } from "@/app/projects/finding-nemo/typography";
 import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
@@ -28,8 +22,7 @@ type ProblemDemoPanelProps = {
   data: NonNullable<FindingNemoDataProjectDocument["problemDemoPanel"]>;
 };
 
-const { desktop, tablet, mobile } = PROBLEM_DEMO_CAROUSEL_IMAGE_DISPLAY;
-const copyWidth = PROBLEM_DEMO_PANEL_COPY_WIDTH;
+const { desktop } = PROBLEM_DEMO_CAROUSEL_IMAGE_DISPLAY;
 const panelGap = PROBLEM_DEMO_PANEL_GAP;
 const captionFontSize = PROBLEM_DEMO_CAROUSEL_CAPTION_FONT_SIZE;
 
@@ -50,87 +43,82 @@ const carouselCaptionSx = {
   },
 } as const;
 
-const sectionContentStackSx = {
-  width: "100%",
-  alignItems: "center",
-  gap: PROBLEM_DEMO_PANEL_TITLE_GAP.mobile,
-  [breakpointMediaQuery.tabletUp]: {
-    gap: PROBLEM_DEMO_PANEL_TITLE_GAP.tablet,
+const sectionLabelSx = [
+  titleTypeSx("heroSubtitle", {
+    fontWeight: 500,
+    color: "#0B6E9F",
+    lineHeight: 1.2,
+    mb: 1.5,
+    textTransform: "uppercase",
+  }),
+  {
+    [breakpointMediaQuery.desktopUp]: {
+      fontSize: "22px",
+    },
   },
-  [breakpointMediaQuery.desktopUp]: {
-    gap: PROBLEM_DEMO_PANEL_TITLE_GAP.desktop,
-  },
-} as const;
+] as const;
 
-const problemDemoPanelSideBySideMq = `@media (min-width: ${PROBLEM_DEMO_PANEL_SIDE_BY_SIDE_MIN_WIDTH_PX}px)`;
+const sectionHeadlineSx = titleTypeSx("sectionTitle", {
+  fontWeight: 700,
+  color: "#073B5E",
+  lineHeight: 1.2,
+});
 
-/** Stacked below 1260px — copy width matches carousel; side-by-side uses fixed copy column. */
+/**
+ * Stacked on mobile/tablet at full content width (same as Overview);
+ * on desktop: ~60% copy / ~40% carousel (flex 3:2, gap excluded).
+ */
 const copyColumnSx = {
   width: "100%",
-  maxWidth: mobile.width,
-  flexShrink: 0,
-  [breakpointMediaQuery.tabletUp]: {
-    maxWidth: tablet.width,
-  },
-  [problemDemoPanelSideBySideMq]: {
-    width: copyWidth.desktop,
-    maxWidth: copyWidth.desktop,
-    minWidth: PROBLEM_DEMO_PANEL_COPY_MIN_WIDTH_PX,
-    flexShrink: 0,
+  maxWidth: "100%",
+  [breakpointMediaQuery.desktopUp]: {
+    flex: "3 1 0%",
+    width: "auto",
+    minWidth: 0,
+    maxWidth: "none",
   },
 } as const;
 
 const panelRowSx = {
+  width: "100%",
   flexDirection: "column",
-  alignItems: "center",
+  alignItems: "stretch",
   justifyContent: "space-between",
   gap: `${panelGap.stacked}px`,
-  [problemDemoPanelSideBySideMq]: {
+  [breakpointMediaQuery.desktopUp]: {
     flexDirection: "row",
     alignItems: "center",
+    justifyContent: "space-between",
     gap: `${panelGap.sideBySide}px`,
   },
 } as const;
 
 const carouselImageSizes = [
-  `(max-width: 767px) ${mobile.width}px`,
-  `(max-width: 1023px) ${tablet.width}px`,
-  `${desktop.width}px`,
+  `(max-width: 767px) 100vw`,
+  `(max-width: 1023px) 100vw`,
+  `40vw`,
 ].join(", ");
 
-/** Fixed frame per breakpoint — steps down at tablet / mobile, no fluid scaling between bands. */
+/** Full-width fluid frame on mobile/tablet; ~40% column beside copy on desktop. */
 const carouselFrameSx = {
   position: "relative",
-  width: mobile.width,
-  height: mobile.height,
+  width: "100%",
+  aspectRatio: "524 / 330",
   maxWidth: "100%",
   overflow: "hidden",
   borderRadius: 5,
   flexShrink: 0,
-  [breakpointMediaQuery.tabletUp]: {
-    width: tablet.width,
-    height: tablet.height,
-    maxWidth: tablet.width,
-  },
-  [breakpointMediaQuery.desktopUp]: {
-    width: desktop.width,
-    height: desktop.height,
-    maxWidth: desktop.width,
-  },
 } as const;
 
 const carouselColumnSx = {
-  flexShrink: 0,
-  width: mobile.width,
+  width: "100%",
   maxWidth: "100%",
   alignItems: "stretch",
-  [breakpointMediaQuery.tabletUp]: {
-    width: tablet.width,
-    maxWidth: tablet.width,
-  },
   [breakpointMediaQuery.desktopUp]: {
-    width: desktop.width,
-    maxWidth: desktop.width,
+    flex: "2 1 0%",
+    width: "auto",
+    maxWidth: "none",
+    minWidth: 0,
   },
 } as const;
 
@@ -148,7 +136,7 @@ const navigationButtons = [
 ] as const;
 
 export default function ProblemDemoPanel({ data }: ProblemDemoPanelProps) {
-  const { sectionTitle, description, slides } = data;
+  const { sectionLabel, title, description, slides } = data;
   const [currentIndex, setCurrentIndex] = useState(0);
   const canNavigate = slides.length > 1;
   const currentSlide = slides[currentIndex];
@@ -172,131 +160,90 @@ export default function ProblemDemoPanel({ data }: ProblemDemoPanelProps) {
       component="section"
       sx={{
         bgcolor: INTRO_SECTIONS_BACKGROUND,
-        px: LAYOUT_DIMENSIONS.mobile.margin,
         pb: { xs: 8, md: 10, lg: 12 },
-        [breakpointMediaQuery.tabletUp]: {
-          px: LAYOUT_DIMENSIONS.tablet.margin,
-        },
-        [breakpointMediaQuery.desktopUp]: {
-          px: LAYOUT_DIMENSIONS.desktop.margin,
-        },
       }}
     >
-      <Container
-        maxWidth={false}
-        sx={{
-          maxWidth: {
-            xs: LAYOUT_DIMENSIONS.mobile.maxWidth,
-            md: LAYOUT_DIMENSIONS.tablet.maxWidth,
-            lg: LAYOUT_DIMENSIONS.desktop.maxWidth,
-          },
-        }}
-      >
-        <Stack sx={sectionContentStackSx}>
-          <Typography
-            component="h2"
-            align="center"
-            sx={titleTypeSx("sectionTitle", {
-              width: "100%",
-              color: "text.primary",
-              fontWeight: 700,
-              lineHeight: 1.2,
-              m: 0,
-            })}
-          >
-            {sectionTitle}
-          </Typography>
-          <Box
-            sx={{
-              width: "100%",
-              maxWidth: "100%",
-              mx: "auto",
-              [breakpointMediaQuery.tabletOnly]: {
-                maxWidth: INTRO_INSET_CARD_TABLET_MAX_WIDTH_PX,
-              },
-              [breakpointMediaQuery.desktopUp]: {
-                maxWidth: INTRO_NARRATIVE_MAX_WIDTH_PX,
-              },
-              bgcolor: PROBLEM_DEMO_PANEL_BACKGROUND,
-              borderRadius: 5,
-              px: { xs: 3, sm: 5, md: 8 },
-              py: { xs: 4, sm: 5, md: 8 },
-            }}
-          >
-            <Stack sx={panelRowSx}>
-              <Box component="article" sx={copyColumnSx}>
-                <Typography
-                  component="p"
-                  sx={bodyTypeSx("sectionDescription", {
-                    color: "common.black",
-                    lineHeight: 1.5,
-                    fontWeight: 400,
-                    m: 0,
-                  })}
-                >
-                  {description}
-                </Typography>
+      <Container maxWidth={false} sx={PROJECT_CONTENT_CONTAINER_SX}>
+        <Stack sx={panelRowSx}>
+          <Stack spacing={3} sx={copyColumnSx}>
+            <Stack sx={sectionTitleContentGapMbSx}>
+              <Typography component="p" align="left" sx={sectionLabelSx}>
+                {sectionLabel}
+              </Typography>
+              <Typography component="h2" align="left" sx={sectionHeadlineSx}>
+                {title}
+              </Typography>
+            </Stack>
+            <Typography
+              component="p"
+              sx={bodyTypeSx("sectionDescription", {
+                color: "common.black",
+                lineHeight: 1.5,
+                fontWeight: 400,
+                m: 0,
+              })}
+            >
+              {description}
+            </Typography>
+          </Stack>
+          <Stack spacing={3} sx={carouselColumnSx}>
+            <Box component="figure" sx={{ m: 0, width: "100%" }}>
+              <Box sx={carouselFrameSx}>
+                <ProjectImage
+                  objectPath={currentSlide.objectPath}
+                  alt={currentSlide.alt}
+                  width={desktop.width}
+                  height={desktop.height}
+                  sizes={carouselImageSizes}
+                  priority={currentIndex === 0}
+                  style={{
+                    display: "block",
+                    width: "100%",
+                    height: "100%",
+                    objectFit: "cover",
+                  }}
+                />
               </Box>
-              <Stack spacing={3} sx={carouselColumnSx}>
-                <Box component="figure" sx={{ m: 0, width: "100%" }}>
-                  <Box sx={carouselFrameSx}>
-                    <ProjectImage
-                      objectPath={currentSlide.objectPath}
-                      alt={currentSlide.alt}
-                      width={desktop.width}
-                      height={desktop.height}
-                      sizes={carouselImageSizes}
-                      priority={currentIndex === 0}
-                      style={{
-                        display: "block",
-                        width: "100%",
-                        height: "100%",
-                        objectFit: "cover",
-                      }}
-                    />
-                  </Box>
-                </Box>
-                <Stack
-                  direction="row"
-                  alignItems="center"
-                  justifyContent="space-between"
-                  spacing={2}
-                  component="figcaption"
-                >
-                  <Box sx={{ flex: 1, minWidth: 0 }} aria-hidden />
-                  <Typography component="span" sx={carouselCaptionSx}>
-                    {currentSlide.caption}
-                  </Typography>
-                  <Stack
-                    direction="row"
-                    spacing={0.5}
-                    sx={{ flex: 1, minWidth: 0 }}
-                    justifyContent="flex-end"
+            </Box>
+            <Stack
+              direction="row"
+              alignItems="center"
+              justifyContent="space-between"
+              spacing={2}
+              component="figcaption"
+            >
+              <Box sx={{ flex: 1, minWidth: 0 }} aria-hidden />
+              <Typography component="span" sx={carouselCaptionSx}>
+                {currentSlide.caption}
+              </Typography>
+              <Stack
+                direction="row"
+                spacing={0.5}
+                sx={{ flex: 1, minWidth: 0 }}
+                justifyContent="flex-end"
+              >
+                {navigationButtons.map((button) => (
+                  <IconButton
+                    key={button.key}
+                    aria-label={button.label}
+                    disabled={!canNavigate}
+                    onClick={
+                      button.key === "previous" ? goToPrevious : goToNext
+                    }
+                    size="small"
+                    sx={{
+                      color: "#8a8a8a",
+                      "&.Mui-disabled": {
+                        color: "rgba(138, 138, 138, 0.35)",
+                      },
+                    }}
                   >
-                    {navigationButtons.map((button) => (
-                      <IconButton
-                        key={button.key}
-                        aria-label={button.label}
-                        disabled={!canNavigate}
-                        onClick={
-                          button.key === "previous" ? goToPrevious : goToNext
-                        }
-                        size="small"
-                        sx={{
-                          color: "#8a8a8a",
-                          "&.Mui-disabled": {
-                            color: "rgba(138, 138, 138, 0.35)",
-                          },
-                        }}
-                      >
-                        {button.icon}
-                      </IconButton>
-                    ))}
-                  </Stack>
-                </Stack>
+                    {button.icon}
+                  </IconButton>
+                ))}
               </Stack>
             </Stack>
-          </Box>
+          </Stack>
         </Stack>
       </Container>
     </Box>

--- a/app/projects/finding-nemo/components/ProbleDemoCarousel.tsx
+++ b/app/projects/finding-nemo/components/ProbleDemoCarousel.tsx
@@ -13,7 +13,7 @@ import {
   PROJECT_CONTENT_CONTAINER_SX,
   sectionTitleContentGapMbSx,
 } from "@/app/projects/finding-nemo/layoutConfig";
-import { bodyTypeSx, FINDING_NEMO_BODY_FONT, titleTypeSx } from "@/app/projects/finding-nemo/typography";
+import { bodyTypeSx, FINDING_NEMO_BODY_COLOR, FINDING_NEMO_BODY_FONT, titleTypeSx } from "@/app/projects/finding-nemo/typography";
 import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
 import ProjectImage from "@/lib/media/ProjectImage";
 import type { FindingNemoDataProjectDocument } from "@/scripts/project-2.data";
@@ -28,7 +28,7 @@ const captionFontSize = PROBLEM_DEMO_CAROUSEL_CAPTION_FONT_SIZE;
 
 const carouselCaptionSx = {
   fontFamily: FINDING_NEMO_BODY_FONT,
-  color: "#000",
+  color: FINDING_NEMO_BODY_COLOR,
   fontSize: captionFontSize.mobile,
   lineHeight: 1.3,
   fontWeight: 600,
@@ -176,12 +176,11 @@ export default function ProblemDemoPanel({ data }: ProblemDemoPanelProps) {
             </Stack>
             <Typography
               component="p"
-              sx={bodyTypeSx("sectionDescription", {
-                color: "common.black",
-                lineHeight: 1.5,
-                fontWeight: 400,
-                m: 0,
-              })}
+                sx={bodyTypeSx("sectionDescription", {
+                  fontWeight: 400,
+                  lineHeight: 1.5,
+                  m: 0,
+                })}
             >
               {description}
             </Typography>

--- a/app/projects/finding-nemo/components/ProjectHeader.tsx
+++ b/app/projects/finding-nemo/components/ProjectHeader.tsx
@@ -1,13 +1,8 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect } from "react";
 import { Box, Stack, Typography } from "@mui/material";
 import type { SxProps, Theme } from "@mui/material/styles";
-
-import RecognitionDialog, {
-  recognitionAwardButtonSx,
-  recognitionLinkSx,
-} from "@/app/projects/finding-nemo/components/RecognitionDialog";
 
 import {
   HEADER_BAND_COLOR,
@@ -148,7 +143,6 @@ const HEADER_FONT_SIZE = {
     tablet: "20px",
     desktop: "22px",
   },
-  award: "clamp(16px, calc(13.5px + 0.68vw), 18px)",
 } as const;
 
 function headerTitleFontSizeSx() {
@@ -176,35 +170,11 @@ function headerSubtitleFontSizeSx() {
 }
 
 export default function ProjectHeader({ data, onReady }: ProjectHeaderProps) {
-  const [recognitionOpen, setRecognitionOpen] = useState(false);
-
   useEffect(() => {
     onReady?.();
   }, [onReady]);
 
-  const { boundingBoxesOverlay, recognition } = data;
-
-  const { awardHeadlineLines, viewRecognitionLine } = useMemo(() => {
-    const headline: string[] = [];
-    let viewLine: string | undefined;
-
-    for (const line of data.awardLines) {
-      if (/view recognition/i.test(line)) {
-        viewLine = line;
-      } else {
-        headline.push(line);
-      }
-    }
-
-    return {
-      awardHeadlineLines: headline,
-      viewRecognitionLine: viewLine,
-    };
-  }, [data.awardLines]);
-
-  const recognitionDialogTitle = `🏆 ${awardHeadlineLines.join(" ")}`;
-  const openRecognition = () => setRecognitionOpen(true);
-  const closeRecognition = () => setRecognitionOpen(false);
+  const { boundingBoxesOverlay } = data;
 
   return (
     <Box
@@ -296,7 +266,6 @@ export default function ProjectHeader({ data, onReady }: ProjectHeaderProps) {
               ...headerTitleFontSizeSx(),
               lineHeight: 1.15,
               fontWeight: 700,
-              WebkitTextStroke: "1px #000000",
             }}
           >
             {data.title}
@@ -316,101 +285,6 @@ export default function ProjectHeader({ data, onReady }: ProjectHeaderProps) {
                 {line}
               </Typography>
             ))}
-          </Stack>
-          <Stack spacing={0.25} alignItems="center" sx={{ pt: 1 }}>
-            {recognition ? (
-              <>
-                <Box
-                  component="button"
-                  type="button"
-                  onClick={openRecognition}
-                  aria-label="View datathon recognition details"
-                  sx={{
-                    ...recognitionAwardButtonSx,
-                    display: "inline-flex",
-                    flexDirection: "column",
-                    alignItems: "center",
-                    gap: 0.25,
-                  }}
-                >
-                  <Typography
-                    component="span"
-                    sx={{
-                      color: "inherit",
-                      fontSize: HEADER_FONT_SIZE.award,
-                      lineHeight: 1.2,
-                      fontWeight: 500,
-                    }}
-                  >
-                    <Box component="span" sx={{ fontWeight: 700, mr: 0.5 }}>
-                      🏆
-                    </Box>
-                    {awardHeadlineLines[0]}
-                  </Typography>
-                  {awardHeadlineLines.slice(1).map((line) => (
-                    <Typography
-                      key={line}
-                      component="span"
-                      sx={{
-                        color: "inherit",
-                        fontSize: HEADER_FONT_SIZE.award,
-                        lineHeight: 1.2,
-                        fontWeight: 500,
-                      }}
-                    >
-                      {line}
-                    </Typography>
-                  ))}
-                </Box>
-                {viewRecognitionLine ? (
-                  <Box
-                    component="button"
-                    type="button"
-                    onClick={openRecognition}
-                    aria-label="View recognition"
-                    sx={{
-                      ...recognitionLinkSx,
-                      fontSize: HEADER_FONT_SIZE.award,
-                      lineHeight: 1.2,
-                      fontWeight: 500,
-                    }}
-                  >
-                    {viewRecognitionLine}
-                  </Box>
-                ) : null}
-              </>
-            ) : (
-              <>
-                <Typography
-                  component="p"
-                  sx={{
-                    color: "#02305d",
-                    fontSize: HEADER_FONT_SIZE.award,
-                    lineHeight: 1.2,
-                    fontWeight: 500,
-                  }}
-                >
-                  <Box component="span" sx={{ fontWeight: 700, mr: 0.5 }}>
-                    🏆
-                  </Box>
-                  {data.awardLines[0]}
-                </Typography>
-                {data.awardLines.slice(1).map((line) => (
-                  <Typography
-                    key={line}
-                    component="p"
-                    sx={{
-                      color: "#02305d",
-                      fontSize: HEADER_FONT_SIZE.award,
-                      lineHeight: 1.2,
-                      fontWeight: 500,
-                    }}
-                  >
-                    {line}
-                  </Typography>
-                ))}
-              </>
-            )}
           </Stack>
         </Stack>
         <Box sx={sceneStageShellSx()}>
@@ -485,14 +359,6 @@ export default function ProjectHeader({ data, onReady }: ProjectHeaderProps) {
           </Box>
         </Box>
       </Stack>
-      {recognition ? (
-        <RecognitionDialog
-          open={recognitionOpen}
-          onClose={closeRecognition}
-          title={recognitionDialogTitle}
-          data={recognition}
-        />
-      ) : null}
     </Box>
   );
 }

--- a/app/projects/finding-nemo/components/ProjectHeader.tsx
+++ b/app/projects/finding-nemo/components/ProjectHeader.tsx
@@ -11,6 +11,7 @@ import RecognitionDialog, {
 
 import {
   HEADER_BAND_COLOR,
+  HEADER_BAND_IMAGE,
   PROJECT_HEADER_EXTRA_TOP_PADDING,
   PROJECT_HEADER_NAV_CLEARANCE,
 } from "@/app/projects/finding-nemo/layoutConfig";
@@ -135,12 +136,44 @@ function sceneStageInnerSx(): SxProps<Theme> {
   };
 }
 
-/** Fluid type — min at ~360px viewport, max at tablet/desktop; scales between breakpoints. */
+/** Responsive type — aligned above sectionTitle (28 / 32 / 36). */
 const HEADER_FONT_SIZE = {
-  title: "clamp(28px, calc(22px + 1.47vw), 34px)",
-  subtitle: "clamp(18px, calc(15.5px + 0.68vw), 20px)",
+  title: {
+    mobile: "32px",
+    tablet: "40px",
+    desktop: "44px",
+  },
+  subtitle: {
+    mobile: "18px",
+    tablet: "20px",
+    desktop: "22px",
+  },
   award: "clamp(16px, calc(13.5px + 0.68vw), 18px)",
 } as const;
+
+function headerTitleFontSizeSx() {
+  return {
+    fontSize: HEADER_FONT_SIZE.title.mobile,
+    [breakpointMediaQuery.tabletUp]: {
+      fontSize: HEADER_FONT_SIZE.title.tablet,
+    },
+    [breakpointMediaQuery.desktopUp]: {
+      fontSize: HEADER_FONT_SIZE.title.desktop,
+    },
+  } as const;
+}
+
+function headerSubtitleFontSizeSx() {
+  return {
+    fontSize: HEADER_FONT_SIZE.subtitle.mobile,
+    [breakpointMediaQuery.tabletUp]: {
+      fontSize: HEADER_FONT_SIZE.subtitle.tablet,
+    },
+    [breakpointMediaQuery.desktopUp]: {
+      fontSize: HEADER_FONT_SIZE.subtitle.desktop,
+    },
+  } as const;
+}
 
 export default function ProjectHeader({ data, onReady }: ProjectHeaderProps) {
   const [recognitionOpen, setRecognitionOpen] = useState(false);
@@ -187,12 +220,35 @@ export default function ProjectHeader({ data, onReady }: ProjectHeaderProps) {
         bgcolor: HEADER_BAND_COLOR,
       }}
     >
+      <Box
+        aria-hidden
+        sx={{
+          position: "absolute",
+          inset: 0,
+          zIndex: 0,
+          pointerEvents: "none",
+        }}
+      >
+        <ProjectImage
+          objectPath={HEADER_BAND_IMAGE.objectPath}
+          alt=""
+          fill
+          priority
+          sizes="100vw"
+          style={{
+            objectFit: "cover",
+            objectPosition: "center",
+          }}
+        />
+      </Box>
       <Stack
         direction="column"
         alignItems="center"
         justifyContent="space-between"
         spacing={{ xs: 5, lg: 8 }}
         sx={{
+          position: "relative",
+          zIndex: 1,
           maxWidth: 1260,
           minHeight: { xs: "auto", lg: 450 },
           mx: "auto",
@@ -236,10 +292,10 @@ export default function ProjectHeader({ data, onReady }: ProjectHeaderProps) {
           <Typography
             component="h1"
             sx={{
-              color: "#022f5d",
-              fontSize: HEADER_FONT_SIZE.title,
+              color: "#FFFFFF",
+              ...headerTitleFontSizeSx(),
               lineHeight: 1.15,
-              fontWeight: 400,
+              fontWeight: 700,
               WebkitTextStroke: "1px #000000",
             }}
           >
@@ -251,10 +307,10 @@ export default function ProjectHeader({ data, onReady }: ProjectHeaderProps) {
                 key={line}
                 component="p"
                 sx={{
-                  color: "#02305d",
-                  fontSize: HEADER_FONT_SIZE.subtitle,
+                  color: "#FFFFFF",
+                  ...headerSubtitleFontSizeSx(),
                   lineHeight: 1.25,
-                  fontWeight: 500,
+                  fontWeight: 600,
                 }}
               >
                 {line}
@@ -421,6 +477,8 @@ export default function ProjectHeader({ data, onReady }: ProjectHeaderProps) {
                   display: "block",
                   width: "100%",
                   height: "auto",
+                  filter:
+                    "brightness(1.55) contrast(1.2) saturate(1.25) drop-shadow(0 0 6px rgba(120, 220, 255, 0.55))",
                 }}
               />
             </Box>

--- a/app/projects/finding-nemo/components/ProjectMetaBar.tsx
+++ b/app/projects/finding-nemo/components/ProjectMetaBar.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { Box, Container, Typography } from "@mui/material";
+
+import {
+  PROJECT_CONTENT_CONTAINER_SX,
+} from "@/app/projects/finding-nemo/layoutConfig";
+import {
+  FINDING_NEMO_HEADLINE_COLOR,
+  FINDING_NEMO_TITLE_FONT,
+} from "@/app/projects/finding-nemo/typography";
+import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
+import type { FindingNemoDataProjectDocument } from "@/scripts/project-2.data";
+
+export type ProjectMetaBarProps = {
+  items: FindingNemoDataProjectDocument["projectMetaBar"];
+  /** Opens the shared recognition dialog (Recognition column). */
+  onOpenRecognition?: () => void;
+};
+
+/**
+ * Meta strip under the hero banner — Role / Year / Team / Recognition.
+ */
+export default function ProjectMetaBar({
+  items,
+  onOpenRecognition,
+}: ProjectMetaBarProps) {
+  if (!items.length) return null;
+
+  return (
+    <Box
+      component="section"
+      aria-label="Project details"
+      sx={{
+        bgcolor: "#FFFFFF",
+        borderTop: "1px solid #E5E9EE",
+        width: "100%",
+      }}
+    >
+      <Container maxWidth={false} sx={PROJECT_CONTENT_CONTAINER_SX}>
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: "1fr",
+            columnGap: { xs: 3, md: 4, lg: 6 },
+            rowGap: { xs: 3, md: 3.5 },
+            py: { xs: 3.5, md: 4.5, lg: 5 },
+            [breakpointMediaQuery.tabletUp]: {
+              gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+            },
+            [breakpointMediaQuery.desktopUp]: {
+              gridTemplateColumns: "repeat(4, minmax(0, 1fr))",
+            },
+          }}
+        >
+          {items.map((item) => {
+            const isRecognition =
+              item.label.toLowerCase() === "recognition" && onOpenRecognition;
+
+            return (
+              <Box
+                key={item.label}
+                sx={{
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "flex-start",
+                  gap: 0.75,
+                  minWidth: 0,
+                }}
+              >
+                <Typography
+                  component="p"
+                  sx={{
+                    m: 0,
+                    fontFamily: FINDING_NEMO_TITLE_FONT,
+                    fontSize: { xs: "12px", md: "13px" },
+                    fontWeight: 500,
+                    letterSpacing: "0.08em",
+                    textTransform: "uppercase",
+                    lineHeight: 1.3,
+                  color: "#0B6E9F",
+                  opacity: 1,
+                }}
+              >
+                {item.label}
+              </Typography>
+                {isRecognition ? (
+                  <Box
+                    component="button"
+                    type="button"
+                    onClick={onOpenRecognition}
+                    aria-label="View datathon recognition details"
+                    sx={{
+                      m: 0,
+                      p: 0,
+                      border: "none",
+                      background: "none",
+                      cursor: "pointer",
+                      textAlign: "left",
+                      fontFamily: FINDING_NEMO_TITLE_FONT,
+                      fontSize: { xs: "15px", md: "16px" },
+                      fontWeight: 700,
+                      lineHeight: 1.35,
+                      color: "#0B6E9F",
+                      textDecoration: "underline",
+                      textDecorationColor: "rgba(11, 110, 159, 0.35)",
+                      textUnderlineOffset: "3px",
+                      "&:hover": {
+                        textDecorationColor: "#0B6E9F",
+                      },
+                      "&:focus-visible": {
+                        outline: "2px solid #0B6E9F",
+                        outlineOffset: 3,
+                        borderRadius: "4px",
+                      },
+                    }}
+                  >
+                    {item.value}
+                    <Box
+                      component="span"
+                      sx={{
+                        ml: 0.75,
+                        fontWeight: 500,
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      (View)
+                    </Box>
+                  </Box>
+                ) : (
+                  <Typography
+                    component="p"
+                    sx={{
+                      m: 0,
+                      fontFamily: FINDING_NEMO_TITLE_FONT,
+                      fontSize: { xs: "15px", md: "16px" },
+                      fontWeight: 700,
+                      lineHeight: 1.35,
+                      color: FINDING_NEMO_HEADLINE_COLOR,
+                    }}
+                  >
+                    {item.value}
+                  </Typography>
+                )}
+              </Box>
+            );
+          })}
+        </Box>
+      </Container>
+    </Box>
+  );
+}

--- a/app/projects/finding-nemo/components/SectionParagraph.tsx
+++ b/app/projects/finding-nemo/components/SectionParagraph.tsx
@@ -3,7 +3,7 @@ import { Stack, Typography } from "@mui/material";
 import {
   SECTION_TITLE_CONTENT_GAP,
 } from "@/app/projects/finding-nemo/layoutConfig";
-import { bodyTypeSx, titleTypeSx } from "@/app/projects/finding-nemo/typography";
+import { bodyTypeSx, titleTypeSx, FINDING_NEMO_HEADLINE_COLOR } from "@/app/projects/finding-nemo/typography";
 import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
 
 export type SectionParagraphProps = {
@@ -26,7 +26,7 @@ const sectionTitleSx = titleTypeSx("sectionTitle", {
 });
 
 const subtitleSx = titleTypeSx("sectionSubtitle", {
-  color: "common.black",
+  color: FINDING_NEMO_HEADLINE_COLOR,
   fontWeight: 700,
   lineHeight: 1.1,
 });

--- a/app/projects/finding-nemo/components/SectionParagraph.tsx
+++ b/app/projects/finding-nemo/components/SectionParagraph.tsx
@@ -73,7 +73,6 @@ export default function SectionParagraph({
               key={index}
               component="p"
               sx={bodyTypeSx("sectionDescription", {
-                color: "common.black",
                 fontWeight: 400,
                 lineHeight: 1.5,
                 m: 0,

--- a/app/projects/finding-nemo/components/SolutionOverviewSection.tsx
+++ b/app/projects/finding-nemo/components/SolutionOverviewSection.tsx
@@ -1,0 +1,209 @@
+import { Box, Container, Stack, Typography } from "@mui/material";
+
+import {
+  INTRO_SECTIONS_BACKGROUND,
+  PROJECT_CONTENT_CONTAINER_SX,
+  SOLUTION_OVERVIEW_IMAGE_DISPLAY,
+  sectionTitleContentGapMbSx,
+} from "@/app/projects/finding-nemo/layoutConfig";
+import {
+  bodyTypeSx,
+  FINDING_NEMO_HEADLINE_COLOR,
+  FINDING_NEMO_TITLE_FONT,
+  TYPOGRAPHY,
+  titleTypeSx,
+} from "@/app/projects/finding-nemo/typography";
+import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
+import ProjectImageLightbox from "@/lib/media/ProjectImageLightbox";
+import type { FindingNemoDataProjectDocument } from "@/scripts/project-2.data";
+
+type SolutionOverviewSectionProps = {
+  data: FindingNemoDataProjectDocument["solutionOverview"];
+};
+
+const SOLUTION_OVERVIEW_LIGHTBOX_ID = "finding-nemo-solution-overview";
+const SOLUTION_OVERVIEW_LIGHTBOX_SIDEBAR_WIDTH_PX = 520;
+
+const sectionLabelSx = {
+  fontFamily: FINDING_NEMO_TITLE_FONT,
+  fontSize: TYPOGRAPHY.heroSubtitle.mobile,
+  fontWeight: 500,
+  color: "#0B6E9F",
+  lineHeight: 1.2,
+  mb: 1.5,
+  textTransform: "uppercase",
+  letterSpacing: "0.04em",
+  [breakpointMediaQuery.tabletUp]: {
+    fontSize: TYPOGRAPHY.heroSubtitle.tablet,
+  },
+  [breakpointMediaQuery.desktopUp]: {
+    fontSize: "22px",
+  },
+} as const;
+
+export default function SolutionOverviewSection({
+  data,
+}: SolutionOverviewSectionProps) {
+  return (
+    <Box
+      component="section"
+      sx={{
+        bgcolor: INTRO_SECTIONS_BACKGROUND,
+        pb: { xs: 8, md: 10, lg: 12 },
+      }}
+    >
+      <Container maxWidth={false} sx={PROJECT_CONTENT_CONTAINER_SX}>
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: "1fr",
+            alignItems: "center",
+            gap: { xs: 6, md: 8 },
+            [breakpointMediaQuery.desktopUp]: {
+              gridTemplateColumns: "minmax(0, 3fr) minmax(280px, 2fr)",
+              gap: 8,
+            },
+          }}
+        >
+          <Box sx={{ width: "100%", minWidth: 0 }}>
+            <Stack sx={sectionTitleContentGapMbSx}>
+              <Typography component="p" align="left" sx={sectionLabelSx}>
+                {data.subtitle}
+              </Typography>
+              <Typography
+                component="h2"
+                align="left"
+                sx={titleTypeSx("sectionTitle", {
+                  color: FINDING_NEMO_HEADLINE_COLOR,
+                  fontWeight: 700,
+                  lineHeight: 1.2,
+                })}
+              >
+                {data.overviewTitle}
+              </Typography>
+            </Stack>
+            <Stack spacing={{ xs: 2.5, md: 3 }}>
+              {data.paragraphs.map((paragraph) => (
+                <Typography
+                  key={paragraph}
+                  component="p"
+                  sx={bodyTypeSx("sectionDescription", {
+                    fontWeight: 400,
+                    lineHeight: 1.5,
+                    m: 0,
+                  })}
+                >
+                  {paragraph}
+                </Typography>
+              ))}
+            </Stack>
+          </Box>
+
+          <Stack
+            component="figure"
+            alignItems="center"
+            spacing={{ xs: 2, md: 2.5 }}
+            sx={{ m: 0, width: "100%" }}
+          >
+            <Box
+              sx={{
+                width: `${SOLUTION_OVERVIEW_IMAGE_DISPLAY.mobile.width}px`,
+                maxWidth: "100%",
+                [breakpointMediaQuery.tabletUp]: {
+                  width: `${SOLUTION_OVERVIEW_IMAGE_DISPLAY.tablet.width}px`,
+                },
+                [breakpointMediaQuery.desktopUp]: {
+                  width: `${SOLUTION_OVERVIEW_IMAGE_DISPLAY.desktop.width}px`,
+                },
+              }}
+            >
+              <ProjectImageLightbox
+                objectPath={data.image.objectPath}
+                alt={data.image.alt}
+                lightboxId={SOLUTION_OVERVIEW_LIGHTBOX_ID}
+                width={data.image.width}
+                height={data.image.height}
+                lightboxSidebarPlacement="left"
+                lightboxSidebarWidthPx={SOLUTION_OVERVIEW_LIGHTBOX_SIDEBAR_WIDTH_PX}
+                lightboxSidebar={
+                  data.image.lightboxAnnotation ? (
+                    <Box
+                      component="aside"
+                      sx={{
+                        width: "100%",
+                        boxSizing: "border-box",
+                        display: "flex",
+                        justifyContent: "flex-end",
+                        px: { xs: 4, lg: 5 },
+                      }}
+                    >
+                      <Stack
+                        sx={{
+                          width: 400,
+                          maxWidth: "100%",
+                        }}
+                      >
+                        <Stack sx={sectionTitleContentGapMbSx}>
+                          <Typography
+                            component="p"
+                            align="left"
+                            sx={sectionLabelSx}
+                          >
+                            {data.subtitle}
+                          </Typography>
+                          <Typography
+                            component="h2"
+                            align="left"
+                            sx={titleTypeSx("sectionTitle", {
+                              color: FINDING_NEMO_HEADLINE_COLOR,
+                              fontWeight: 700,
+                              lineHeight: 1.2,
+                            })}
+                          >
+                            {data.overviewTitle}
+                          </Typography>
+                        </Stack>
+                        <Typography
+                          component="p"
+                          sx={bodyTypeSx("contentCardBody", {
+                            color: FINDING_NEMO_HEADLINE_COLOR,
+                            fontWeight: 400,
+                            lineHeight: 1.6,
+                            textAlign: "left",
+                            m: 0,
+                          })}
+                        >
+                          {data.image.lightboxAnnotation}
+                        </Typography>
+                      </Stack>
+                    </Box>
+                  ) : undefined
+                }
+                style={{
+                  display: "block",
+                  width: "100%",
+                  height: "auto",
+                  maxWidth: "100%",
+                }}
+              />
+            </Box>
+            {data.image.annotation ? (
+              <Typography
+                component="figcaption"
+                sx={bodyTypeSx("smallCaption", {
+                  fontWeight: 400,
+                  lineHeight: 1.5,
+                  textAlign: "center",
+                  m: 0,
+                  maxWidth: 440,
+                })}
+              >
+                {data.image.annotation}
+              </Typography>
+            ) : null}
+          </Stack>
+        </Box>
+      </Container>
+    </Box>
+  );
+}

--- a/app/projects/finding-nemo/components/StageInfoCardsRow.tsx
+++ b/app/projects/finding-nemo/components/StageInfoCardsRow.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Box, List, ListItem, Typography } from "@mui/material";
+import type { SxProps, Theme } from "@mui/material/styles";
+
+import { IDENTIFY_AI_OPPORTUNITY_CARD } from "@/app/projects/finding-nemo/layoutConfig";
+import { interactiveCardHoverSx } from "@/app/projects/finding-nemo/components/interactiveCardStyles";
+import { bodyTypeSx, titleTypeSx } from "@/app/projects/finding-nemo/typography";
+import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
+
+const CARD_REVEAL_STAGGER_MS = 90;
+
+export type StageInfoCardItem = {
+  title: string;
+  description: string | string[];
+};
+
+export type StageInfoCardWidths = {
+  mobile: number;
+  tablet: number;
+  desktop: number;
+};
+
+type StageInfoCardsRowProps = {
+  cards: StageInfoCardItem[];
+  /** Defaults to Business Opportunities orange title color. */
+  titleColor?: string;
+  /** Defaults to Stage 01 card widths; override for wider Primary Users cards. */
+  widthPx?: StageInfoCardWidths;
+  /** Keep cards centered at all breakpoints (matches Personas row). */
+  centered?: boolean;
+  sx?: SxProps<Theme>;
+};
+
+function buildCardsRowSx(centered: boolean) {
+  return {
+    width: "100%",
+    display: "flex",
+    flexDirection: "row",
+    flexWrap: "wrap",
+    alignItems: "stretch",
+    justifyContent: "center",
+    gap: `${IDENTIFY_AI_OPPORTUNITY_CARD.gap.mobile}px`,
+    [breakpointMediaQuery.tabletUp]: {
+      justifyContent: centered ? "center" : "flex-start",
+      gap: `${IDENTIFY_AI_OPPORTUNITY_CARD.gap.tablet}px`,
+    },
+    [breakpointMediaQuery.desktopUp]: {
+      gap: `${IDENTIFY_AI_OPPORTUNITY_CARD.gap.desktop}px`,
+    },
+  } as const;
+}
+
+function buildCardShellSx(widthPx: StageInfoCardWidths) {
+  return {
+    flex: "0 1 auto",
+    width: widthPx.mobile,
+    maxWidth: "100%",
+    boxSizing: "border-box",
+    borderRadius: `${IDENTIFY_AI_OPPORTUNITY_CARD.borderRadiusPx}px`,
+    bgcolor: IDENTIFY_AI_OPPORTUNITY_CARD.background,
+    border: `1px solid ${IDENTIFY_AI_OPPORTUNITY_CARD.border}`,
+    px: { xs: 2.5, md: 3 },
+    py: { xs: 2.5, md: 3 },
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "flex-start",
+    gap: 1.5,
+    [breakpointMediaQuery.tabletUp]: {
+      width: widthPx.tablet,
+    },
+    [breakpointMediaQuery.desktopUp]: {
+      width: widthPx.desktop,
+    },
+  } as const;
+}
+
+/**
+ * Compact fixed-width info cards used by Business Opportunities, challenge cards,
+ * and Primary Users — wrapping row, orange titles, left-aligned body.
+ */
+export default function StageInfoCardsRow({
+  cards,
+  titleColor = IDENTIFY_AI_OPPORTUNITY_CARD.opportunityTitleColor,
+  widthPx = IDENTIFY_AI_OPPORTUNITY_CARD.widthPx,
+  centered = false,
+  sx,
+}: StageInfoCardsRowProps) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [inView, setInView] = useState(false);
+  const cardShellSx = buildCardShellSx(widthPx);
+  const cardsRowSx = buildCardsRowSx(centered);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setInView(true);
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      {
+        root: null,
+        threshold: 0.12,
+        rootMargin: "0px 0px -10% 0px",
+      },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <Box ref={ref} sx={[cardsRowSx, ...(sx ? [sx] : [])] as SxProps<Theme>}>
+      {cards.map((card, index) => {
+        const bulletItems = Array.isArray(card.description)
+          ? card.description
+          : null;
+
+        return (
+          <Box
+            key={card.title}
+            sx={{
+              opacity: inView ? 1 : 0,
+              transform: inView ? "translateY(0)" : "translateY(24px)",
+              transition: "opacity 0.6s ease-out, transform 0.6s ease-out",
+              transitionDelay: inView
+                ? `${index * CARD_REVEAL_STAGGER_MS}ms`
+                : "0ms",
+            }}
+          >
+            <Box
+              component="article"
+              sx={{
+                ...cardShellSx,
+                height: "100%",
+                ...interactiveCardHoverSx,
+                "&:hover": {
+                  ...interactiveCardHoverSx["&:hover"],
+                  bgcolor: IDENTIFY_AI_OPPORTUNITY_CARD.background,
+                  backgroundColor: IDENTIFY_AI_OPPORTUNITY_CARD.background,
+                },
+              }}
+            >
+            <Typography
+              component="h3"
+              sx={[
+                titleTypeSx("contentCardTitle", {
+                  fontWeight: 700,
+                  lineHeight: 1.2,
+                  m: 0,
+                }),
+                { color: titleColor },
+              ]}
+            >
+              {card.title}
+            </Typography>
+            {bulletItems ? (
+              <List
+                sx={{
+                  width: "100%",
+                  my: 0,
+                  p: 0,
+                  listStyleType: "disc",
+                  listStylePosition: "outside",
+                  pl: 2.5,
+                }}
+              >
+                {bulletItems.map((item) => (
+                  <ListItem
+                    key={item}
+                    disableGutters
+                    sx={
+                      [
+                        {
+                          display: "list-item",
+                          py: 0.25,
+                        },
+                        bodyTypeSx("contentCardBody", {
+                          lineHeight: 1.55,
+                          fontWeight: 400,
+                        }),
+                      ] as SxProps<Theme>
+                    }
+                  >
+                    <Typography
+                      component="span"
+                      sx={{
+                        fontSize: "inherit",
+                        lineHeight: "inherit",
+                        color: "inherit",
+                        fontFamily: "inherit",
+                        fontWeight: 400,
+                      }}
+                    >
+                      {item}
+                    </Typography>
+                  </ListItem>
+                ))}
+              </List>
+            ) : (
+              <Typography
+                component="p"
+                sx={bodyTypeSx("contentCardBody", {
+                  fontWeight: 400,
+                  lineHeight: 1.5,
+                  textAlign: "left",
+                  m: 0,
+                })}
+              >
+                {card.description}
+              </Typography>
+            )}
+            </Box>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}

--- a/app/projects/finding-nemo/components/StageInfoCardsRow.tsx
+++ b/app/projects/finding-nemo/components/StageInfoCardsRow.tsx
@@ -151,7 +151,7 @@ export default function StageInfoCardsRow({
             <Typography
               component="h3"
               sx={[
-                titleTypeSx("contentCardTitle", {
+                titleTypeSx("kpiCardTitle", {
                   fontWeight: 700,
                   lineHeight: 1.2,
                   m: 0,

--- a/app/projects/finding-nemo/components/StageInfoCardsRow.tsx
+++ b/app/projects/finding-nemo/components/StageInfoCardsRow.tsx
@@ -30,6 +30,8 @@ type StageInfoCardsRowProps = {
   widthPx?: StageInfoCardWidths;
   /** Keep cards centered at all breakpoints (matches Personas row). */
   centered?: boolean;
+  /** Reserve a consistent number of title lines across every card. */
+  titleMinLines?: number;
   sx?: SxProps<Theme>;
 };
 
@@ -85,6 +87,7 @@ export default function StageInfoCardsRow({
   titleColor = IDENTIFY_AI_OPPORTUNITY_CARD.opportunityTitleColor,
   widthPx = IDENTIFY_AI_OPPORTUNITY_CARD.widthPx,
   centered = false,
+  titleMinLines,
   sx,
 }: StageInfoCardsRowProps) {
   const ref = useRef<HTMLDivElement | null>(null);
@@ -156,7 +159,12 @@ export default function StageInfoCardsRow({
                   lineHeight: 1.2,
                   m: 0,
                 }),
-                { color: titleColor },
+                {
+                  color: titleColor,
+                  minHeight: titleMinLines
+                    ? `${titleMinLines * 1.2}em`
+                    : undefined,
+                },
               ]}
             >
               {card.title}

--- a/app/projects/finding-nemo/components/StageSectionHeader.tsx
+++ b/app/projects/finding-nemo/components/StageSectionHeader.tsx
@@ -4,7 +4,11 @@ import {
   PANEL_CONTENT_MAX_WIDTH_PX,
   sectionTitleContentGapMbSx,
 } from "@/app/projects/finding-nemo/layoutConfig";
-import { bodyTypeSx, titleTypeSx } from "@/app/projects/finding-nemo/typography";
+import {
+  bodyTypeSx,
+  FINDING_NEMO_HEADLINE_COLOR,
+  titleTypeSx,
+} from "@/app/projects/finding-nemo/typography";
 import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
 
 export type StageSectionHeaderProps = {
@@ -33,7 +37,7 @@ const sectionLabelSx = [
 
 const sectionHeadlineSx = titleTypeSx("sectionTitle", {
   fontWeight: 700,
-  color: "#073B5E",
+  color: FINDING_NEMO_HEADLINE_COLOR,
   lineHeight: 1.2,
 });
 
@@ -54,7 +58,7 @@ export default function StageSectionHeader({
         maxWidth: constrainIntroWidth ? PANEL_CONTENT_MAX_WIDTH_PX : "none",
       }}
     >
-      <Stack sx={sectionTitleContentGapMbSx}>
+      <Stack sx={paragraphs.length > 0 ? sectionTitleContentGapMbSx : undefined}>
         {sectionLabel ? (
           <Typography component="p" align="left" sx={sectionLabelSx}>
             {sectionLabel}

--- a/app/projects/finding-nemo/components/StageSectionHeader.tsx
+++ b/app/projects/finding-nemo/components/StageSectionHeader.tsx
@@ -1,0 +1,87 @@
+import { Stack, Typography } from "@mui/material";
+
+import {
+  PANEL_CONTENT_MAX_WIDTH_PX,
+  sectionTitleContentGapMbSx,
+} from "@/app/projects/finding-nemo/layoutConfig";
+import { bodyTypeSx, titleTypeSx } from "@/app/projects/finding-nemo/typography";
+import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
+
+export type StageSectionHeaderProps = {
+  sectionLabel?: string;
+  title: string;
+  paragraphs?: string[];
+  /** Cap intro copy width (default 1100px). Set false for full content width. */
+  constrainIntroWidth?: boolean;
+};
+
+const sectionLabelSx = [
+  titleTypeSx("heroSubtitle", {
+    fontWeight: 500,
+    color: "#0B6E9F",
+    lineHeight: 1.2,
+    mb: 1.5,
+    textTransform: "uppercase",
+    letterSpacing: "0.04em",
+  }),
+  {
+    [breakpointMediaQuery.desktopUp]: {
+      fontSize: "22px",
+    },
+  },
+] as const;
+
+const sectionHeadlineSx = titleTypeSx("sectionTitle", {
+  fontWeight: 700,
+  color: "#073B5E",
+  lineHeight: 1.2,
+});
+
+/**
+ * Shared stage header used across Finding Nemo numbered stages
+ * (STAGE 01, STAGE 02, …): label + title + optional intro paragraphs.
+ */
+export default function StageSectionHeader({
+  sectionLabel,
+  title,
+  paragraphs = [],
+  constrainIntroWidth = true,
+}: StageSectionHeaderProps) {
+  return (
+    <Stack
+      sx={{
+        width: "100%",
+        maxWidth: constrainIntroWidth ? PANEL_CONTENT_MAX_WIDTH_PX : "none",
+      }}
+    >
+      <Stack sx={sectionTitleContentGapMbSx}>
+        {sectionLabel ? (
+          <Typography component="p" align="left" sx={sectionLabelSx}>
+            {sectionLabel}
+          </Typography>
+        ) : null}
+        <Typography component="h2" align="left" sx={sectionHeadlineSx}>
+          {title}
+        </Typography>
+      </Stack>
+      {paragraphs.length > 0 ? (
+        <Stack spacing={{ xs: 2.5, md: 3.5 }} component="article">
+          {paragraphs.map((paragraph, index) => (
+            <Typography
+              key={index}
+              component="p"
+              sx={bodyTypeSx("sectionDescription", {
+                fontWeight: 400,
+                lineHeight: 1.5,
+                textAlign: "left",
+                m: 0,
+              })}
+            >
+              {paragraph}
+            </Typography>
+          ))}
+        </Stack>
+      ) : null}
+    </Stack>
+  );
+}

--- a/app/projects/finding-nemo/footerTheme.ts
+++ b/app/projects/finding-nemo/footerTheme.ts
@@ -1,0 +1,12 @@
+import type { ProjectFooterTheme } from "@/components/Footer/FooterState";
+
+import { BAND_COLORS } from "@/app/projects/finding-nemo/layoutConfig";
+
+/**
+ * Footer blends into the final full-bleed band
+ * (Expected Impact + Reflections & Key Learnings).
+ */
+export const FINDING_NEMO_FOOTER_THEME: ProjectFooterTheme = {
+  isDark: false,
+  backgroundColor: BAND_COLORS.expectedImpactAndReflections,
+};

--- a/app/projects/finding-nemo/headerTheme.ts
+++ b/app/projects/finding-nemo/headerTheme.ts
@@ -1,3 +1,4 @@
+import type { ProjectHeaderTheme } from "@/components/Header/HeaderState";
 import { HEADER_LOGO_DEFAULT_COLORS } from "@/components/Header/HeaderLogo";
 
 import { HEADER_BAND_COLOR } from "./layoutConfig";
@@ -5,8 +6,21 @@ import { HEADER_BAND_COLOR } from "./layoutConfig";
 /** Header band + nav overlay colors while the Finding Nemo case study is mounted. */
 export const FINDING_NEMO_HEADER_BAND_COLOR = HEADER_BAND_COLOR;
 
-/** Default brand logo on the light blue hero band (`isDark: false`). */
+/**
+ * Global top nav overrides while Finding Nemo is mounted.
+ * Absolute + transparent over the hero image; `isDark: true` forces white nav text.
+ */
+export const FINDING_NEMO_HEADER_THEME: ProjectHeaderTheme = {
+  position: "absolute",
+  isDark: true,
+  logoPrimaryColor: "#FFFFFF",
+  logoAccentColor: HEADER_LOGO_DEFAULT_COLORS.accent,
+  backgroundColor: "transparent",
+};
+
+/** @deprecated Prefer `FINDING_NEMO_HEADER_THEME` logo fields. */
 export const FINDING_NEMO_HEADER_LOGO = {
-  primary: HEADER_LOGO_DEFAULT_COLORS.primary,
-  accent: HEADER_LOGO_DEFAULT_COLORS.accent,
+  primary: FINDING_NEMO_HEADER_THEME.logoPrimaryColor ?? "#FFFFFF",
+  accent:
+    FINDING_NEMO_HEADER_THEME.logoAccentColor ?? HEADER_LOGO_DEFAULT_COLORS.accent,
 } as const;

--- a/app/projects/finding-nemo/layoutConfig.ts
+++ b/app/projects/finding-nemo/layoutConfig.ts
@@ -107,7 +107,7 @@ export const BAND_COLORS = {
   /** White inset / neutral full-bleed bands */
   neutralPanel: "#FFFFFF",
   /** `01 - Identify the AI Opportunity` */
-  identifyAiOpportunity: "#FFFFFF",
+  identifyAiOpportunity: "#EEF2F6",
   /** `02 - Define the AI-Assisted Solution` */
   defineAiSolution: "#EEF3F9",
   /** `04 — Design the Decision Support Experience` */
@@ -148,21 +148,45 @@ export const DEFINING_SUCCESS_KPI_CARD = {
   background: "#E6F1FF",
 } as const;
 
-/**
- * Four-stage framework cards (`Designing Human-Centered AI`).
- * 250×297px at all breakpoints so copy is not clipped on mobile.
- */
-export const HUMAN_CENTERED_AI_FRAMEWORK_CARD = {
-  mobile: { width: 250, height: 297 },
-  tablet: { width: 250, height: 297 },
-  desktop: { width: 250, height: 297 },
+/** Stage 01 challenge + opportunity cards (`Identify the AI Opportunity`). */
+export const IDENTIFY_AI_OPPORTUNITY_CARD = {
+  background: "#FFFFFF",
+  border: "#D5DCE3",
+  challengeTitleColor: "#073B5E",
+  opportunityTitleColor: "#E89B0C",
+  bodyColor: "#3F5266",
+  borderRadiusPx: 16,
+  widthPx: {
+    mobile: 360,
+    tablet: 280,
+    desktop: 300,
+  },
+  gap: { mobile: 16, tablet: 20, desktop: 24 },
 } as const;
 
-/** Gaps between framework cards — mobile 16px; tablet 32px; desktop 16–32px (uses 32px). */
+/**
+ * Four-stage framework cards (`Designing Human-Centered AI`).
+ * Fixed widths match Stage 01 cards; wrap in a row on wider viewports.
+ */
+export const HUMAN_CENTERED_AI_FRAMEWORK_CARD = {
+  background: "#FFFFFF",
+  border: "#D5DCE3",
+  numberColor: "#E89B0C",
+  titleColor: "#073B5E",
+  bodyColor: "#3F5266",
+  borderRadiusPx: 16,
+  widthPx: {
+    mobile: 360,
+    tablet: 280,
+    desktop: 300,
+  },
+} as const;
+
+/** Gaps between framework cards — mobile 16px; tablet 20px; desktop 24px. */
 export const HUMAN_CENTERED_AI_FRAMEWORK_CARD_GAP = {
   mobile: 16,
-  tablet: 32,
-  desktop: 32,
+  tablet: 20,
+  desktop: 24,
 } as const;
 
 /** Inset panel shell backgrounds (white panels inside full-bleed bands). */

--- a/app/projects/finding-nemo/layoutConfig.ts
+++ b/app/projects/finding-nemo/layoutConfig.ts
@@ -108,6 +108,8 @@ export const BAND_COLORS = {
   neutralPanel: "#FFFFFF",
   /** `01 - Identify the AI Opportunity` */
   identifyAiOpportunity: "#EEF2F6",
+  /** `03 - AI Technology & MVP Architecture` — same band as Stage 01 */
+  aiTechnologyMvpArchitecture: "#EEF2F6",
   /** `02 - Define the AI-Assisted Solution` */
   defineAiSolution: "#FFFFFF",
   /** `04 — Design the Decision Support Experience` */

--- a/app/projects/finding-nemo/layoutConfig.ts
+++ b/app/projects/finding-nemo/layoutConfig.ts
@@ -113,7 +113,7 @@ export const BAND_COLORS = {
   /** `02 - Define the AI-Assisted Solution` */
   defineAiSolution: "#FFFFFF",
   /** `04 — Design the Decision Support Experience` */
-  designDecisionSupportExperience: "#EEF3F9",
+  designDecisionSupportExperience: "#FFFFFF",
   /** Expected Impact + Reflections & Key Learnings */
   expectedImpactAndReflections: "#FFFFFF",
 } as const;

--- a/app/projects/finding-nemo/layoutConfig.ts
+++ b/app/projects/finding-nemo/layoutConfig.ts
@@ -122,12 +122,22 @@ export const BAND_COLORS = {
  */
 export const INTRO_SECTIONS_BACKGROUND = "#ffffff" as const;
 
-/** Inset card shell for the My Contributions block. */
+/** Inset card shell for the My Contributions block (legacy card surfaces). */
 export const MY_CONTRIBUTIONS_CARD = {
   background: "#F6FBFF",
   paddingPx: 64,
   maxWidthPx: 600,
   borderRadiusPx: 32,
+} as const;
+
+/** Full-bleed band + contribution tag chips for My Contributions. */
+export const MY_CONTRIBUTIONS_BAND = {
+  background: "#EEF2F6",
+  tagBackground: "#FFFFFF",
+  tagBorder: "#D5DCE3",
+  tagText: "#1F3347",
+  titleColor: "#0B6E9F",
+  tagGap: { mobile: 12, tablet: 14, desktop: 16 },
 } as const;
 
 /**
@@ -191,16 +201,15 @@ export const PROBLEM_DEMO_CAROUSEL_IMAGE_DISPLAY = {
 /** Inset panel background for the problem demo carousel section. */
 export const PROBLEM_DEMO_PANEL_BACKGROUND = MY_CONTRIBUTIONS_CARD.background;
 
-/** Problem demo panel — copy column width when side-by-side at desktop (1260px+). */
+/** Problem demo panel — min copy column width when side-by-side at desktop (1024px+). */
 export const PROBLEM_DEMO_PANEL_COPY_WIDTH = {
-  desktop: 330,
+  desktop: 360,
 } as const;
 
-/** Gap between copy and carousel — stacked (vertical) vs side-by-side (horizontal at 1260px+). */
+/** Gap between copy and carousel — stacked (vertical) vs side-by-side (horizontal at desktop). */
 export const PROBLEM_DEMO_PANEL_GAP = {
   stacked: 64,
-  /** Fits copy (306) + carousel (450) inside 920px panel with md horizontal padding. */
-  sideBySide: 36,
+  sideBySide: 48,
 } as const;
 
 /**
@@ -255,10 +264,11 @@ export const PROBLEM_DEMO_CAROUSEL_CAPTION_FONT_SIZE = {
  * Side-by-side copy + carousel only at this viewport width and above
  * (matches `LAYOUT_DIMENSIONS.desktop.maxWidth`).
  */
-export const PROBLEM_DEMO_PANEL_SIDE_BY_SIDE_MIN_WIDTH_PX = 1260 as const;
+/** @deprecated Prefer `breakpointMediaQuery.desktopUp` — kept for any remaining references. */
+export const PROBLEM_DEMO_PANEL_SIDE_BY_SIDE_MIN_WIDTH_PX = 1024 as const;
 
 /** Copy column minimum width when side-by-side at the desktop band. */
-export const PROBLEM_DEMO_PANEL_COPY_MIN_WIDTH_PX = 295 as const;
+export const PROBLEM_DEMO_PANEL_COPY_MIN_WIDTH_PX = 320 as const;
 
 /**
  * Solution overview hi-fi mockup display (402:874 intrinsic aspect ratio).

--- a/app/projects/finding-nemo/layoutConfig.ts
+++ b/app/projects/finding-nemo/layoutConfig.ts
@@ -185,7 +185,7 @@ export const PRIMARY_USERS_CARD = {
 
 /**
  * Four-stage framework cards (`Designing Human-Centered AI`).
- * Fixed widths match Stage 01 cards; wrap in a row on wider viewports.
+ * Desktop uses a 4-column grid so all cards share one row within the content band.
  */
 export const HUMAN_CENTERED_AI_FRAMEWORK_CARD = {
   background: "#FFFFFF",
@@ -197,7 +197,8 @@ export const HUMAN_CENTERED_AI_FRAMEWORK_CARD = {
   widthPx: {
     mobile: 360,
     tablet: 280,
-    desktop: 300,
+    /** Unused on desktop — cards fill equal grid columns. */
+    desktop: 257,
   },
 } as const;
 
@@ -315,12 +316,12 @@ export const PROBLEM_DEMO_PANEL_COPY_MIN_WIDTH_PX = 320 as const;
 
 /**
  * Solution overview hi-fi mockup display (402:874 intrinsic aspect ratio).
- * Desktop width scaled +30% from legacy 211px frame; tablet +30% from 190px; mobile ~75%.
+ * Kept compact beside the narrative so the figure remains proportional to the copy column.
  */
 export const SOLUTION_OVERVIEW_IMAGE_DISPLAY = {
-  mobile: { width: 158, height: 343 },
-  tablet: { width: 284, height: 618 },
-  desktop: { width: 315, height: 685 },
+  mobile: { width: 165, height: 359 },
+  tablet: { width: 209, height: 454 },
+  desktop: { width: 220, height: 478 },
 } as const;
 
 /** Mobile experience mockup display — phone mockup row (402:874 hi-fi assets). */

--- a/app/projects/finding-nemo/layoutConfig.ts
+++ b/app/projects/finding-nemo/layoutConfig.ts
@@ -109,7 +109,7 @@ export const BAND_COLORS = {
   /** `01 - Identify the AI Opportunity` */
   identifyAiOpportunity: "#EEF2F6",
   /** `02 - Define the AI-Assisted Solution` */
-  defineAiSolution: "#EEF3F9",
+  defineAiSolution: "#FFFFFF",
   /** `04 — Design the Decision Support Experience` */
   designDecisionSupportExperience: "#EEF3F9",
   /** Expected Impact + Reflections & Key Learnings */
@@ -135,7 +135,7 @@ export const MY_CONTRIBUTIONS_BAND = {
   background: "#EEF2F6",
   tagBackground: "#FFFFFF",
   tagBorder: "#D5DCE3",
-  tagText: "#1F3347",
+  tagText: "#3F5266",
   titleColor: "#0B6E9F",
   tagGap: { mobile: 12, tablet: 14, desktop: 16 },
 } as const;
@@ -162,6 +162,17 @@ export const IDENTIFY_AI_OPPORTUNITY_CARD = {
     desktop: 300,
   },
   gap: { mobile: 16, tablet: 20, desktop: 24 },
+} as const;
+
+/**
+ * Primary Users cards — match Persona card width (490px).
+ */
+export const PRIMARY_USERS_CARD = {
+  widthPx: {
+    mobile: 490,
+    tablet: 490,
+    desktop: 490,
+  },
 } as const;
 
 /**

--- a/app/projects/finding-nemo/layoutConfig.ts
+++ b/app/projects/finding-nemo/layoutConfig.ts
@@ -80,6 +80,12 @@ export const PANEL_BLOCK_PADDINGS = {
 /** Project hero band behind the absolute global nav (overlay model). */
 export const HEADER_BAND_COLOR = "#dde8f2" as const;
 
+/** Full-bleed hero band image (covers `HEADER_BAND_COLOR` while loading). */
+export const HEADER_BAND_IMAGE = {
+  objectPath: "projects/project_2/FindingNemoBannerImage.png",
+  alt: "Finding Nemo case study hero background",
+} as const;
+
 /**
  * Vertical clearance under the global top bar when `headerState.position` is
  * `"absolute"` (AR Story Teller overlay model).
@@ -114,8 +120,8 @@ export const BAND_COLORS = {
   defineAiSolution: "#FFFFFF",
   /** `04 — Design the Decision Support Experience` */
   designDecisionSupportExperience: "#FFFFFF",
-  /** Expected Impact + Reflections & Key Learnings */
-  expectedImpactAndReflections: "#FFFFFF",
+  /** Expected Impact + Reflections & Key Learnings — same as Stage 03 */
+  expectedImpactAndReflections: "#EEF2F6",
 } as const;
 
 /**

--- a/app/projects/finding-nemo/typography.ts
+++ b/app/projects/finding-nemo/typography.ts
@@ -10,6 +10,9 @@ export const FINDING_NEMO_TITLE_FONT =
 export const FINDING_NEMO_BODY_FONT =
   'var(--font-source-sans-3), "Source Sans 3", system-ui, sans-serif';
 
+/** Default color for body / paragraph copy across the Finding Nemo case study. */
+export const FINDING_NEMO_BODY_COLOR = "#3F5266";
+
 /**
  * Finding Nemo responsive type scale (px).
  * Breakpoints match `styles/variables.scss` / `lib/responsive/breakpoints.ts`.
@@ -76,7 +79,9 @@ export function bodyTypeSx(
     },
   };
 
-  if (!extra) return responsive;
+  if (!extra) {
+    return { ...responsive, color: FINDING_NEMO_BODY_COLOR };
+  }
 
-  return { ...extra, ...responsive };
+  return { ...extra, ...responsive, color: FINDING_NEMO_BODY_COLOR };
 }

--- a/app/projects/finding-nemo/typography.ts
+++ b/app/projects/finding-nemo/typography.ts
@@ -13,6 +13,9 @@ export const FINDING_NEMO_BODY_FONT =
 /** Default color for body / paragraph copy across the Finding Nemo case study. */
 export const FINDING_NEMO_BODY_COLOR = "#3F5266";
 
+/** Headline / subtitle color (matches stage titles like “AI Technology & MVP Architecture”). */
+export const FINDING_NEMO_HEADLINE_COLOR = "#073B5E";
+
 /**
  * Finding Nemo responsive type scale (px).
  * Breakpoints match `styles/variables.scss` / `lib/responsive/breakpoints.ts`.
@@ -33,8 +36,8 @@ export const TYPOGRAPHY = {
   personaSectionTitle: { mobile: "17px", tablet: "19px", desktop: "20px" },
   /** `Persona` role description — Source Sans 3, fixed 16px all breakpoints. */
   personaRoleDescription: { mobile: "16px", tablet: "16px", desktop: "16px" },
-  /** `KpiCard` title — IBM Plex Sans Semibold. */
-  kpiCardTitle: { mobile: "18px", tablet: "19px", desktop: "20px" },
+  /** `KpiCard` title — IBM Plex Sans Bold; sits under row subtitles (e.g. AI Performance). */
+  kpiCardTitle: { mobile: "16px", tablet: "17px", desktop: "18px" },
   /** `KpiCard` description — Source Sans 3 Regular. */
   kpiCardBody: { mobile: "16px", tablet: "17px", desktop: "18px" },
   bodyText: { mobile: "17px", tablet: "18px", desktop: "18px" },

--- a/lib/media/ProjectImageLightbox.tsx
+++ b/lib/media/ProjectImageLightbox.tsx
@@ -2,7 +2,7 @@
 
 import { Box, CircularProgress, Typography } from "@mui/material";
 import { SlideshowLightbox } from "lightbox.js-react";
-import type { CSSProperties } from "react";
+import type { CSSProperties, ReactNode } from "react";
 
 import { useProjectAccess } from "@/lib/access/ProjectAccessContext";
 import {
@@ -14,6 +14,7 @@ import {
   PROJECT_IMAGE_LIGHTBOX_MODAL_BG_WHITE,
 } from "@/lib/media/lightboxModal";
 import { useSignedMediaUrl } from "@/lib/media/useSignedMediaUrl";
+import { breakpointMediaQuery } from "@/lib/responsive/breakpoints";
 
 export type ProjectImageLightboxProps = {
   objectPath: string;
@@ -25,6 +26,12 @@ export type ProjectImageLightboxProps = {
   style?: CSSProperties;
   /** Backdrop when the lightbox is open. */
   modalBackground?: string;
+  /** Optional contextual content rendered beside the expanded image. */
+  lightboxSidebar?: ReactNode;
+  /** Which side of the expanded image the sidebar sits on. */
+  lightboxSidebarPlacement?: "left" | "right";
+  /** Sidebar column width (hidden below the tablet breakpoint). */
+  lightboxSidebarWidthPx?: number;
 };
 
 /**
@@ -39,6 +46,9 @@ export default function ProjectImageLightbox({
   height,
   style,
   modalBackground = PROJECT_IMAGE_LIGHTBOX_MODAL_BG_WHITE,
+  lightboxSidebar,
+  lightboxSidebarPlacement = "right",
+  lightboxSidebarWidthPx = 360,
 }: ProjectImageLightboxProps) {
   const { projectKey, visibility } = useProjectAccess();
   const normalizedPath = stripLeadingSlash(objectPath);
@@ -76,6 +86,32 @@ export default function ProjectImageLightbox({
     );
   }
 
+  /**
+   * `lightbox.js` paints the modal background on the slide container only; a sidebar sibling
+   * would leave the page visible through its column, so the wrapper repeats the background.
+   */
+  const sidebar = lightboxSidebar ? (
+    <Box
+      sx={{
+        order: lightboxSidebarPlacement === "left" ? -1 : 1,
+        display: "none",
+        flexShrink: 0,
+        boxSizing: "border-box",
+        width: `min(${lightboxSidebarWidthPx}px, 38vw)`,
+        height: "100vh",
+        bgcolor: modalBg,
+        backgroundColor: modalBg,
+        overflowY: "auto",
+        alignItems: "center",
+        [breakpointMediaQuery.tabletUp]: {
+          display: "flex",
+        },
+      }}
+    >
+      {lightboxSidebar}
+    </Box>
+  ) : undefined;
+
   return (
     <SlideshowLightbox
       framework="next"
@@ -87,6 +123,7 @@ export default function ProjectImageLightbox({
       backgroundColor={modalBg}
       iconColor={lightboxIconColorForModalBackground(modalBg)}
       modalClose="clickOutside"
+      rightSidebarComponent={sidebar}
     >
       <img
         src={url}


### PR DESCRIPTION
### Summary
Refines the Finding Nemo case study into a clearer, more consistent narrative across Stages 01–04, with stronger visual hierarchy, reusable card patterns, and new Stage 04 implementation content.

**Hero & intro**

- Image-based hero banner with white title hierarchy and dark-mode nav
- Project meta strip (Role / Year / Team / Recognition) with recognition dialog
- Solution Overview moved beside The Problem, with lightbox + sidebar annotation
- Consistent headline color and card chrome across early sections

**Stage structure & content**

- Stage 02 — Define the AI-Assisted Solution: Concept Evolution, Core Principles, Personas (“Who It Serves”), and Mobile Experience Concepts (From alert to action)
- Stage 03 — AI Technology & MVP Architecture: Core MVP Components and Conceptual MVP Architecture with eyebrow/subtitle hierarchy; Defining Success restyled as KPI cards
- Stage 04 — Tinkering: Computer Vision Pipeline card, Architectural Principles cards, Business Rule Evaluation, Metadata-Driven Architecture card, Event-Driven Dashboard, Extending the Experience, plus mobile mockup chips/captions and responsive layouts

**Design system / components**

- Shared stage headers, info cards, and interactive hover treatment
- New ComputerVisionPipelineCard and MetadataDrivenArchitectureCard
- Lightbox sidebar support for contextual annotations
- Responsive card/mockup grids (2-up on tablet, 4-up on desktop where intended)
- Footer band color aligned with the last section